### PR TITLE
[fix] add engram_embedding_gradient_scaling_factor

### DIFF
--- a/megatron/core/distributed/distributed_data_parallel.py
+++ b/megatron/core/distributed/distributed_data_parallel.py
@@ -279,6 +279,9 @@ class DistributedDataParallel(_BaseDataParallel):
             ), "Cannot average in collective when calculating per-token loss!"
             gradient_scaling_factor = 1.0
             expert_gradient_scaling_factor = 1.0
+            ########## FlagScale Begin ##########
+            engram_embedding_gradient_scaling_factor = 1.0
+            ########## FlagScale End ##########
         else:
             # The goal is to scale reduced gradients by 1/dp_size.
             # This can be achieved in two ways:


### PR DESCRIPTION
Is `engram_dp_group is not None and calculate_per_token_loss == True` possible? I meet this case, if it's possible, we need initial `engram_embedding_gradient_scaling_factor`.