### PR TITLE
add untie_embeddings_and_output_weights config

### DIFF
--- a/megatron/core/transformer/transformer_config.py
+++ b/megatron/core/transformer/transformer_config.py
@@ -216,6 +216,9 @@ class TransformerConfig(ModelParallelConfig):
     """Number of SMs to use for HybridEP. In pure NVL scenarios, 
     16 SMs can generally achieve good bandwidth."""
 
+    untie_embeddings_and_output_weights: bool = False
+    """The model's input word embedding matrix and the output layer's weight matrix are tied"""
+
     ####################
     # initialization
     ####################
@@ -786,7 +789,6 @@ class TransformerConfig(ModelParallelConfig):
     """Lora a init method"""
     lora_out_init_method: Optional[str] = None
     """Lora b init method"""
-
 
     ####################
     # TE_FL


### PR DESCRIPTION
In order to solve the problem that the newly added nemo-bridge function in flagscale fails to obtain the 'untie_embeddings_and_output_weights' parameter configuration when processing the mcore-model, by adding this option, the problem can be permanently resolved. This will enable the acquisition of the parameters of the mcore-model when converting from the hf format to the mcore-model or when converting from the mcore-model to the hf format, and then corresponding processing of the model weights can be carried out.