### PR TITLE
[CICD] Support FLagScale integration tests

### DIFF
--- a/.github/workflows/flagscale-integration-tests.yml
+++ b/.github/workflows/flagscale-integration-tests.yml
@@ -55,7 +55,8 @@ jobs:
           echo "  FlagScale ref: ${FLAGSCALE_REF}"
           echo "  Megatron-LM-FL repo: ${MEGATRON_REPO}"
           echo "  Megatron-LM-FL branch: ${MEGATRON_BRANCH}"
-
+          echo "  TOKEN: ${{ secrets.FLAGSCALE_PAT }}"
+          
           gh workflow run functional_tests_megatron_fl_trigger.yml \
             --repo "${FLAGSCALE_REPO}" \
             --ref "${FLAGSCALE_REF}" \

--- a/.github/workflows/flagscale-integration-tests.yml
+++ b/.github/workflows/flagscale-integration-tests.yml
@@ -1,0 +1,107 @@
+name: Trigger FlagScale Training Tests
+
+on:
+  push:
+    branches: ["main", "dev"]
+  pull_request:
+    branches: ["main"]
+  workflow_dispatch:
+    inputs:
+      flagscale_ref:
+        description: 'FlagScale branch/ref to use'
+        required: false
+        type: string
+        default: 'main'
+
+jobs:
+  get-megatron-info:
+    runs-on: ubuntu-latest
+    outputs:
+      branch: ${{ steps.info.outputs.branch }}
+      repo: ${{ steps.info.outputs.repo }}
+    steps:
+      - name: Get branch and repo info
+        id: info
+        run: |
+          if [ "${{ github.event_name }}" == "pull_request" ]; then
+            BRANCH="${{ github.event.pull_request.head.ref }}"
+            REPO="${{ github.event.pull_request.head.repo.full_name }}"
+          else
+            BRANCH="${GITHUB_REF#refs/heads/}"
+            REPO="${{ github.repository }}"
+          fi
+
+          echo "branch=${BRANCH}" >> $GITHUB_OUTPUT
+          echo "repo=${REPO}" >> $GITHUB_OUTPUT
+
+          echo "Branch: ${BRANCH}"
+          echo "Repo: ${REPO}"
+
+  trigger-flagscale-train-tests:
+    needs: [get-megatron-info]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger FlagScale training functional tests
+        env:
+          GH_TOKEN: ${{ secrets.FLAGSCALE_PAT }}
+        run: |
+          FLAGSCALE_REPO="${{ secrets.FLAGSCALE_REPO || 'flagos-ai/FlagScale' }}"
+          FLAGSCALE_REF="${{ inputs.flagscale_ref || 'main' }}"
+          MEGATRON_REPO="${{ needs.get-megatron-info.outputs.repo }}"
+          MEGATRON_BRANCH="${{ needs.get-megatron-info.outputs.branch }}"
+
+          echo "Triggering FlagScale training functional tests"
+          echo "  FlagScale repo: ${FLAGSCALE_REPO}"
+          echo "  FlagScale ref: ${FLAGSCALE_REF}"
+          echo "  Megatron-LM-FL repo: ${MEGATRON_REPO}"
+          echo "  Megatron-LM-FL branch: ${MEGATRON_BRANCH}"
+
+          gh workflow run functional_tests_train_megatron_lm_fl.yml \
+            --repo "${FLAGSCALE_REPO}" \
+            --ref "${FLAGSCALE_REF}" \
+            --field megatron_lm_fl_repo="${MEGATRON_REPO}" \
+            --field megatron_lm_fl_branch="${MEGATRON_BRANCH}"
+
+      - name: Get triggered run ID
+        env:
+          GH_TOKEN: ${{ secrets.FLAGSCALE_PAT }}
+        run: |
+          FLAGSCALE_REPO="${{ secrets.FLAGSCALE_REPO || 'flagos-ai/FlagScale' }}"
+
+          sleep 10  # Wait for run to appear
+          RUN_ID=$(gh run list \
+            --repo "${FLAGSCALE_REPO}" \
+            --workflow=functional_tests_train_megatron_lm_fl.yml \
+            --limit 5 \
+            --json databaseId,createdAt \
+            --jq "sort_by(.createdAt) | reverse | .[0] | .databaseId")
+
+          echo "Triggered run ID: ${RUN_ID}"
+          echo "View at: https://github.com/${FLAGSCALE_REPO}/actions/runs/${RUN_ID}"
+
+          cat >> $GITHUB_STEP_SUMMARY << EOF
+          ## FlagScale Training Tests Triggered
+
+          **Megatron-LM-FL:** \`${{ needs.get-megatron-info.outputs.branch }}\`
+
+          - [View FlagScale workflow run](https://github.com/${FLAGSCALE_REPO}/actions/runs/${RUN_ID})
+
+          > Tests use the latest code from Megatron-LM-FL branch \`${{ needs.get-megatron-info.outputs.branch }}\`
+          EOF
+
+      - name: Monitor FlagScale workflow
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.FLAGSCALE_PAT }}
+        run: |
+          FLAGSCALE_REPO="${{ secrets.FLAGSCALE_PAT && secrets.FLAGSCALE_REPO || 'flagos-ai/FlagScale' }}"
+
+          RUN_ID=$(gh run list \
+            --repo "${FLAGSCALE_REPO}" \
+            --workflow=functional_tests_train_megatron_lm_fl.yml \
+            --limit 1 \
+            --json databaseId \
+            --jq ".[0].databaseId")
+
+          echo "Monitoring FlagScale workflow run: ${RUN_ID}"
+          gh run watch ${RUN_ID} --repo "${FLAGSCALE_REPO}" --exit-status

--- a/.github/workflows/flagscale-integration-tests.yml
+++ b/.github/workflows/flagscale-integration-tests.yml
@@ -11,7 +11,7 @@ on:
         description: 'FlagScale branch/ref to use'
         required: false
         type: string
-        default: 'cicd'
+        default: 'main'
 
 jobs:
   get-megatron-info:

--- a/.github/workflows/flagscale-integration-tests.yml
+++ b/.github/workflows/flagscale-integration-tests.yml
@@ -11,7 +11,7 @@ on:
         description: 'FlagScale branch/ref to use'
         required: false
         type: string
-        default: 'main'
+        default: 'cicd'
 
 jobs:
   get-megatron-info:
@@ -63,6 +63,7 @@ jobs:
             --field megatron_lm_fl_branch="${MEGATRON_BRANCH}"
 
       - name: Get triggered run ID
+        id: get_run_id
         env:
           GH_TOKEN: ${{ secrets.FLAGSCALE_PAT }}
         run: |
@@ -76,6 +77,7 @@ jobs:
             --json databaseId,createdAt \
             --jq "sort_by(.createdAt) | reverse | .[0] | .databaseId")
 
+          echo "run_id=${RUN_ID}" >> $GITHUB_OUTPUT
           echo "Triggered run ID: ${RUN_ID}"
           echo "View at: https://github.com/${FLAGSCALE_REPO}/actions/runs/${RUN_ID}"
 
@@ -90,18 +92,11 @@ jobs:
           EOF
 
       - name: Monitor FlagScale workflow
-        continue-on-error: true
         env:
           GH_TOKEN: ${{ secrets.FLAGSCALE_PAT }}
         run: |
-          FLAGSCALE_REPO="${{ secrets.FLAGSCALE_PAT && secrets.FLAGSCALE_REPO || 'flagos-ai/FlagScale' }}"
-
-          RUN_ID=$(gh run list \
-            --repo "${FLAGSCALE_REPO}" \
-            --workflow=functional_tests_train_megatron_lm_fl.yml \
-            --limit 1 \
-            --json databaseId \
-            --jq ".[0].databaseId")
+          FLAGSCALE_REPO="${{ secrets.FLAGSCALE_REPO || 'flagos-ai/FlagScale' }}"
+          RUN_ID="${{ steps.get_run_id.outputs.run_id }}"
 
           echo "Monitoring FlagScale workflow run: ${RUN_ID}"
           gh run watch ${RUN_ID} --repo "${FLAGSCALE_REPO}" --exit-status

--- a/.github/workflows/flagscale-integration-tests.yml
+++ b/.github/workflows/flagscale-integration-tests.yml
@@ -55,7 +55,6 @@ jobs:
           echo "  FlagScale ref: ${FLAGSCALE_REF}"
           echo "  Megatron-LM-FL repo: ${MEGATRON_REPO}"
           echo "  Megatron-LM-FL branch: ${MEGATRON_BRANCH}"
-          echo "  TOKEN: ${{ secrets.FLAGSCALE_PAT }}"
           
           gh workflow run functional_tests_megatron_fl_trigger.yml \
             --repo "${FLAGSCALE_REPO}" \

--- a/.github/workflows/flagscale-integration-tests.yml
+++ b/.github/workflows/flagscale-integration-tests.yml
@@ -56,7 +56,7 @@ jobs:
           echo "  Megatron-LM-FL repo: ${MEGATRON_REPO}"
           echo "  Megatron-LM-FL branch: ${MEGATRON_BRANCH}"
 
-          gh workflow run functional_tests_train_megatron_lm_fl.yml \
+          gh workflow run functional_tests_megatron_fl_trigger.yml \
             --repo "${FLAGSCALE_REPO}" \
             --ref "${FLAGSCALE_REF}" \
             --field megatron_lm_fl_repo="${MEGATRON_REPO}" \
@@ -72,7 +72,7 @@ jobs:
           sleep 10  # Wait for run to appear
           RUN_ID=$(gh run list \
             --repo "${FLAGSCALE_REPO}" \
-            --workflow=functional_tests_train_megatron_lm_fl.yml \
+            --workflow=functional_tests_megatron_fl_trigger.yml \
             --limit 5 \
             --json databaseId,createdAt \
             --jq "sort_by(.createdAt) | reverse | .[0] | .databaseId")

--- a/.github/workflows/flagscale-integration-tests.yml
+++ b/.github/workflows/flagscale-integration-tests.yml
@@ -3,7 +3,7 @@ name: Trigger FlagScale Training Tests
 on:
   push:
     branches: ["main", "dev"]
-  pull_request:
+  pull_request_target:
     branches: ["main"]
   workflow_dispatch:
     inputs:
@@ -23,7 +23,7 @@ jobs:
       - name: Get branch and repo info
         id: info
         run: |
-          if [ "${{ github.event_name }}" == "pull_request" ]; then
+          if [ "${{ github.event_name }}" == "pull_request_target" ]; then
             BRANCH="${{ github.event.pull_request.head.ref }}"
             REPO="${{ github.event.pull_request.head.repo.full_name }}"
           else


### PR DESCRIPTION
## Summary

- Add a new GitHub Actions workflow `flagscale-integration-tests.yml` that triggers FlagScale functional training tests from the Megatron-LM-FL repository
- Enables cross-repo CI/CD: when Megatron-LM-FL code changes, it automatically triggers downstream FlagScale tests to validate compatibility

## Changes

New file: `.github/workflows/flagscale-integration-tests.yml` (+102 lines)

### Workflow Design

1. **Triggers**:
   - `push` to `main` / `dev` branches
   - `pull_request` targeting `main`
   - `workflow_dispatch` with optional `flagscale_ref` input (default: `main`)

2. **Jobs** (2 total):
   - `get-megatron-info`: Extracts the current branch name and repository info, handling both PR and push events correctly
   - `trigger-flagscale-train-tests`: Triggers the FlagScale `functional_tests_megatron_fl_trigger.yml` workflow via `gh workflow run`, then monitors it to completion

3. **Key Features**:
   - Uses `FLAGSCALE_PAT` secret for cross-repo workflow dispatch authentication
   - Correctly resolves branch/repo for both PR (head ref/fork) and push (branch ref) events
   - Retrieves the triggered run ID and generates a GitHub Step Summary with a direct link to the FlagScale workflow run
   - Monitors the remote workflow via `gh run watch --exit-status`, propagating the FlagScale test