### PR TITLE
Fix missing FlagScale annotations

### DIFF
--- a/.github/workflows/flagscale-integration-tests.yml
+++ b/.github/workflows/flagscale-integration-tests.yml
@@ -99,4 +99,28 @@ jobs:
           RUN_ID="${{ steps.get_run_id.outputs.run_id }}"
 
           echo "Monitoring FlagScale workflow run: ${RUN_ID}"
-          gh run watch ${RUN_ID} --repo "${FLAGSCALE_REPO}" --exit-status
+
+          POLL_INTERVAL=60
+          MAX_ATTEMPTS=120  # 120 * 60s = 2 hours max
+
+          for i in $(seq 1 ${MAX_ATTEMPTS}); do
+            STATUS=$(gh run view ${RUN_ID} --repo "${FLAGSCALE_REPO}" --json status,conclusion --jq '.status')
+            CONCLUSION=$(gh run view ${RUN_ID} --repo "${FLAGSCALE_REPO}" --json status,conclusion --jq '.conclusion')
+
+            echo "[$(date -u '+%H:%M:%S')] Attempt ${i}/${MAX_ATTEMPTS}: status=${STATUS}, conclusion=${CONCLUSION}"
+
+            if [ "${STATUS}" = "completed" ]; then
+              if [ "${CONCLUSION}" = "success" ]; then
+                echo "Workflow completed successfully!"
+                exit 0
+              else
+                echo "Workflow failed with conclusion: ${CONCLUSION}"
+                exit 1
+              fi
+            fi
+
+            sleep ${POLL_INTERVAL}
+          done
+
+          echo "Timed out waiting for workflow to complete"
+          exit 1

--- a/megatron/core/datasets/blended_dataset.py
+++ b/megatron/core/datasets/blended_dataset.py
@@ -15,7 +15,7 @@ from megatron.core.datasets.blended_megatron_dataset_config import BlendedMegatr
 from megatron.core.datasets.megatron_dataset import MegatronDataset
 from megatron.core.datasets.utils import normalize
 from megatron.core.utils import log_single_rank
-from megatron.plugin.utils import is_built_on_zero_rank
+from megatron.plugin.utils import is_built_on_zero_rank  # FlagScale Add
 
 logger = logging.getLogger(__name__)
 
@@ -151,7 +151,7 @@ class BlendedDataset(torch.utils.data.Dataset):
         else:
             cache_hit = False
 
-        if not path_to_cache or (not cache_hit and is_built_on_zero_rank()):
+        if not path_to_cache or (not cache_hit and is_built_on_zero_rank()):  # FlagScale Add
             log_single_rank(
                 logger, logging.INFO, f"Build and save the {type(self).__name__} indices"
             )

--- a/megatron/core/datasets/blended_megatron_dataset_builder.py
+++ b/megatron/core/datasets/blended_megatron_dataset_builder.py
@@ -14,10 +14,12 @@ from megatron.core.datasets.gpt_dataset import GPTDatasetConfig
 from megatron.core.datasets.megatron_dataset import LowLevelDataset, MegatronDataset
 from megatron.core.datasets.utils import Split, normalize
 from megatron.core.utils import log_single_rank
+# FlagScale Begin
 from megatron.plugin.platform import get_platform
 from megatron.plugin.utils import is_built_on_zero_rank
 
 cur_platform = get_platform()
+# FlagScale End
 
 logger = logging.getLogger(__name__)
 
@@ -387,14 +389,14 @@ class BlendedMegatronDatasetBuilder(object):
         ):
             rank = torch.distributed.get_rank()
             # First, build on rank 0
-            if is_built_on_zero_rank():
+            if is_built_on_zero_rank():  # FlagScale Add
                 num_workers = num_dataset_builder_threads
                 if num_workers > 1:
                     # since only rank 0 is running, scale up the thread count
                     # but not too much to avoid overloading storage on miss path.
                     # if user set num_dataset_builder_threads to 1,
                     # i.e. meant for serial build, do not scale up.
-                    num_workers *= min(2, max(1, cur_platform.device_count()))
+                    num_workers *= min(2, max(1, cur_platform.device_count()))  # FlagScale Add
                 _threading_helper(
                     megatron_datasets, num_workers, prefixes, split, sizes_per_dataset
                 )
@@ -402,7 +404,7 @@ class BlendedMegatronDatasetBuilder(object):
             torch.distributed.barrier()
 
             # Then, build on other ranks; guaranteed to be data_cache hit
-            if not is_built_on_zero_rank():
+            if not is_built_on_zero_rank():  # FlagScale Add
                 _threading_helper(
                     megatron_datasets,
                     num_dataset_builder_threads,
@@ -530,7 +532,7 @@ class BlendedMegatronDatasetBuilder(object):
             dataset = None
 
             # First, build on rank 0
-            if is_built_on_zero_rank() and is_built_on_rank():
+            if is_built_on_zero_rank() and is_built_on_rank():  # FlagScale Add
                 try:
                     dataset = cls(*args)
                 except OSError as err:
@@ -546,7 +548,7 @@ class BlendedMegatronDatasetBuilder(object):
                 torch.distributed.barrier()
 
             # After, build on other ranks
-            if not is_built_on_zero_rank() and is_built_on_rank():
+            if not is_built_on_zero_rank() and is_built_on_rank():  # FlagScale Add
                 dataset = cls(*args)
 
             return dataset

--- a/megatron/core/datasets/data_schedule.py
+++ b/megatron/core/datasets/data_schedule.py
@@ -5,9 +5,11 @@ from typing import Any, List, Optional
 import torch
 
 from megatron.core import parallel_state
+# FlagScale Begin
 from megatron.plugin.platform import get_platform
 
 cur_platform = get_platform()
+# FlagScale End
 from megatron.core.pipeline_parallel.hybrid_cp_schedule import BalancedCPScheduler
 from megatron.core.process_groups_config import ProcessGroupCollection
 
@@ -211,14 +213,16 @@ class HybridCPDataLoaderWrapper:
         def _pack_sample_by_key(key: str) -> torch.Tensor:
             flattened_tensors = []
             for gid in send_ids_sorted:
+                # FlagScale Begin
                 t = batch[gid2local_id[gid]][key].to(
                     cur_platform.current_device(), non_blocking=True
                 )
+                # FlagScale End
                 flattened_tensors.append(t)
             return (
                 torch.cat(flattened_tensors, dim=0)
                 if flattened_tensors
-                else torch.empty(0, device=cur_platform.current_device(), dtype=batch[0][key].dtype)
+                else torch.empty(0, device=cur_platform.current_device(), dtype=batch[0][key].dtype)  # FlagScale Add
             )
 
         def _unpack_sample_by_key(key: str, recv_tensor: torch.Tensor):
@@ -231,7 +235,7 @@ class HybridCPDataLoaderWrapper:
         for key in data_keys:
             send_tensor = _pack_sample_by_key(key)
             recv_tensor = torch.empty(
-                sum(recv_lens_split), device=cur_platform.current_device(), dtype=send_tensor.dtype
+                sum(recv_lens_split), device=cur_platform.current_device(), dtype=send_tensor.dtype  # FlagScale Add
             )
             torch.distributed.all_to_all_single(
                 output=recv_tensor,

--- a/megatron/core/datasets/gpt_dataset.py
+++ b/megatron/core/datasets/gpt_dataset.py
@@ -17,7 +17,7 @@ from megatron.core.datasets.object_storage_utils import ObjectStorageConfig, is_
 from megatron.core.datasets.utils import Split
 from megatron.core.tokenizers import MegatronTokenizerBase
 from megatron.core.utils import log_single_rank
-from megatron.plugin.utils import is_built_on_zero_rank
+from megatron.plugin.utils import is_built_on_zero_rank  # FlagScale Add
 
 logger = logging.getLogger(__name__)
 
@@ -441,7 +441,7 @@ class GPTDataset(MegatronDataset):
             cache_hit = False
 
         if not path_to_cache or (
-            not cache_hit and (not torch.distributed.is_initialized() or is_built_on_zero_rank())
+            not cache_hit and (not torch.distributed.is_initialized() or is_built_on_zero_rank())  # FlagScale Add
         ):
             log_single_rank(
                 logger,

--- a/megatron/core/datasets/utils.py
+++ b/megatron/core/datasets/utils.py
@@ -22,7 +22,7 @@ def compile_helpers():
     import os
     import subprocess
 
-    src_dir = os.path.abspath(os.path.dirname(__file__))
+    src_dir = os.path.abspath(os.path.dirname(__file__))  # FlagScale Add
 
     # FlagScale Begin
     # Skip compilation if the shared library already exists (e.g. pip-installed package
@@ -35,7 +35,7 @@ def compile_helpers():
         return
     # FlagScale End
 
-    command = ["make", "-C", src_dir]
+    command = ["make", "-C", src_dir]  # FlagScale Add
     if subprocess.run(command).returncode != 0:
         import sys
 

--- a/megatron/core/dist_checkpointing/exchange_utils.py
+++ b/megatron/core/dist_checkpointing/exchange_utils.py
@@ -35,9 +35,11 @@ def is_float8tensor(tensor: torch.Tensor) -> bool:
 
 logger = logging.getLogger(__name__)
 
+# FlagScale Begin
 from megatron.plugin.platform import get_platform
 
 cur_platform = get_platform()
+# FlagScale End
 
 
 class ShardDistribution(NamedTuple):
@@ -98,19 +100,19 @@ def _get_empty_tensor_for_exchange(
         orig_device = None  # this tensor will be discarded anyway
         sh_ten = unneeded_shards[shard_id]
         if sh_ten.data is None:
-            sh_ten.init_data(cur_platform.device_name())
+            sh_ten.init_data(cur_platform.device_name())  # FlagScale Add
             tensor = sh_ten.data
             sh_ten.data = None  # won't be used. free memory
         else:
             tensor = sh_ten.data
             if tensor.device.type == "cpu":
-                tensor = torch.empty_like(tensor, device=cur_platform.device_name())
+                tensor = torch.empty_like(tensor, device=cur_platform.device_name())  # FlagScale Add
     else:
-        local_unloaded_sh_ten.init_data(cur_platform.device_name())
+        local_unloaded_sh_ten.init_data(cur_platform.device_name())  # FlagScale Add
         orig_device = local_unloaded_sh_ten.data.device
         tensor = local_unloaded_sh_ten.data
         if tensor.device.type == "cpu":
-            tensor = torch.empty_like(tensor, device=cur_platform.device_name())
+            tensor = torch.empty_like(tensor, device=cur_platform.device_name())  # FlagScale Add
         loaded_tensors[shard_id] = tensor
     return tensor, orig_device
 
@@ -330,7 +332,7 @@ def exchange_loaded_tensors_gather_rounds(
                 for rank, shard_id in enumerate(round_shard_ids):
                     if shard_id is None:
                         # if no more useful data, the given rank will exchange empty tensor
-                        local_ten = torch.empty(0, dtype=dtype, device=cur_platform.device_name())
+                        local_ten = torch.empty(0, dtype=dtype, device=cur_platform.device_name())  # FlagScale Add
                         orig_device = None
                     else:
                         assert isinstance(shard_id, tuple), type(shard_id)
@@ -340,9 +342,11 @@ def exchange_loaded_tensors_gather_rounds(
                                 all_loaded_tensors.keys(),
                             )
                             orig_device = all_loaded_tensors[shard_id]
+                            # FlagScale Begin
                             all_loaded_tensors[shard_id] = all_loaded_tensors[shard_id].to(
                                 cur_platform.device()
                             )
+                            # FlagScale End
                             local_ten = all_loaded_tensors[shard_id]
                         else:
                             local_ten, orig_device = _get_empty_tensor_for_exchange(
@@ -509,7 +513,7 @@ def exchange_loaded_tensors_broadcast(
         if rank == local_rank:
             assert shard_id in all_loaded_tensors, (shard_id, all_loaded_tensors.keys())
             orig_device = all_loaded_tensors[shard_id].device
-            local_ten = all_loaded_tensors[shard_id].to(cur_platform.device())
+            local_ten = all_loaded_tensors[shard_id].to(cur_platform.device())  # FlagScale Add
         else:
             local_ten, orig_device = _get_empty_tensor_for_exchange(
                 shard_id, unloaded_shards, shard_to_metadata, all_loaded_tensors

--- a/megatron/core/dist_checkpointing/strategies/async_utils.py
+++ b/megatron/core/dist_checkpointing/strategies/async_utils.py
@@ -25,9 +25,11 @@ from ..utils import debug_time
 
 logger = logging.getLogger(__name__)
 
+# FlagScale Begin
 from megatron.plugin.platform import get_platform
 
 cur_platform = get_platform()
+# FlagScale End
 
 
 def _set_process_qos(cpu_priority: int, io_priority: Optional[int]) -> None:
@@ -225,7 +227,7 @@ class AsyncCaller(ABC):
             bool: True if all ranks are done, False if at least one rank is still active.
 
         """
-        ten = torch.tensor([is_alive], dtype=torch.int, device=cur_platform.current_device())
+        ten = torch.tensor([is_alive], dtype=torch.int, device=cur_platform.current_device())  # FlagScale Add
         torch.distributed.all_reduce(ten)
         return ten[0] == 0
 
@@ -274,7 +276,7 @@ class TemporalAsyncCaller(AsyncCaller):
 
         rank = torch.distributed.get_rank()
         start_sync = time()
-        cur_platform.synchronize()
+        cur_platform.synchronize()  # FlagScale Add
         end_sync = time()
         logger.debug(f"rank: {rank}, takes {end_sync - start_sync} to finish D2H ")
 
@@ -566,7 +568,7 @@ class PersistentAsyncCaller(AsyncCaller):
         # in this new process are on the right device, and device 0 on the node does not
         # take on undue memory burden from other devices on node (default behavior without
         # this line).
-        cur_platform.set_device(rank % cur_platform.device_count())
+        cur_platform.set_device(rank % cur_platform.device_count())  # FlagScale Add
 
         # Set QoS to deprioritize checkpoint writing vs training
         # This prevents checkpoint I/O from interfering with data loader
@@ -699,9 +701,11 @@ class AsyncCallsQueue:
                 call_idx, _, async_request = self.async_calls.popleft()
                 for finalize_fn in async_request.finalize_fns:
                     finalize_fn()
+                # FlagScale Begin
                 ten = torch.tensor(
                     [call_idx], dtype=torch.int, device=cur_platform.current_device()
                 )
+                # FlagScale End
                 torch.distributed.all_reduce(ten, op=torch.distributed.ReduceOp.MAX)
                 assert ten.item() == call_idx, "Unmatched async calls. "
                 "That probably means not all ranks are participating in async finalization"

--- a/megatron/core/dist_checkpointing/strategies/filesystem_async.py
+++ b/megatron/core/dist_checkpointing/strategies/filesystem_async.py
@@ -48,9 +48,11 @@ except ImportError:
 
 _results_queue = None
 
+# FlagScale Begin
 from megatron.plugin.platform import get_platform
 
 cur_platform = get_platform()
+# FlagScale End
 
 
 @_disable_gc()
@@ -249,7 +251,7 @@ class FileSystemWriterAsync(FileSystemWriter):
                 del tensor
             result.append((file_name, storage_key, (bytes_data, tensor_list)))
         if non_blocking:
-            cur_platform.synchronize()
+            cur_platform.synchronize()  # FlagScale Add
         return result
 
     @staticmethod

--- a/megatron/core/dist_checkpointing/strategies/fully_parallel.py
+++ b/megatron/core/dist_checkpointing/strategies/fully_parallel.py
@@ -40,9 +40,11 @@ from megatron.core.dist_checkpointing.validation import (
 
 logger = logging.getLogger(__name__)
 
+# FlagScale Begin
 from megatron.plugin.platform import get_platform
 
 cur_platform = get_platform()
+# FlagScale End
 
 
 T = TypeVar('T', ShardedObject, ShardedTensor)
@@ -282,7 +284,7 @@ class FullyParallelLoadStrategyWrapper:
                 )
 
             with debug_time("torch.cuda.synchronize", logger):
-                cur_platform.synchronize()
+                cur_platform.synchronize()  # FlagScale Add
 
         all_loaded_objects = exchange_loaded_objects_gather_object(loaded_objects)
 
@@ -291,7 +293,7 @@ class FullyParallelLoadStrategyWrapper:
             raise CheckpointingException(
                 f'Missing object shards after fully parallel loading: {missing_object_shards}'
             )
-        cur_platform.synchronize()
+        cur_platform.synchronize()  # FlagScale Add
 
         self.fill_in_deferred_sharded_tensors(sharded_tensors, all_loaded_tensors)
         self.fill_in_deferred_sharded_objects(sharded_objects, all_loaded_objects)

--- a/megatron/core/dist_checkpointing/strategies/state_dict_saver.py
+++ b/megatron/core/dist_checkpointing/strategies/state_dict_saver.py
@@ -23,9 +23,11 @@ logger = getLogger(__name__)
 
 from dataclasses import fields
 
+# FlagScale Begin
 from megatron.plugin.platform import get_platform
 
 cur_platform = get_platform()
+# FlagScale End
 
 
 def _compare_dataclasses(obj1, obj2):
@@ -205,9 +207,11 @@ def verify_global_md_reuse(
                 f"local_verify_reuse is False: diffs -"
                 f" {_compare_dataclasses(local_plan, loaded_all_plans[rank])}"
             )
+        # FlagScale Begin
         all_results = torch.tensor(
             [local_verify_reuse], dtype=torch.int, device=cur_platform.device_name()
         )
+        # FlagScale End
         torch.distributed.all_reduce(all_results, op=torch.distributed.ReduceOp.MIN)
         # Check if all reduced results are True
         global_md_verify_reuse = all_results.item() == 1
@@ -255,7 +259,7 @@ def save_state_dict_async_finalize(
     # Broadcast failure status to all ranks to raise exceptions everywhere if needed.
     # The failure details are only raised on the coordinator.
     failures_occurred = torch.tensor(
-        [int(len(node_failures) > 0)], dtype=torch.int, device=cur_platform.current_device()
+        [int(len(node_failures) > 0)], dtype=torch.int, device=cur_platform.current_device()  # FlagScale Add
     )
     torch.distributed.broadcast(
         failures_occurred, src=dist_wrapper.coordinator_rank, group=dist_wrapper.group

--- a/megatron/core/dist_checkpointing/strategies/torch.py
+++ b/megatron/core/dist_checkpointing/strategies/torch.py
@@ -71,7 +71,7 @@ except (ImportError, ModuleNotFoundError):
     HAVE_NVRX = False
 
 try:
-    if not cur_platform.is_available():
+    if not cur_platform.is_available():  # FlagScale Add
         raise ImportError
     from transformer_engine.pytorch.float8_tensor import Float8Tensor
 

--- a/megatron/core/dist_checkpointing/tensor_aware_state_dict.py
+++ b/megatron/core/dist_checkpointing/tensor_aware_state_dict.py
@@ -43,9 +43,11 @@ except ImportError:
     TensorAwareStateDict = types.new_class("TensorAwareStateDict", ())
     HAVE_NVRX = False
 
+# FlagScale Begin
 from megatron.plugin.platform import get_platform
 
 cur_platform = get_platform()
+# FlagScale End
 
 
 @dataclass
@@ -305,7 +307,7 @@ class MCoreTensorAwareStateDict(TensorAwareStateDict):
                         parallelization_group,
                         exchange_algo,
                     )
-                    cur_platform.synchronize()
+                    cur_platform.synchronize()  # FlagScale Add
         loaded_objects = {}
         for sh_base in nested_values(self.sharded_state_dict):
             if not isinstance(sh_base, ShardedTensor):

--- a/megatron/core/distributed/distributed_data_parallel.py
+++ b/megatron/core/distributed/distributed_data_parallel.py
@@ -246,7 +246,7 @@ class DistributedDataParallel(_BaseDataParallel):
                 assert (
                     self.ddp_config.use_distributed_optimizer
                 ), 'Partial DistOpt cannot be used without DistOpt'
-                communication_stream = cur_platform.Stream(device=cur_platform.current_device())
+                communication_stream = cur_platform.Stream(device=cur_platform.current_device())  # FlagScale Add
                 for bucket_group in bucket_groups:
                     bucket_group.inter_distributed_optimizer_instance_group = (
                         self.inter_dist_opt_group
@@ -499,20 +499,24 @@ class DistributedDataParallel(_BaseDataParallel):
         """
         Context manager that turns off gradient synchronization.
         """
+        # FlagScale Begin
         for bucket_group in (
             self.bucket_groups
             + self.expert_parallel_bucket_groups
             + self.engram_embedding_bucket_groups
         ):
+        # FlagScale End
             bucket_group.is_last_microbatch = False
         try:
             yield
         finally:
+            # FlagScale Begin
             for bucket_group in (
                 self.bucket_groups
                 + self.expert_parallel_bucket_groups
                 + self.engram_embedding_bucket_groups
             ):
+            # FlagScale End
                 bucket_group.is_last_microbatch = True
 
     def start_param_sync(self, *unused, force_sync: bool = False, force_dispatch: bool = False):
@@ -534,11 +538,13 @@ class DistributedDataParallel(_BaseDataParallel):
             if self.overlap_param_gather_with_optimizer_step and not force_dispatch:
                 return
 
+        # FlagScale Begin
         for bucket_group in (
             self.bucket_groups
             + self.expert_parallel_bucket_groups
             + self.engram_embedding_bucket_groups
         ):
+        # FlagScale End
             bucket_group.start_param_sync(force_sync=force_sync)
 
             if not self.ddp_config.overlap_param_gather:
@@ -586,11 +592,13 @@ class DistributedDataParallel(_BaseDataParallel):
         calls. When overlap_grad_reduce is set to False, calls synchronous
         communication ops.
         """
+        # FlagScale Begin
         for bucket_group in (
             self.bucket_groups
             + self.expert_parallel_bucket_groups
             + self.engram_embedding_bucket_groups
         ):
+        # FlagScale End
             bucket_group.start_grad_sync()
 
     def finish_grad_sync(self, force_all_reduce: Optional[bool] = False):
@@ -602,25 +610,29 @@ class DistributedDataParallel(_BaseDataParallel):
         calls to complete. When overlap_grad_reduce is set to False, calls synchronous
         communication ops.
         """
+        # FlagScale Begin
         for bucket_group in (
             self.bucket_groups
             + self.expert_parallel_bucket_groups
             + self.engram_embedding_bucket_groups
         ):
+        # FlagScale End
             bucket_group.finish_grad_sync(force_all_reduce=force_all_reduce)
 
     def free_overlap_buffers(self):
         """Free overlap param-gather GPU buffers across all bucket groups."""
+        # FlagScale Begin
         for bucket_group in (
             self.bucket_groups
             + self.expert_parallel_bucket_groups
             + self.engram_embedding_bucket_groups
         ):
+        # FlagScale End
             bucket_group.free_overlap_buffers()
 
     def scale_gradients(self, scaling_factor: float):
         """Scale all gradients inside the buffers by `scaling_factor`."""
-        for buffer in self.buffers + self.expert_parallel_buffers + self.engram_embedding_buffers:
+        for buffer in self.buffers + self.expert_parallel_buffers + self.engram_embedding_buffers:  # FlagScale Add
             buffer.scale_gradients(scaling_factor)
 
     def zero_grad_buffer(self):
@@ -634,13 +646,15 @@ class DistributedDataParallel(_BaseDataParallel):
             # to True, and there will be a double-GA.
             for param in self.params_with_grad:
                 param.grad_added_to_main_grad = False
-        for buffer in self.buffers + self.expert_parallel_buffers + self.engram_embedding_buffers:
+        for buffer in self.buffers + self.expert_parallel_buffers + self.engram_embedding_buffers:  # FlagScale Add
             buffer.reset()
+        # FlagScale Begin
         for bucket_group in (
             self.bucket_groups
             + self.expert_parallel_bucket_groups
             + self.engram_embedding_bucket_groups
         ):
+        # FlagScale End
             bucket_group.reset()
 
     def broadcast_params(self):
@@ -679,13 +693,13 @@ class DistributedDataParallel(_BaseDataParallel):
             empty_cache: Whether to call torch.cuda.empty_cache() after freeing.
         """
         if synchronize:
-            cur_platform.synchronize()
+            cur_platform.synchronize()  # FlagScale Add
 
-        for buffer in self.buffers + self.expert_parallel_buffers + self.engram_embedding_buffers:
+        for buffer in self.buffers + self.expert_parallel_buffers + self.engram_embedding_buffers:  # FlagScale Add
             buffer.offload_to_cpu(move_params=False, move_grads=True)
 
         if empty_cache:
-            cur_platform.empty_cache()
+            cur_platform.empty_cache()  # FlagScale Add
 
     def restore_grad_buffers(self, synchronize: bool = True) -> None:
         """
@@ -698,8 +712,8 @@ class DistributedDataParallel(_BaseDataParallel):
         Args:
             synchronize: Whether to call torch.cuda.synchronize() after allocation.
         """
-        for buffer in self.buffers + self.expert_parallel_buffers + self.engram_embedding_buffers:
+        for buffer in self.buffers + self.expert_parallel_buffers + self.engram_embedding_buffers:  # FlagScale Add
             buffer.reload_from_cpu(move_params=False, move_grads=True)
 
         if synchronize:
-            cur_platform.synchronize()
+            cur_platform.synchronize()  # FlagScale Add

--- a/megatron/core/distributed/finalize_model_grads.py
+++ b/megatron/core/distributed/finalize_model_grads.py
@@ -19,7 +19,7 @@ from megatron.core.pipeline_parallel.utils import (
     is_pp_last_stage,
 )
 from megatron.core.process_groups_config import ProcessGroupCollection
-from megatron.plugin.decorators import overridable
+from megatron.plugin.decorators import overridable  # FlagScale Add
 
 from .. import parallel_state
 from ..transformer.moe.moe_utils import get_updated_expert_bias
@@ -209,7 +209,7 @@ def _allreduce_word_embedding_grads(
     )
 
 
-@overridable
+@overridable  # FlagScale Add
 def _allreduce_embedding_grad(
     model: List[torch.nn.Module],
     embd_group: torch.distributed.ProcessGroup,

--- a/megatron/core/distributed/fsdp/mcore_fsdp_adapter.py
+++ b/megatron/core/distributed/fsdp/mcore_fsdp_adapter.py
@@ -123,7 +123,7 @@ class FullyShardedDataParallel(_BaseDataParallel):
         self.bucket_size = self.ddp_config.bucket_size
         if disable_bucketing:
             self.bucket_size = None
-        self.device = device if device else torch.device(cur_platform.current_device_name())
+        self.device = device if device else torch.device(cur_platform.current_device_name())  # FlagScale Add
 
         if fsdp_unit_modules is not None:
             self.fsdp_unit_modules = fsdp_unit_modules
@@ -499,7 +499,7 @@ def _get_rng_state_dict():
         'random_rng_state': random.getstate(),
         'np_rng_state': np.random.get_state(),
         'torch_rng_state': torch.get_rng_state(),
-        'cuda_rng_state': cur_platform.get_rng_state(),
+        'cuda_rng_state': cur_platform.get_rng_state(),  # FlagScale Add
         'rng_tracker_states': tensor_parallel.get_cuda_rng_tracker().get_states(),
     }
     return rng_state_dict
@@ -509,5 +509,5 @@ def _load_rng_state_dict(rng_state_dict):
     random.setstate(rng_state_dict['random_rng_state'])
     np.random.set_state(rng_state_dict['np_rng_state'])
     torch.set_rng_state(rng_state_dict['torch_rng_state'])
-    cur_platform.set_rng_state(rng_state_dict['cuda_rng_state'])
+    cur_platform.set_rng_state(rng_state_dict['cuda_rng_state'])  # FlagScale Add
     tensor_parallel.get_cuda_rng_tracker().set_states(rng_state_dict['rng_tracker_states'])

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/megatron_fsdp.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/megatron_fsdp.py
@@ -197,13 +197,13 @@ class MegatronFSDP(torch.nn.Module):
         super().__init__()
         # If device is not specified, use the current device.
         self.device = (
-            device if device is not None else torch.device(cur_platform.current_device_name())
+            device if device is not None else torch.device(cur_platform.current_device_name())  # FlagScale Add
         )
-        if self.device != torch.device(cur_platform.current_device_name()):
+        if self.device != torch.device(cur_platform.current_device_name()):  # FlagScale Add
             logger.warning(
                 f"[Rank {torch.distributed.get_rank()}] Megatron-FSDP is "
                 f"using device {self.device} instead of the current device "
-                f"{torch.device(cur_platform.current_device_name())}, "
+                f"{torch.device(cur_platform.current_device_name())}, "  # FlagScale Add
                 "which may cause process-to-device mapping issues or "
                 "cross-device Tensor operation errors. If necessary, "
                 "send all Tensors in the module to the Megatron-FSDP "
@@ -373,8 +373,10 @@ class MegatronFSDP(torch.nn.Module):
         self.raw_param = dict(self.module.named_parameters())
 
         # Initialize a gradient buffer and accumulation stream for the GradReducePipeline.
+        # FlagScale Begin
         self.side_stream_for_buffer_copy_and_grad_accum = cur_platform.Stream()
         self.side_stream_for_param_gather = cur_platform.Stream()
+        # FlagScale End
 
         # Initialize the reduce-scatter pipeline.
         self.grad_reduce_pipeline = GradReducePipeline(

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/param_and_grad_buffer.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/param_and_grad_buffer.py
@@ -211,7 +211,7 @@ class MultiGroupUBRAllocator:
 
     def __enter__(self):
         for group in self.groups[1:]:
-            backend = group._get_backend(torch.device("cuda", cur_platform.current_device()))
+            backend = group._get_backend(torch.device("cuda", cur_platform.current_device()))  # FlagScale Add
             try:
                 # Since the registration is done in mempool granularity, we need to deregister
                 # the tensors in the mempool and re-register the mempool including the newly created
@@ -224,7 +224,7 @@ class MultiGroupUBRAllocator:
     def __exit__(self, *args):
         self.mem_allocator.__exit__(*args)
         for group in self.groups[1:]:
-            backend = group._get_backend(torch.device("cuda", cur_platform.current_device()))
+            backend = group._get_backend(torch.device("cuda", cur_platform.current_device()))  # FlagScale Add
             log_single_rank(
                 logger,
                 logging.INFO,
@@ -802,7 +802,7 @@ class FixedPoolAllocator(TemporaryBucketAllocator):
             ):
                 # Requires synchronization for new buffer allocation
                 self.allocation_tracker[(buffer_name, dtype)] = size
-                cur_platform.synchronize()
+                cur_platform.synchronize()  # FlagScale Add
         return Bucket(
             data=get_global_memory_buffer().get_tensor(
                 [size], dtype=dtype, name=buffer_name, mem_alloc_context=mem_alloc_context
@@ -1849,9 +1849,9 @@ class ParamAndGradBuffer:
         self.already_registered = True
 
         global NCCL_MEMORY_POOL
-        cur_platform.synchronize()
+        cur_platform.synchronize()  # FlagScale Add
         torch.distributed.barrier(async_op=False)
-        cur_platform.synchronize()
+        cur_platform.synchronize()  # FlagScale Add
 
         for group in self.ubr_groups:
             log_single_rank(
@@ -2492,7 +2492,7 @@ class ParamAndGradBuffer:
                             # CUDA device.
                             if check_gpu_memory(threshold=0.5):
                                 gc.collect()
-                                cur_platform.empty_cache()
+                                cur_platform.empty_cache()  # FlagScale Add
 
                             m.to_empty(device=self.device, recurse=False)
                             if (
@@ -2706,7 +2706,7 @@ class ParamAndGradBuffer:
 
         # Clean up deallocated memory.
         gc.collect()
-        cur_platform.empty_cache()
+        cur_platform.empty_cache()  # FlagScale Add
 
     def _reset_parameters(self, old_params, new_params):
         assert len(old_params) == len(new_params)
@@ -3386,7 +3386,7 @@ class GradReducePipeline:
     def __init__(
         self,
         param_and_grad_buffer: ParamAndGradBuffer,
-        rs_stream: Optional[cur_platform.Stream] = None,
+        rs_stream: Optional[cur_platform.Stream] = None,  # FlagScale Add
         check_nans: bool = False,
     ) -> None:
         self.buffer = param_and_grad_buffer
@@ -3409,7 +3409,7 @@ class GradReducePipeline:
         if dist_index.use_hybrid_fsdp:
             # If there are multiple FSDP groups, we need to reduce gradients across groups.
             self.outer_fsdp_group_grad_reduce = True
-            self.outer_fsdp_group_grad_reduce_stream = cur_platform.Stream()
+            self.outer_fsdp_group_grad_reduce_stream = cur_platform.Stream()  # FlagScale Add
         else:
             self.outer_fsdp_group_grad_reduce = False
 
@@ -3593,15 +3593,15 @@ class GradReducePipeline:
         if ddp_config.fsdp_double_buffer:
             self._enforce_double_buffer_limit(bucket_group)
 
-        current_stream = cur_platform.current_stream()
+        current_stream = cur_platform.current_stream()  # FlagScale Add
         reduce_scatter_stream = (
-            self.rs_stream if self.rs_stream is not None else cur_platform.current_stream()
+            self.rs_stream if self.rs_stream is not None else cur_platform.current_stream()  # FlagScale Add
         )
         reduce_scatter_stream.wait_stream(current_stream)
 
         # DP-Shard Gradient Reduction
         dp_group = self.get_fsdp_buffer(bucket_group[0]).data_parallel_group
-        with cur_platform.stream(reduce_scatter_stream):
+        with cur_platform.stream(reduce_scatter_stream):  # FlagScale Add
             with _coalescing_manager(dp_group):
                 # List of gradient accumulation closure tasks.
                 # (grad_buffer, reduced_grad)
@@ -3695,7 +3695,7 @@ class GradReducePipeline:
             # Wait on the DP-Shard reduction before further reduction.
             self.outer_fsdp_group_grad_reduce_stream.wait_stream(reduce_scatter_stream)
             outer_fsdp_group = self.buffer.dist_index.get_outer_fsdp_group()
-            with cur_platform.stream(self.outer_fsdp_group_grad_reduce_stream):
+            with cur_platform.stream(self.outer_fsdp_group_grad_reduce_stream):  # FlagScale Add
                 with _coalescing_manager(outer_fsdp_group):
                     # List of gradient accumulation closure tasks.
                     # (grad_buffer, reduced_grad)
@@ -3842,7 +3842,7 @@ class AllGatherPipeline:
     def __init__(
         self,
         param_and_grad_buffer: ParamAndGradBuffer,
-        ag_stream: Optional[cur_platform.Stream] = None,
+        ag_stream: Optional[cur_platform.Stream] = None,  # FlagScale Add
     ) -> None:
         self.buffer = param_and_grad_buffer
         self.ag_stream = ag_stream
@@ -3881,7 +3881,7 @@ class AllGatherPipeline:
         ):
             # If there are multiple FSDP groups and full sharding, we need to
             # all-gather parameters across groups.
-            self.outer_fsdp_group_param_gather_stream = cur_platform.Stream()
+            self.outer_fsdp_group_param_gather_stream = cur_platform.Stream()  # FlagScale Add
 
     def get_bucket_key(self, bucket_id, bwd):
         """Get the key for the bucket."""
@@ -4062,11 +4062,13 @@ class AllGatherPipeline:
         # Coalesce all-gather operations for all buckets in the same data-parallel-group
         for _, buckets in bucket_group_to_buckets.items():
             all_gather_stream = (
-                self.ag_stream if self.ag_stream is not None else cur_platform.current_stream()
+                self.ag_stream if self.ag_stream is not None else cur_platform.current_stream()  # FlagScale Add
             )
             if outer_fsdp_group_param_gather:
+                # FlagScale Begin
                 self.outer_fsdp_group_param_gather_stream.wait_stream(cur_platform.current_stream())
                 with cur_platform.stream(self.outer_fsdp_group_param_gather_stream):
+                # FlagScale End
                     is_expert_parallel = parameter_groups[buckets[0]].is_expert_param
                     outer_fsdp_group = self.buffer.dist_index.get_outer_fsdp_group(
                         is_expert_parallel=is_expert_parallel
@@ -4087,9 +4089,9 @@ class AllGatherPipeline:
                 all_gather_stream.wait_stream(self.outer_fsdp_group_param_gather_stream)
 
             # Coalesce the asynchronous NCCL operations in this context.
-            all_gather_stream.wait_stream(cur_platform.current_stream())
+            all_gather_stream.wait_stream(cur_platform.current_stream())  # FlagScale Add
             dp_group = self.get_fsdp_buffer(buckets[0]).data_parallel_group
-            with cur_platform.stream(all_gather_stream):
+            with cur_platform.stream(all_gather_stream):  # FlagScale Add
                 with _coalescing_manager(
                     dp_group, async_ops=async_param_gather
                 ) as coalescing_event:
@@ -4303,12 +4305,14 @@ def check_gpu_memory(threshold=0.9):
     Returns:
         bool: True if the GPU memory is over the threshold.
     """
-    if not cur_platform.is_available():
+    if not cur_platform.is_available():  # FlagScale Add
         return False
+    # FlagScale Begin
     device = cur_platform.current_device()
     allocated = cur_platform.memory_allocated(device)
     reserved = cur_platform.memory_reserved(device)
     total = cur_platform.get_device_properties(device).total_memory
+    # FlagScale End
 
     allocated_ratio = allocated / total
     reserved_ratio = reserved / total

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/utils.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/utils.py
@@ -166,7 +166,7 @@ def contains_submesh(
 
 
 def _get_cuda_rng_state(
-    device: Union[int, str, torch.device] = cur_platform.device_name(), clone: bool = False, graph_safe: bool = False
+    device: Union[int, str, torch.device] = cur_platform.device_name(), clone: bool = False, graph_safe: bool = False  # FlagScale Add
 ) -> torch.Tensor:
     """Return the random number generator state of the specified GPU.
 
@@ -179,18 +179,18 @@ def _get_cuda_rng_state(
 
     # if not using cuda graphs, just use the builtin pytorch function
     if not graph_safe:
-        return cur_platform.random().get_rng_state(device=device)
+        return cur_platform.random().get_rng_state(device=device)  # FlagScale Add
 
     _lazy_init()
     if isinstance(device, str):
         device = torch.device(device)
     elif isinstance(device, int):
-        device = torch.device(cur_platform.current_device_name())
+        device = torch.device(cur_platform.current_device_name())  # FlagScale Add
     idx = device.index
     if idx is None:
-        idx = cur_platform.current_device()
+        idx = cur_platform.current_device()  # FlagScale Add
 
-    default_generator = cur_platform.default_generator(idx)
+    default_generator = cur_platform.default_generator(idx)  # FlagScale Add
     if clone:
         return default_generator.clone_state()
     return default_generator.graphsafe_get_state()
@@ -217,17 +217,19 @@ def _set_cuda_rng_state(new_state: torch.Tensor, device: int = -1, graph_safe: b
     else:
         # newer PyTorch
         if device == -1:
-            device = torch.device(cur_platform.device_name())
+            device = torch.device(cur_platform.device_name())  # FlagScale Add
         elif isinstance(device, str):
             device = torch.device(device)
         elif isinstance(device, int):
-            device = torch.device(cur_platform.device(int))
+            device = torch.device(cur_platform.device(int))  # FlagScale Add
 
         def cb():
             idx = device.index
             if idx is None:
+                # FlagScale Begin
                 idx = cur_platform.current_device()
             default_generator = cur_platform.default_generator(idx)
+                # FlagScale End
 
             # if graph capturing, set the rng state in a cudagraphable way
             if graph_safe:
@@ -365,10 +367,12 @@ def initialize_rng_tracker(
                     self.states_[name] = new_state
                 else:
                     # Get the current rng state.
-                    orig_rng_state = cur_platform.get_rng_state()
+                    orig_rng_state = cur_platform.get_rng_state()  # FlagScale Add
                     # Set the new state and store it.
+                    # FlagScale Begin
                     cur_platform.manual_seed(seed)
                     self.states_[name] = cur_platform.get_rng_state()
+                    # FlagScale End
                     # Reset rng state to what it was.
                     _set_cuda_rng_state(orig_rng_state)
 
@@ -770,7 +774,7 @@ class GlobalMemoryBuffer:
                 self.buffer[(name, dtype)] = torch.empty(
                     required_len,
                     dtype=dtype,
-                    device=cur_platform.current_device(),
+                    device=cur_platform.current_device(),  # FlagScale Add
                     requires_grad=False,
                 )
 

--- a/megatron/core/distributed/param_and_grad_buffer.py
+++ b/megatron/core/distributed/param_and_grad_buffer.py
@@ -585,12 +585,12 @@ class _ParamAndGradBucketGroup:
         ):
             # Assign a communication stream if we have multiple DistOpt instances and we
             # need to overlap communication.
-            stream_context = cur_platform.stream(self.communication_stream)
+            stream_context = cur_platform.stream(self.communication_stream)  # FlagScale Add
 
             # The RS/AR communication stream needs to wait for the current stream
             # to complete its gradient computation before launching the next
             # gradient reduction collective.
-            self.communication_stream.wait_stream(cur_platform.current_stream())
+            self.communication_stream.wait_stream(cur_platform.current_stream())  # FlagScale Add
         else:
             stream_context = nullcontext()
 
@@ -698,7 +698,7 @@ class _ParamAndGradBucketGroup:
         # When using multiple DistOpt instances, we don't need to sync here as we launch
         # communications on a separate communication stream.
         if self.ddp_config.num_distributed_optimizer_instances > 1:
-            cur_platform.current_stream().wait_stream(self.communication_stream)
+            cur_platform.current_stream().wait_stream(self.communication_stream)  # FlagScale Add
             self._copy_back_extra_main_grads()
             return
         assert self.grad_reduce_handle is not None, (
@@ -1042,7 +1042,7 @@ class _ParamAndGradBuffer:
                 self.shared_buffer = torch.zeros(
                     self.numel,
                     dtype=self.grad_dtype,
-                    device=cur_platform.current_device(),
+                    device=cur_platform.current_device(),  # FlagScale Add
                     requires_grad=False,
                 )
                 # For FP32 weight grads, only half of the buffer is used to store params in bf16.
@@ -1059,7 +1059,7 @@ class _ParamAndGradBuffer:
                     self.param_data = torch.zeros(
                         self.numel,
                         dtype=self.param_dtype,
-                        device=cur_platform.current_device(),
+                        device=cur_platform.current_device(),  # FlagScale Add
                         requires_grad=False,
                     )
                 # For NVFP4, grad buffer uses full size (grad_numel),
@@ -1067,7 +1067,7 @@ class _ParamAndGradBuffer:
                 self.grad_data = torch.zeros(
                     self.grad_numel,
                     dtype=self.grad_dtype,
-                    device=cur_platform.current_device(),
+                    device=cur_platform.current_device(),  # FlagScale Add
                     requires_grad=False,
                 )
 

--- a/megatron/core/energy_monitor.py
+++ b/megatron/core/energy_monitor.py
@@ -18,9 +18,11 @@ try:
 except ImportError:
     has_nvml = False
 
+# FlagScale Begin
 from megatron.plugin.platform import get_platform
 
 cur_platform = get_platform()
+# FlagScale End
 
 
 class EnergyMonitor:
@@ -42,7 +44,7 @@ class EnergyMonitor:
         """Setup the NVML Handler."""
         if has_nvml:
             nvmlInit()
-            self._handle = nvmlDeviceGetHandleByIndex(cur_platform.current_device())
+            self._handle = nvmlDeviceGetHandleByIndex(cur_platform.current_device())  # FlagScale Add
 
     def shutdown(self) -> None:
         """Shutdown NVML."""
@@ -79,9 +81,11 @@ class EnergyMonitor:
         self._lap_energy = 0
         self._last_energy = energy
 
+        # FlagScale Begin
         lap_tensor = torch.tensor(
             [lap_energy], dtype=torch.int64, device=cur_platform.device_name()
         )
+        # FlagScale End
         dist.all_reduce(lap_tensor, op=dist.ReduceOp.SUM)
 
         return lap_tensor.item() / 1000.0
@@ -91,9 +95,11 @@ class EnergyMonitor:
         if not has_nvml:
             return 0.0
 
+        # FlagScale Begin
         energy_tensor = torch.tensor(
             [self._total_energy], dtype=torch.int64, device=cur_platform.device_name()
         )
+        # FlagScale End
         dist.all_reduce(energy_tensor, op=dist.ReduceOp.SUM)
 
         return energy_tensor.item() / 1000.0

--- a/megatron/core/export/trtllm/trtllm_weights_converter/distributed_trtllm_model_weights_converter.py
+++ b/megatron/core/export/trtllm/trtllm_weights_converter/distributed_trtllm_model_weights_converter.py
@@ -19,9 +19,11 @@ try:
 except ImportError:
     HAVE_TQDM = False
 
+# FlagScale Begin
 from megatron.plugin.platform import get_platform
 
 cur_platform = get_platform()
+# FlagScale End
 
 
 def str_dtype_to_torch(dtype: DataType):
@@ -223,7 +225,7 @@ class DistributedTRTLLMModelWeightsConverter:
             dim_size = list(val.size())
             dim_size[0] = vocab_size_padded
             gathered_val = torch.zeros(
-                dim_size, dtype=val.dtype, device=cur_platform.current_device()
+                dim_size, dtype=val.dtype, device=cur_platform.current_device()  # FlagScale Add
             )
             gathered_val[vocab_start_index:vocab_end_index] = val
             torch.distributed.all_reduce(gathered_val, group=self.tp_group)

--- a/megatron/core/extensions/transformer_engine.py
+++ b/megatron/core/extensions/transformer_engine.py
@@ -296,9 +296,11 @@ def _get_should_context_be_quantized_params(
         )
 
 
+# FlagScale Begin
 from megatron.plugin.platform import get_platform
 
 cur_platform = get_platform()
+# FlagScale End
 
 
 def _get_extra_te_kwargs(config: TransformerConfig):
@@ -310,7 +312,7 @@ def _get_extra_te_kwargs(config: TransformerConfig):
         elif config.init_model_with_meta_device:
             extra_transformer_engine_kwargs["device"] = "meta"
         else:
-            extra_transformer_engine_kwargs["device"] = cur_platform.current_device()
+            extra_transformer_engine_kwargs["device"] = cur_platform.current_device()  # FlagScale Add
     return extra_transformer_engine_kwargs
 
 
@@ -1031,7 +1033,7 @@ class TELayerNormColumnParallelLinear(te.pytorch.LayerNormLinear):
             sequence_parallel=self.config.sequence_parallel,
             fuse_wgrad_accumulation=self.config.gradient_accumulation_fusion,
             tp_group=tp_group if torch.distributed.is_initialized() else None,
-            tp_size=get_tensor_model_parallel_world_size(),
+            tp_size=get_tensor_model_parallel_world_size(),  # FlagScale Add
             get_rng_state_tracker=(
                 get_cuda_rng_tracker if get_cuda_rng_tracker().is_initialized() else None
             ),
@@ -1362,7 +1364,7 @@ class TEDotProductAttention(te.pytorch.DotProductAttention):
     via set_tensor_parallel_group() and set_context_parallel_group().
     """
 
-    cp_stream: cur_platform.Stream = None
+    cp_stream: cur_platform.Stream = None  # FlagScale Add
 
     def __init__(
         self,
@@ -1446,7 +1448,7 @@ class TEDotProductAttention(te.pytorch.DotProductAttention):
                 "1.0.0"
             ), "Only Transformer-Engine version >= 1.0.0 supports context parallelism!"
             if getattr(TEDotProductAttention, "cp_stream") is None:
-                TEDotProductAttention.cp_stream = cur_platform.Stream()
+                TEDotProductAttention.cp_stream = cur_platform.Stream()  # FlagScale Add
             extra_kwargs["cp_group"] = pg_collection.cp
             extra_kwargs["cp_global_ranks"] = torch.distributed.get_process_group_ranks(
                 pg_collection.cp
@@ -1541,7 +1543,7 @@ class TEDotProductAttention(te.pytorch.DotProductAttention):
             ),
             attn_mask_type=attn_mask_type.name,
             sequence_parallel=self.config.sequence_parallel,
-            tp_size=get_tensor_model_parallel_world_size(),
+            tp_size=get_tensor_model_parallel_world_size(),  # FlagScale Add
             get_rng_state_tracker=(
                 get_cuda_rng_tracker if get_cuda_rng_tracker().is_initialized() else None
             ),
@@ -1916,7 +1918,7 @@ if HAVE_TE and is_te_min_version("1.9.0.dev0"):
         def _encode_extra_state(self, state):
             # TE 2.0 changed the format of extra_state to be a byte tensor
             if is_te_min_version("2.0.0"):
-                cur_platform.synchronize()
+                cur_platform.synchronize()  # FlagScale Add
                 state_serialized = bytearray(pickle.dumps(state))
                 state_serialized = torch.frombuffer(state_serialized, dtype=torch.uint8)
             else:
@@ -1932,9 +1934,11 @@ if HAVE_TE and is_te_min_version("1.9.0.dev0"):
                 return pickle.loads(state.detach().cpu().numpy().tobytes())
             elif isinstance(state, io.BytesIO):
                 state.seek(0)
+                # FlagScale Begin
                 return torch.load(
                     state, map_location=cur_platform.device_name(), weights_only=False
                 )
+                # FlagScale End
             else:
                 raise RuntimeError("Unsupported checkpoint format.")
 

--- a/megatron/core/fp8_utils.py
+++ b/megatron/core/fp8_utils.py
@@ -19,9 +19,11 @@ from megatron.core.tensor_parallel import (
 )
 from megatron.core.transformer.transformer_config import TransformerConfig
 from megatron.core.utils import get_te_version, is_te_min_version
+# FlagScale Begin
 from megatron.plugin.platform import get_platform
 
 cur_platform = get_platform()
+# FlagScale End
 
 # Check if Transformer Engine is installed
 HAVE_TE = False
@@ -340,7 +342,7 @@ elif HAVE_TE and is_te_min_version("2.0"):
             scale_invs.append(model_param._scale_inv.view(1))
             model_param._reset_caches()
 
-        dummy_overflow_buf = torch.tensor([0], dtype=torch.int, device=cur_platform.device_name())
+        dummy_overflow_buf = torch.tensor([0], dtype=torch.int, device=cur_platform.device_name())  # FlagScale Add
 
         # Update scaling factors.
         packed_scales = torch.empty(len(scales), dtype=torch.float32, device=scales[0].device)
@@ -427,7 +429,7 @@ elif HAVE_TE and is_te_min_version("1.0"):
             scale_invs.append(model_param._scale_inv.view(1))
             model_param._reset_caches()
 
-        dummy_overflow_buf = torch.tensor([0], dtype=torch.int, device=cur_platform.device_name())
+        dummy_overflow_buf = torch.tensor([0], dtype=torch.int, device=cur_platform.device_name())  # FlagScale Add
 
         # Update scaling factors.
         packed_scales = torch.empty(len(scales), dtype=torch.float32, device=scales[0].device)

--- a/megatron/core/full_cuda_graph.py
+++ b/megatron/core/full_cuda_graph.py
@@ -66,7 +66,7 @@ class StaticBufferLoader:
     static_buffers: dict = {'training': [], 'validation': []}
 
     def __init__(self):
-        self.stream = cur_platform.Stream()
+        self.stream = cur_platform.Stream()  # FlagScale Add
 
     def __call__(self, inputs, stage, microbatch):
         assert stage in ['training', 'validation']
@@ -76,8 +76,10 @@ class StaticBufferLoader:
 
         assert isinstance(inputs, dict)
         if microbatch == len(StaticBufferLoader.static_buffers[stage]):
+            # FlagScale Begin
             self.stream.wait_stream(cur_platform.current_stream())
             with cur_platform.stream(self.stream):
+            # FlagScale End
                 StaticBufferLoader.static_buffers[stage].append(copy_tensors_in_struct(inputs))
         else:
 
@@ -90,12 +92,14 @@ class StaticBufferLoader:
                     else:
                         StaticBufferLoader.static_buffers[stage][microbatch][k] = inputs[k]
 
+            # FlagScale Begin
             self.stream.wait_stream(cur_platform.current_stream())
             with cur_platform.stream(self.stream):
+            # FlagScale End
                 clone_tensors_in_struct(
                     StaticBufferLoader.static_buffers[stage][microbatch], inputs
                 )
-        cur_platform.current_stream().wait_stream(self.stream)
+        cur_platform.current_stream().wait_stream(self.stream)  # FlagScale Add
         return StaticBufferLoader.static_buffers[stage][microbatch]
 
 
@@ -175,8 +179,10 @@ class FullCudaGraphWrapper:
             FullCudaGraphWrapper.cuda_graph[training_str] = torch.cuda.CUDAGraph()
             for _, state in get_all_rng_states().items():
                 FullCudaGraphWrapper.cuda_graph[training_str].register_generator_state(state)
+            # FlagScale Begin
             cur_platform.synchronize()
             capture_stream = cur_platform.Stream()
+            # FlagScale End
             with torch.cuda.graph(
                 FullCudaGraphWrapper.cuda_graph[training_str],
                 stream=capture_stream,
@@ -185,7 +191,7 @@ class FullCudaGraphWrapper:
                 FullCudaGraphWrapper.result[training_str] = self.forward_backward_func(
                     *args, **kwargs
                 )
-            cur_platform.synchronize()
+            cur_platform.synchronize()  # FlagScale Add
             torch.distributed.barrier()
             logger.info(f'CUDA graph capture done for {training_str}!!!')
 

--- a/megatron/core/fusions/fused_indices_converter.py
+++ b/megatron/core/fusions/fused_indices_converter.py
@@ -7,18 +7,22 @@ import torch
 from packaging import version
 
 from megatron.core.utils import null_decorator
+# FlagScale Begin
 from megatron.plugin.platform import get_platform
 
 cur_platform = get_platform()
+# FlagScale End
 
 try:
     import triton
     import triton.language as tl
 
+    # FlagScale Begin
     if (
         version.parse(triton.__version__) < version.parse("3.4.0")
         and not cur_platform.is_available()
     ):
+    # FlagScale End
         HAVE_TRITON = False
     else:
         HAVE_TRITON = tl.constexpr(version.parse(triton.__version__) >= version.parse("2.0.0"))
@@ -209,19 +213,25 @@ class IndicesToMultihot(torch.autograd.Function):
         ), "indices and probs_indices must have the same shape"
         topk = indices.shape[1]
         multihot_indices = torch.empty(
+            # FlagScale Begin
             (num_of_tokens, num_of_local_experts),
             dtype=torch.bool,
             device=cur_platform.device_name(),
+            # FlagScale End
         )
         probs_in_multihot = torch.empty(
+            # FlagScale Begin
             (num_of_tokens, num_of_local_experts),
             dtype=probs_indices.dtype,
             device=cur_platform.device_name(),
+            # FlagScale End
         )
         position_map = torch.empty(
+            # FlagScale Begin
             (num_of_tokens, num_of_local_experts),
             dtype=torch.int32,
             device=cur_platform.device_name(),
+            # FlagScale End
         )
         # Compute the next power of 2 for the topk and num_of_local_experts
         topk_next_power_of_2 = 2 ** int(math.ceil(math.log2(topk)))
@@ -268,9 +278,11 @@ class IndicesToMultihot(torch.autograd.Function):
 
         # Initialize the gradient of the indices and probs_indices
         grad_probs_indices = torch.empty(
+            # FlagScale Begin
             (num_of_tokens, topk),
             dtype=grad_probs_in_multihot.dtype,
             device=cur_platform.device_name(),
+            # FlagScale End
         )
         # Compute the next power of 2 for the topk and num_of_local_experts
         topk_next_power_of_2 = 2 ** int(math.ceil(math.log2(topk)))

--- a/megatron/core/fusions/fused_mla_yarn_rope_apply.py
+++ b/megatron/core/fusions/fused_mla_yarn_rope_apply.py
@@ -7,18 +7,22 @@ import torch
 from packaging import version
 
 from megatron.core.utils import null_decorator
+# FlagScale Begin
 from megatron.plugin.platform import get_platform
 
 cur_platform = get_platform()
+# FlagScale End
 
 try:
     import triton
     import triton.language as tl
 
+    # FlagScale Begin
     if (
         version.parse(triton.__version__) < version.parse("3.4.0")
         and not cur_platform.is_available()
     ):
+    # FlagScale End
         HAVE_TRITON = False
     else:
         HAVE_TRITON = tl.constexpr(version.parse(triton.__version__) >= version.parse("2.0.0"))

--- a/megatron/core/fusions/fused_pad_routing_map.py
+++ b/megatron/core/fusions/fused_pad_routing_map.py
@@ -7,18 +7,22 @@ from packaging import version
 
 from megatron.core.jit import jit_fuser
 from megatron.core.utils import null_decorator
+# FlagScale Begin
 from megatron.plugin.platform import get_platform
 
 cur_platform = get_platform()
+# FlagScale End
 
 try:
     import triton
     import triton.language as tl
 
+    # FlagScale Begin
     if (
         version.parse(triton.__version__) < version.parse("3.4.0")
         and not cur_platform.is_available()
     ):
+    # FlagScale End
         HAVE_TRITON = False
     else:
         HAVE_TRITON = tl.constexpr(version.parse(triton.__version__) >= version.parse("2.0.0"))

--- a/megatron/core/inference/communication_utils.py
+++ b/megatron/core/inference/communication_utils.py
@@ -6,8 +6,10 @@ from torch.distributed import ProcessGroup
 
 from megatron.core import parallel_state
 
+# FlagScale Begin
 from megatron.plugin.platform import get_platform
 cur_platform = get_platform()
+# FlagScale End
 
 def is_pipeline_first_stage(pp_group: ProcessGroup):
     """Check if the current process is the first stage of the pipeline"""
@@ -75,7 +77,7 @@ def broadcast_from_last_pipeline_stage(
         assert dtype == tensor.dtype, f"Expected tensor of type {dtype} but got {tensor.dtype}"
         _is_cuda_contiguous(tensor)
     else:
-        tensor = torch.empty(size, dtype=dtype, device=cur_platform.current_device())
+        tensor = torch.empty(size, dtype=dtype, device=cur_platform.current_device())  # FlagScale Add
 
     # Broadcast the tensor
     torch.distributed.broadcast(tensor, src=last_rank, group=pp_group)
@@ -110,7 +112,7 @@ def recv_from_prev_pipeline_rank_(
     for req in reqs:
         req.wait()
     # To protect against race condition when using batch_isend_irecv().
-    cur_platform.synchronize()
+    cur_platform.synchronize()  # FlagScale Add
 
 
 def send_to_next_pipeline_rank(
@@ -141,7 +143,7 @@ def send_to_next_pipeline_rank(
     for req in reqs:
         req.wait()
     # To protect against race condition when using batch_isend_irecv().
-    cur_platform.synchronize()
+    cur_platform.synchronize()  # FlagScale Add
 
 
 def broadcast_tensor(size, dtype, tensor=None, rank=0, data_parallel=False):
@@ -157,7 +159,7 @@ def broadcast_tensor(size, dtype, tensor=None, rank=0, data_parallel=False):
     if torch.distributed.get_rank() == rank:
         _is_cuda_contiguous(tensor)
     else:
-        tensor = torch.empty(size, dtype=dtype, device=cur_platform.current_device())
+        tensor = torch.empty(size, dtype=dtype, device=cur_platform.current_device())  # FlagScale Add
 
     group = None
     if data_parallel:
@@ -179,12 +181,12 @@ def broadcast_list(size, dtype, list_values=None, rank=0, data_parallel=False):
 
     if data_parallel:
         if parallel_state.get_model_parallel_src_rank() == torch.distributed.get_rank():
-            tensor = torch.tensor(list_values, dtype=dtype, device=cur_platform.current_device())
+            tensor = torch.tensor(list_values, dtype=dtype, device=cur_platform.current_device())  # FlagScale Add
 
         rank = parallel_state.get_model_parallel_src_rank()
     else:
         if torch.distributed.get_rank() == rank:
-            tensor = torch.tensor(list_values, dtype=dtype, device=cur_platform.current_device())
+            tensor = torch.tensor(list_values, dtype=dtype, device=cur_platform.current_device())  # FlagScale Add
 
     return broadcast_tensor(size, dtype, tensor=tensor, rank=rank, data_parallel=data_parallel)
 

--- a/megatron/core/model_parallel_config.py
+++ b/megatron/core/model_parallel_config.py
@@ -398,6 +398,7 @@ class ModelParallelConfig:
        the user adds a level 1 timer that is not called by all ranks.
     """
 
+    # FlagScale Begin
     ###################
     # Heterogeneous Training
     ###################
@@ -406,6 +407,7 @@ class ModelParallelConfig:
 
     hetero_pipeline_layer_split: list = None
     """A list of lists, each sublist contains numbers of layers to be processed in the corresponding pipeline stages for one device type."""
+    # FlagScale End
 
     def __post_init__(self):
         """Python dataclass method that is used to modify attributes after initialization.

--- a/megatron/core/models/bert/bert_model.py
+++ b/megatron/core/models/bert/bert_model.py
@@ -28,9 +28,11 @@ from megatron.core.transformer.utils import get_linear_layer
 from megatron.core.utils import deprecate_inference_params, is_te_min_version
 
 
+# FlagScale Begin
 from megatron.plugin.platform import get_platform
 
 cur_platform = get_platform()
+# FlagScale End
 
 
 class BertModel(LanguageModule):
@@ -369,7 +371,7 @@ class BertModel(LanguageModule):
             output = torch.zeros(
                 size=(embeddings.shape[0], embeddings.shape[2]),
                 dtype=torch.float32,
-                device=cur_platform.current_device(),
+                device=cur_platform.current_device(),  # FlagScale Add
             )
             for i, (embedding, mask) in enumerate(zip(embeddings, masks)):
                 output[i, :] = torch.mean(embedding[1 : mask - 1], dim=0)

--- a/megatron/core/models/common/embeddings/rope_utils.py
+++ b/megatron/core/models/common/embeddings/rope_utils.py
@@ -34,9 +34,11 @@ try:
 except ImportError:
     apply_rotary_emb_flash = None
 
+# FlagScale Begin
 from megatron.plugin.platform import get_platform
 
 cur_platform = get_platform()
+# FlagScale End
 
 __all__ = [
     'apply_rotary_pos_emb',
@@ -62,9 +64,11 @@ def get_pos_emb_on_this_cp_rank(
         raise ValueError("cp_group must be provided to get positional embedding per CP rank")
     cp_size = cp_group.size()
     cp_rank = cp_group.rank()
+    # FlagScale Begin
     cp_idx = torch.tensor([cp_rank, (2 * cp_size - cp_rank - 1)], device="cpu", pin_memory=True).to(
         device=cur_platform.device(), non_blocking=True
     )
+    # FlagScale End
     pos_emb = pos_emb.view(
         *pos_emb.shape[:seq_dim], 2 * cp_size, -1, *pos_emb.shape[(seq_dim + 1) :]
     )

--- a/megatron/core/models/common/embeddings/rotary_pos_embedding.py
+++ b/megatron/core/models/common/embeddings/rotary_pos_embedding.py
@@ -26,9 +26,11 @@ from megatron.core.models.common.embeddings.rope_utils import (  # for backward 
     get_pos_emb_on_this_cp_rank,
 )
 from megatron.core.utils import deprecate_inference_params, internal_api
+# FlagScale Begin
 from megatron.plugin.platform import get_platform
 
 cur_platform = get_platform()
+# FlagScale End
 
 logger = logging.getLogger(__name__)
 
@@ -78,7 +80,7 @@ class RotaryEmbedding(nn.Module):
         self.rotary_interleaved = rotary_interleaved
 
         self.seq_len_interpolation_factor = seq_len_interpolation_factor
-        device = 'cpu' if use_cpu_initialization else cur_platform.current_device()
+        device = 'cpu' if use_cpu_initialization else cur_platform.current_device()  # FlagScale Add
         self.inv_freq = 1.0 / (
             rotary_base ** (torch.arange(0, dim, 2, dtype=torch.float32, device=device) / dim)
         )
@@ -162,7 +164,7 @@ class RotaryEmbedding(nn.Module):
         """
         if self.inv_freq.device.type == 'cpu':
             # move `inv_freq` to GPU once at the first micro-batch forward pass
-            self.inv_freq = self.inv_freq.to(device=cur_platform.current_device())
+            self.inv_freq = self.inv_freq.to(device=cur_platform.current_device())  # FlagScale Add
 
         freqs = self.get_freqs_non_repeated(max_seq_len, offset)
         # first part even vector components, second part odd vector components,
@@ -259,7 +261,7 @@ class RotaryEmbedding(nn.Module):
                 rotary_seq_len = transformer_input.size(0)
 
             if transformer_config.sequence_parallel:
-                rotary_seq_len *= parallel_state.get_tensor_model_parallel_world_size()
+                rotary_seq_len *= parallel_state.get_tensor_model_parallel_world_size()  # FlagScale Add
 
         rotary_seq_len *= transformer_config.context_parallel_size
 
@@ -305,7 +307,7 @@ class MultimodalRotaryEmbedding(nn.Module):
         self.inv_freq = 1.0 / (
             rotary_base
             ** (
-                torch.arange(0, dim, 2, dtype=torch.float32, device=cur_platform.current_device())
+                torch.arange(0, dim, 2, dtype=torch.float32, device=cur_platform.current_device())  # FlagScale Add
                 / dim
             )
         )

--- a/megatron/core/models/common/embeddings/yarn_rotary_pos_embedding.py
+++ b/megatron/core/models/common/embeddings/yarn_rotary_pos_embedding.py
@@ -14,9 +14,11 @@ from megatron.core.models.common.embeddings.rope_utils import get_pos_emb_on_thi
 from megatron.core.models.common.embeddings.rotary_pos_embedding import RotaryEmbedding
 from megatron.core.transformer import TransformerConfig
 from megatron.core.utils import internal_api
+# FlagScale Begin
 from megatron.plugin.platform import get_platform
 
 cur_platform = get_platform()
+# FlagScale End
 
 logger = logging.getLogger(__name__)
 
@@ -76,7 +78,7 @@ class YarnRotaryEmbedding(RotaryEmbedding):
         self.mscale_all_dim = mscale_all_dim
         self.correction_range_round_to_int = correction_range_round_to_int
 
-        device = 'cpu' if use_cpu_initialization else cur_platform.current_device()
+        device = 'cpu' if use_cpu_initialization else cur_platform.current_device()  # FlagScale Add
 
         with torch.device(device):
             self.inv_freq_extra = 1.0 / (
@@ -122,11 +124,11 @@ class YarnRotaryEmbedding(RotaryEmbedding):
 
         if self.inv_freq_extra.device.type == 'cpu':
             # move `inv_freq_extra` to GPU once at the first micro-batch forward pass
-            self.inv_freq_extra = self.inv_freq_extra.to(device=cur_platform.current_device())
+            self.inv_freq_extra = self.inv_freq_extra.to(device=cur_platform.current_device())  # FlagScale Add
 
         if self.inv_freq_inter.device.type == 'cpu':
             # move `inv_freq_inter` to GPU once at the first micro-batch forward pass
-            self.inv_freq_inter = self.inv_freq_inter.to(device=cur_platform.current_device())
+            self.inv_freq_inter = self.inv_freq_inter.to(device=cur_platform.current_device())  # FlagScale Add
 
         low, high = _yarn_find_correction_range(
             self.beta_fast,

--- a/megatron/core/models/common/language_module/language_module.py
+++ b/megatron/core/models/common/language_module/language_module.py
@@ -70,7 +70,7 @@ class LanguageModule(MegatronModule):
         self.vp_stage = None
         self.vp_size = self.config.virtual_pipeline_model_parallel_size
 
-    @overridable
+    @overridable  # FlagScale Add
     def _is_in_embd_group(self):
         if self.embd_group is None:
             return False
@@ -179,7 +179,7 @@ class LanguageModule(MegatronModule):
         loss = loss.transpose(0, 1).contiguous()
         return loss
 
-    @overridable
+    @overridable  # FlagScale Add
     def setup_embeddings_and_output_layer(self) -> None:
         """Sets up embedding layer in first stage and output layer in last stage.
 
@@ -280,7 +280,7 @@ class LanguageModule(MegatronModule):
         if torch.distributed.is_initialized():
             if self._is_in_embd_group() and not self.config.init_model_with_meta_device:
                 weight = self.shared_embedding_or_output_weight()
-                weight.data = weight.data.to(cur_platform.device())
+                weight.data = weight.data.to(cur_platform.device())  # FlagScale Add
                 torch.distributed.all_reduce(weight.data, group=self.embd_group)
 
         elif not getattr(LanguageModule, "embedding_warning_printed", False):

--- a/megatron/core/models/common/model_chunk_schedule_plan.py
+++ b/megatron/core/models/common/model_chunk_schedule_plan.py
@@ -318,7 +318,7 @@ class TransformerModelChunkSchedulePlan(AbstractSchedulePlan):
 
         self._model_chunk_state = ModelChunkState()
         self._transformer_layers = []
-        self._event = cur_platform.Event()
+        self._event = cur_platform.Event()  # FlagScale Add
         self.pre_process = None
         self.post_process = None
         self.vp_stage = model.vp_stage
@@ -364,7 +364,7 @@ class TransformerModelChunkSchedulePlan(AbstractSchedulePlan):
             return
         num_layers = len(module.layers)
         for layer_idx in range(num_layers):
-            layer = module.layers[layer_idx]
+            layer = module.layers[layer_idx]  # FlagScale Add
             extra_args = {
                 "is_first_layer": layer_idx == 0,
                 "is_last_layer": layer_idx == num_layers - 1,
@@ -377,7 +377,7 @@ class TransformerModelChunkSchedulePlan(AbstractSchedulePlan):
                 ]
             ########## FlagScale End ##########
             layer_plan = TransformerLayerSchedulePlan(
-                layer,
+                layer,  # FlagScale Add
                 self.event,
                 self.state,
                 comp_stream,
@@ -393,12 +393,12 @@ class TransformerModelChunkSchedulePlan(AbstractSchedulePlan):
 
     def record_current_stream(self):
         """Records the current CUDA stream in the event."""
-        stream = cur_platform.current_stream()
+        stream = cur_platform.current_stream()  # FlagScale Add
         self.event.record(stream)
 
     def wait_current_stream(self):
         """Waits for the event to complete on the current CUDA stream."""
-        stream = cur_platform.current_stream()
+        stream = cur_platform.current_stream()  # FlagScale Add
         self.event.wait(stream)
 
     def get_layer(self, i):
@@ -493,7 +493,7 @@ class TransformerModelChunkSchedulePlan(AbstractSchedulePlan):
         for i in range(overlapped_layers):
             f_layer = f_schedule_plan.get_layer(i)
             b_layer = b_schedule_plan.pop_layer()
-            cur_platform.range_push(f"layer_{i}f-layer_{b_schedule_plan.num_layers()}b")
+            cur_platform.range_push(f"layer_{i}f-layer_{b_schedule_plan.num_layers()}b")  # FlagScale Add
             f_input, b_grad = TransformerLayerSchedulePlan.run(
                 f_layer,
                 b_layer,
@@ -503,30 +503,30 @@ class TransformerModelChunkSchedulePlan(AbstractSchedulePlan):
             )
             if i < b_num_layers - 1:
                 b_layer.release_state()
-            cur_platform.range_pop()
+            cur_platform.range_pop()  # FlagScale Add
 
         # backward pass for the remaining layers
         for i in range(overlapped_layers, b_num_layers):
             b_layer = b_schedule_plan.pop_layer()
-            cur_platform.range_push(f"layer_{b_schedule_plan.num_layers()}b")
+            cur_platform.range_push(f"layer_{b_schedule_plan.num_layers()}b")  # FlagScale Add
             _, b_grad = TransformerLayerSchedulePlan.run(
                 None, b_layer, b_grad=b_grad, is_last_layer_in_bwd=(i == b_num_layers - 1)
             )
             if i < b_num_layers - 1:
                 b_layer.release_state()
-            cur_platform.range_pop()
+            cur_platform.range_pop()  # FlagScale Add
 
         # forward pass for the remaining layers
         for i in range(overlapped_layers, f_num_layers):
             f_layer = f_schedule_plan.get_layer(i)
-            cur_platform.range_push(f"layer_{i}f")
+            cur_platform.range_push(f"layer_{i}f")  # FlagScale Add
             f_input, _ = TransformerLayerSchedulePlan.run(f_layer, None, f_input=f_input)
-            cur_platform.range_pop()
+            cur_platform.range_pop()  # FlagScale Add
 
         if f_schedule_plan is not None and post_forward is not None:
             # post_forward()/send_forward_recv_forward() is running in the communication stream,
             # so the p2p comm could be overlapped with the attn backward
-            with cur_platform.stream(get_comm_stream()):
+            with cur_platform.stream(get_comm_stream()):  # FlagScale Add
                 f_schedule_plan.wait_current_stream()
                 post_forward(f_input, f_schedule_plan.vp_stage)
 

--- a/megatron/core/models/gpt/fine_grained_callables.py
+++ b/megatron/core/models/gpt/fine_grained_callables.py
@@ -338,11 +338,13 @@ class TransformerLayerNode(ScheduleNode):
             return
         if isinstance(self.stream, Callable):
             self.stream = self.stream()
+        # FlagScale Begin
         with cur_platform.stream(self.stream):
             cur_platform.range_push(f"{self.name} wgrad")
+        # FlagScale End
             for module in self.bwd_dw_callables:
                 module.backward_dw()
-            cur_platform.range_pop()
+            cur_platform.range_pop()  # FlagScale Add
 
         # the output grad memory is last used in wgrad compute, should be safe to release.
         assert self.delay_grads_release, "output grad memory should be valid before wgrad."
@@ -618,9 +620,9 @@ def build_transformer_layer_callables(layer: TransformerLayer):
         )
 
         # Need to record tensors created on comp stream to comm stream
-        node.layer_state.residual.record_stream(cur_platform.current_stream())
+        node.layer_state.residual.record_stream(cur_platform.current_stream())  # FlagScale Add
         if shared_expert_output is not None:
-            shared_expert_output.record_stream(cur_platform.current_stream())
+            shared_expert_output.record_stream(cur_platform.current_stream())  # FlagScale Add
 
         # release tensor reference after use
         node.layer_state.residual = None

--- a/megatron/core/models/gpt/gpt_layer_specs.py
+++ b/megatron/core/models/gpt/gpt_layer_specs.py
@@ -553,7 +553,7 @@ def get_gpt_decoder_layer_specs(
     qk_l2_norm: Optional[bool] = False,
     vp_stage: Optional[int] = None,
     pp_rank: Optional[int] = None,
-    is_dualpipev_first_chunk: Optional[bool] = False,
+    is_dualpipev_first_chunk: Optional[bool] = False,  # FlagScale Add
 ) -> TransformerBlockSubmodules:
     """GPT block spec."""
     if use_transformer_engine:
@@ -662,7 +662,7 @@ def get_gpt_decoder_block_spec(
     qk_l2_norm: Optional[bool] = False,
     vp_stage: Optional[int] = None,
     pp_rank: Optional[int] = None,
-    is_dualpipev_first_chunk: Optional[bool] = False,
+    is_dualpipev_first_chunk: Optional[bool] = False,  # FlagScale Add
 ) -> TransformerBlockSubmodules:
     """GPT block spec."""
     layer_specs = get_gpt_decoder_layer_specs(
@@ -670,6 +670,7 @@ def get_gpt_decoder_block_spec(
     )
     # Slice the layer specs to only include the layers that are built in this pipeline stage.
     # Note: MCore layer_number starts at 1
+    # FlagScale Begin
     ######### FlagScale Modify ########
     num_layers_to_build = get_num_layers_to_build(
         config,
@@ -677,6 +678,7 @@ def get_gpt_decoder_block_spec(
         pp_rank=pp_rank,
         is_dualpipev_first_chunk=is_dualpipev_first_chunk,
     )
+    # FlagScale End
 
     if config.pipeline_model_parallel_layout is not None:
         layout = config.pipeline_model_parallel_layout
@@ -688,6 +690,7 @@ def get_gpt_decoder_block_spec(
             )
         ]
     else:
+        # FlagScale Begin
         ######### FlagScale Modify ########
         offset = get_transformer_layer_offset(
             config,
@@ -695,6 +698,7 @@ def get_gpt_decoder_block_spec(
             pp_rank=pp_rank,
             is_dualpipev_first_chunk=is_dualpipev_first_chunk,
         )
+        # FlagScale End
         local_layer_specs = layer_specs[offset : offset + num_layers_to_build]
 
     if use_transformer_engine:

--- a/megatron/core/models/gpt/gpt_model.py
+++ b/megatron/core/models/gpt/gpt_model.py
@@ -425,7 +425,7 @@ class GPTModel(LanguageModule):
             sequence_len_offset = torch.tensor(
                 [inference_context.sequence_len_offset] * current_batch_size,
                 dtype=torch.int32,
-                device=cur_platform.current_device(),
+                device=cur_platform.current_device(),  # FlagScale Add
             )
         else:
             sequence_len_offset = None

--- a/megatron/core/models/vision/clip_vit_model.py
+++ b/megatron/core/models/vision/clip_vit_model.py
@@ -21,9 +21,11 @@ try:
 except:
     NORM_IMPL = torch.nn.LayerNorm
 
+# FlagScale Begin
 from megatron.plugin.platform import get_platform
 
 cur_platform = get_platform()
+# FlagScale End
 
 
 # Note: This is under development and is missing features like position embedding interpolation.
@@ -125,7 +127,7 @@ class CLIPViTModel(VisionModule):
             padding=padding,
         )
 
-        self.position_ids = torch.arange(self.seq_length).expand(1, -1).to(cur_platform.device())
+        self.position_ids = torch.arange(self.seq_length).expand(1, -1).to(cur_platform.device())  # FlagScale Add
 
         self.position_embeddings = torch.nn.Embedding(
             self.seq_length, self.visual_hidden_size, dtype=transformer_config.params_dtype

--- a/megatron/core/nccl_allocator.py
+++ b/megatron/core/nccl_allocator.py
@@ -21,9 +21,11 @@ logger = logging.getLogger(__name__)
 
 _allocator = None
 
+# FlagScale Begin
 from megatron.plugin.platform import get_platform
 
 cur_platform = get_platform()
+# FlagScale End
 
 
 def _build_nccl_allocator():
@@ -127,20 +129,22 @@ def create_nccl_mem_pool(symmetric=None):  # symmetric: bool | None = None -> to
 
     assert _allocator is not None, "NCCL allocator is not initialized"
     if not symmetric:
-        _pool = cur_platform.MemPool(_allocator)
+        _pool = cur_platform.MemPool(_allocator)  # FlagScale Add
     else:
-        if 'symmetric' in get_func_args(cur_platform.MemPool):
+        if 'symmetric' in get_func_args(cur_platform.MemPool):  # FlagScale Add
             # The PyTorch version >= 2.9.0a0 and before PyTorch PR #161238,
             # The symmetric knob should passed to the MemPool constructor.
             # Since PyTorch PR #161238 symmetric knob is now in registration function.
+            # FlagScale Begin
             _pool = cur_platform.MemPool(_allocator, symmetric=symmetric)
         elif 'symm_mem' in get_func_args(cur_platform.MemPool):
+            # FlagScale End
             # This path handles argument name divergence between
             # nvidia pytorch and the official pytorch.
-            _pool = cur_platform.MemPool(_allocator, symm_mem=symmetric)
+            _pool = cur_platform.MemPool(_allocator, symm_mem=symmetric)  # FlagScale Add
         else:
             # This path handles the case where the symmetric knob is in the registration function.
-            _pool = cur_platform.MemPool(_allocator)
+            _pool = cur_platform.MemPool(_allocator)  # FlagScale Add
     return _pool
 
 
@@ -169,7 +173,7 @@ def register_mem_pool(pool, group, symmetric=True):
     Register a memory pool to a group.
     symmetric: bool, this is for future use.
     """
-    backend = group._get_backend(torch.device("cuda", cur_platform.current_device()))
+    backend = group._get_backend(torch.device("cuda", cur_platform.current_device()))  # FlagScale Add
     if symmetric:
         try:
             backend.register_mem_pool(pool, symm=symmetric)
@@ -190,7 +194,7 @@ def deregister_mem_pool(pool, group):
     """
     Deregister a memory pool from a group.
     """
-    backend = group._get_backend(torch.device("cuda", cur_platform.current_device()))
+    backend = group._get_backend(torch.device("cuda", cur_platform.current_device()))  # FlagScale Add
     if pool.snapshot():
         backend.deregister_mem_pool(pool)
 
@@ -210,9 +214,9 @@ class nccl_mem:
 
         if enabled:
             if device is None:
-                self.device = torch.device(cur_platform.current_device_name())
+                self.device = torch.device(cur_platform.current_device_name())  # FlagScale Add
             elif isinstance(device, int):
-                self.device = torch.device(cur_platform.device(device))
+                self.device = torch.device(cur_platform.device(device))  # FlagScale Add
             elif isinstance(device, str):
                 assert "cuda" in device, "only cuda devices are supported"
                 self.device = torch.device(device)
@@ -222,7 +226,7 @@ class nccl_mem:
             else:
                 self.group = group
 
-            self.mem_context = cur_platform.use_mem_pool(self.pool)
+            self.mem_context = cur_platform.use_mem_pool(self.pool)  # FlagScale Add
         else:
             self.mem_context = nullcontext()
 
@@ -307,10 +311,10 @@ class MultiGroupMemPoolAllocator:
     ):  # pool: torch.cuda.MemPool, groups: List[torch.distributed.ProcessGroup]
         self.pool = pool
         self.groups = groups
-        self.mem_context = cur_platform.use_mem_pool(self.pool)
+        self.mem_context = cur_platform.use_mem_pool(self.pool)  # FlagScale Add
         self.symmetric = symmetric
 
-        assert isinstance(self.pool, cur_platform.MemPool), "pool must be a cur_platform.MemPool"
+        assert isinstance(self.pool, cur_platform.MemPool), "pool must be a cur_platform.MemPool"  # FlagScale Add
         assert isinstance(self.groups, list), "groups must be a list"
         assert all(
             isinstance(group, torch.distributed.ProcessGroup) for group in self.groups
@@ -321,7 +325,7 @@ class MultiGroupMemPoolAllocator:
         # If the pool is not empty, deregister the pool from all the groups.
         if self.pool.snapshot():
             for group in self.groups:
-                backend = group._get_backend(torch.device(cur_platform.current_device_name()))
+                backend = group._get_backend(torch.device(cur_platform.current_device_name()))  # FlagScale Add
                 try:
                     # Since the registration is done in mempool granularity, we need to deregister
                     # the tensors in the mempool and re-register the mempool including
@@ -338,7 +342,7 @@ class MultiGroupMemPoolAllocator:
 
     def __exit__(self, *args):
         for group in self.groups:
-            backend = group._get_backend(torch.device(cur_platform.current_device_name()))
+            backend = group._get_backend(torch.device(cur_platform.current_device_name()))  # FlagScale Add
             try:
                 # Prefer attempting symmetric registration first; fall back if unsupported.
                 if self.symmetric:

--- a/megatron/core/optimizer/__init__.py
+++ b/megatron/core/optimizer/__init__.py
@@ -314,7 +314,7 @@ def _get_param_groups(
         List of parameter groups.
     """
 
-    # Map (pg_overrides, is_expert_parallel, is_engram_parallel) to params.
+    # Map (pg_overrides, is_expert_parallel, is_engram_parallel) to params.  # FlagScale Add
     params_map = {}
 
     if config_overrides is None:
@@ -346,15 +346,17 @@ def _get_param_groups(
                 param_override = None
 
             is_expert_parallel = not getattr(param, 'allreduce', True)
+            # FlagScale Begin
             is_engram_parallel = getattr(
                 param, 'is_engram_embedding', False
             )  # FlagScale add is_engram_parallel
+            # FlagScale End
 
             # Create config_tuple that is hash-able, and has a consistent ordering of the keys.
             param_override_tuple: tuple[tuple[str, Any], ...] | None = (
                 param_group_override_to_tuple(param_override)
             )
-            key = (param_override_tuple, is_expert_parallel, is_engram_parallel)
+            key = (param_override_tuple, is_expert_parallel, is_engram_parallel)  # FlagScale Add
             if key not in params_map:
                 params_map[key] = []
             params_map[key].append(param)
@@ -373,7 +375,7 @@ def _get_param_groups(
     param_groups = []
     # Sort keys, None first.
     for key in sorted(params_key, key=lambda x: (x[0] is not None, x[0])):
-        param_override_tuple, is_expert_parallel, is_engram_parallel = key
+        param_override_tuple, is_expert_parallel, is_engram_parallel = key  # FlagScale Add
         params = params_map[key] if key in params_map else []
         if param_override_tuple is None:
             param_override: ParamGroupOverride = {}
@@ -406,8 +408,10 @@ def _get_param_groups(
         param_group = {
             'params': params,
             'is_expert_parallel': is_expert_parallel,
+            # FlagScale Begin
             'is_engram_parallel': is_engram_parallel,  # FlagScale add is_engram_parallel
             'is_vision_model_param': False,  # FlagScale add is_vision_model_param
+            # FlagScale End
             'default_config': uses_default_lr_schedule,
             **default_config,
             **param_override,  # keep **param_override last so that users can override other fields.
@@ -765,9 +769,11 @@ def get_megatron_optimizer(
     intra_dp_cp_group_gloo = process_groups_dict['intra_dp_cp_group_gloo']
     intra_expt_dp_group_gloo = process_groups_dict['intra_expt_dp_group_gloo']
     intra_dist_opt_group = process_groups_dict['intra_dist_opt_group']
+    # FlagScale Begin
     engram_dp_group = process_groups_dict['engram_dp_group']
     engram_mp_group = process_groups_dict['engram_mp_group']
     engram_dp_group_gloo = process_groups_dict['engram_dp_group_gloo']
+    # FlagScale End
 
     model_parallel_rank = get_pg_rank(mp_group)
 
@@ -826,7 +832,7 @@ def get_megatron_optimizer(
             model_chunk_offset=model_chunk_offset,
             config=config,
             config_overrides=config_overrides,
-            filter_fn=lambda g: not g['is_expert_parallel'] and not g['is_engram_parallel'],
+            filter_fn=lambda g: not g['is_expert_parallel'] and not g['is_engram_parallel'],  # FlagScale Add
             buffer_name='buffers',
         )
         for model_chunk in dense_model_chunks:
@@ -863,7 +869,7 @@ def get_megatron_optimizer(
         model_chunk_offset=0,
         config=config,
         config_overrides=config_overrides,
-        filter_fn=lambda g: g['is_expert_parallel'] and not g['is_engram_parallel'],
+        filter_fn=lambda g: g['is_expert_parallel'] and not g['is_engram_parallel'],  # FlagScale Add
         buffer_name='expert_parallel_buffers',
     )
     if dump_param_to_param_group_map is not None:
@@ -895,6 +901,7 @@ def get_megatron_optimizer(
             )
         )
 
+    # FlagScale Begin
     # Engram parallel param groups and buffers
     engram_param_groups, engram_buffers = _get_param_groups_and_buffers(
         model_chunks,
@@ -936,6 +943,7 @@ def get_megatron_optimizer(
                 pg_collection=pg_collection,
             )
         )
+    # FlagScale End
 
     if dump_param_to_param_group_map is not None:
         torch.distributed.checkpoint.save(

--- a/megatron/core/optimizer/clip_grads.py
+++ b/megatron/core/optimizer/clip_grads.py
@@ -59,7 +59,7 @@ cur_platform = get_platform()
 ########## FlagScale End ##########
 
 
-@overridable
+@overridable  # FlagScale Add
 def get_grad_norm_fp32(
     grads_for_norm: Union[List[torch.Tensor], torch.Tensor],
     norm_type: Union[int, float] = 2,
@@ -200,7 +200,7 @@ def clip_grad_by_total_norm_fp32(
         )
 
 
-@overridable
+@overridable  # FlagScale Add
 def count_zeros_fp32(
     parameters: Union[List[torch.Tensor], torch.Tensor],
     grad_stats_parallel_group: torch.distributed.ProcessGroup,

--- a/megatron/core/optimizer/cpu_offloading/hybrid_optimizer.py
+++ b/megatron/core/optimizer/cpu_offloading/hybrid_optimizer.py
@@ -4,9 +4,11 @@ from typing import Dict
 
 import torch
 
+# FlagScale Begin
 from megatron.plugin.platform import get_platform
 
 cur_platform = get_platform()
+# FlagScale End
 
 
 def _param_generator(cpu_optimizer):
@@ -121,12 +123,14 @@ class HybridDeviceOptimizer(torch.optim.Optimizer):
     def _register_param_copy_back_gpu_hook(self):
         def param_copy_back_gpu_hook_closure():
             def param_copy_back_gpu_hook(optimizer, args, kwargs):
+                # FlagScale Begin
                 self._h2d_stream.wait_stream(cur_platform.current_stream())
                 with cur_platform.stream(self._h2d_stream):
+                # FlagScale End
                     for param in _param_generator(optimizer):
                         gpu_param = self.cpu_copys_map_gpu_param[param]
                         gpu_param.data.copy_(param.data, non_blocking=True)
-                self._h2d_stream.record_event().wait(cur_platform.current_stream())
+                self._h2d_stream.record_event().wait(cur_platform.current_stream())  # FlagScale Add
 
             return param_copy_back_gpu_hook
 
@@ -163,8 +167,10 @@ class HybridDeviceOptimizer(torch.optim.Optimizer):
         # the lr, wd, etc. are up-to-date.
         self._sync_hdo_param_groups_to_sub_optimizers()
 
+        # FlagScale Begin
         self._d2h_stream.wait_stream(cur_platform.current_stream())
         with cur_platform.stream(self._d2h_stream):
+        # FlagScale End
             self._set_sub_optimizer_grads()
 
         # Step the sub-optimizers.
@@ -218,11 +224,15 @@ class HybridDeviceOptimizer(torch.optim.Optimizer):
             self.gpu_optimizer = None
 
         self.cpu_copy_map_grad: Dict[torch.Tensor, torch.Tensor] = defaultdict(torch.Tensor)
+        # FlagScale Begin
         self._d2h_stream = cur_platform.current_stream()
         self._h2d_stream = cur_platform.current_stream()
+        # FlagScale End
         if self.overlap_cpu_optimizer_d2h_h2d:
+            # FlagScale Begin
             self._d2h_stream = cur_platform.Stream()
             self._h2d_stream = cur_platform.Stream()
+            # FlagScale End
         self._cpu_optimizer_map_data_event = dict()
 
         self._register_param_copy_back_gpu_hook()
@@ -274,11 +284,13 @@ class HybridDeviceOptimizer(torch.optim.Optimizer):
             for param in group["params"]:
                 orig_param = param
                 cpu_copy = False
+                # FlagScale Begin
                 if (
                     getattr(param, "is_offloading_candidate", False)
                     or offload_params_numel < offload_threshold
                 ) and param.is_cuda:
                     # If the param is a candidate for offloading and enven if we have not offloaded enough params, we offload it to CPU.
+                # FlagScale End
                     param = param.detach().clone().cpu().pin_memory()
                     offload_params_numel += param.numel()
                     cpu_copy = True
@@ -372,7 +384,7 @@ class HybridDeviceOptimizer(torch.optim.Optimizer):
                     if isinstance(optimizer, self.defaults["cpu_optimizer_cls"]):
                         self.state[orig_param][k] = state[k] = v.to("cpu")
                     else:
-                        self.state[orig_param][k] = state[k] = v.to(cur_platform.device_name())
+                        self.state[orig_param][k] = state[k] = v.to(cur_platform.device_name())  # FlagScale Add
 
     def _update_fp32_params_by_new_state(self):
         if not self.param_update_in_fp32:

--- a/megatron/core/optimizer/distrib_optimizer.py
+++ b/megatron/core/optimizer/distrib_optimizer.py
@@ -367,10 +367,12 @@ class DistributedOptimizer(MixedPrecisionOptimizer):
                 param_range = gbuf_range["param_map"][model_param]["param"]
 
                 # fp16, bf16 params.
+                # FlagScale Begin
                 if model_param.device.type == cur_platform.device_name() and model_param.dtype in (
                     torch.float16,
                     torch.bfloat16,
                 ):
+                # FlagScale End
 
                     # Generate sharded model param.
                     if (
@@ -431,10 +433,12 @@ class DistributedOptimizer(MixedPrecisionOptimizer):
                     shard_fp32_from_float16_params_this_group.append(shard_main_param)
 
                 # fp32 params.
+                # FlagScale Begin
                 elif (
                     model_param.device.type == cur_platform.device_name()
                     and model_param.dtype == torch.float32
                 ):
+                # FlagScale End
                     shard_model_param = model_param.view(-1)[param_range.start : param_range.end]
                     model_fp32_params_this_group.append(model_param)
                     shard_fp32_params_this_group.append(shard_model_param)
@@ -447,7 +451,7 @@ class DistributedOptimizer(MixedPrecisionOptimizer):
                 else:
                     raise TypeError(
                         'Wrapped parameters must be one of '
-                        'accelerator FloatTensor, HalfTensor, or BFloat16Tensor. '
+                        'accelerator FloatTensor, HalfTensor, or BFloat16Tensor. '  # FlagScale Add
                         'Received {}'.format(model_param.type())
                     )
 
@@ -594,10 +598,12 @@ class DistributedOptimizer(MixedPrecisionOptimizer):
             for param in param_group['params']:
                 if param.requires_grad:
                     # fp32 copy only needed for 16-bit parameters.
+                    # FlagScale Begin
                     if param.device.type == cur_platform.device_name() and param.dtype in (
                         torch.float16,
                         torch.bfloat16,
                     ):
+                    # FlagScale End
                         param.main_param = None
                         param.main_param_sharded = True
 
@@ -806,7 +812,7 @@ class DistributedOptimizer(MixedPrecisionOptimizer):
                             # Allocate dummy tensors.
                             numel = len(param_range_map["gbuf_world"])
                             init_shard = lambda dtype=torch.float32: torch.empty(
-                                (numel,), dtype=dtype, device=cur_platform.current_device()
+                                (numel,), dtype=dtype, device=cur_platform.current_device()  # FlagScale Add
                             )
 
                             # For precision_aware_optimizer, the empty tensors should also be
@@ -1104,7 +1110,7 @@ class DistributedOptimizer(MixedPrecisionOptimizer):
 
                             # Gather tensor list.
                             if data_parallel_rank == 0 or return_on_all_ranks:
-                                device = "cpu" if use_gloo_comm else cur_platform.current_device()
+                                device = "cpu" if use_gloo_comm else cur_platform.current_device()  # FlagScale Add
                                 recv_tensors = [
                                     torch.zeros(
                                         (gbuf_local_numel,), dtype=torch.float32, device=device

--- a/megatron/core/optimizer/grad_scaler.py
+++ b/megatron/core/optimizer/grad_scaler.py
@@ -7,18 +7,22 @@ from typing import Dict
 
 import torch
 
+# FlagScale Begin
 from megatron.plugin.platform import get_platform
 
 cur_platform = get_platform()
+# FlagScale End
 
 
 class MegatronGradScaler(ABC):
     def __init__(self, initial_scale: float):
         """Initialize scale value with the input initial scale."""
         assert initial_scale > 0.0
+        # FlagScale Begin
         self._scale = torch.tensor(
             [initial_scale], dtype=torch.float, device=cur_platform.device_name()
         )
+        # FlagScale End
 
     @property
     def scale(self):
@@ -91,19 +95,25 @@ class DynamicGradScaler(MegatronGradScaler):
         # Lower bound on the scale.
         assert min_scale > 0.0
         assert min_scale <= initial_scale
+        # FlagScale Begin
         self.min_scale = torch.tensor(
             [min_scale], dtype=torch.float, device=cur_platform.device_name()
         )
+        # FlagScale End
         # Growth and backoff factors for the scale.
         assert growth_factor > 1.0
+        # FlagScale Begin
         self.growth_factor = torch.tensor(
             [growth_factor], dtype=torch.float, device=cur_platform.device_name()
         )
+        # FlagScale End
         assert backoff_factor < 1.0
         assert backoff_factor > 0.0
+        # FlagScale Begin
         self.backoff_factor = torch.tensor(
             [backoff_factor], dtype=torch.float, device=cur_platform.device_name()
         )
+        # FlagScale End
         # Interval over which if we don't see any inf/nan,
         # we will scale the grad scale by the growth factor.
         assert growth_interval > 0
@@ -149,6 +159,6 @@ class DynamicGradScaler(MegatronGradScaler):
         return state_dict
 
     def load_state_dict(self, state_dict: Dict):
-        self._scale = state_dict['scale'].to(device=cur_platform.current_device())
+        self._scale = state_dict['scale'].to(device=cur_platform.current_device())  # FlagScale Add
         self._growth_tracker = state_dict['growth_tracker']
         self._hysteresis_tracker = state_dict['hysteresis_tracker']

--- a/megatron/core/optimizer/optimizer.py
+++ b/megatron/core/optimizer/optimizer.py
@@ -37,7 +37,7 @@ except ImportError:
         multi_tensor_applier = local_multi_tensor_applier
         multi_tensor_scale_impl = local_multi_tensor_scale
 
-from megatron.plugin.decorators import overridable
+from megatron.plugin.decorators import overridable  # FlagScale Add
 
 from .. import parallel_state, tensor_parallel
 from ..config_logger import has_config_logger_enabled, log_config_to_disk
@@ -56,9 +56,11 @@ from .optimizer_config import OptimizerConfig
 
 logger = getLogger(__name__)
 
+# FlagScale Begin
 from megatron.plugin.platform import get_platform
 
 cur_platform = get_platform()
+# FlagScale End
 
 
 def _zero_grad_group_helper(
@@ -100,6 +102,7 @@ def _multi_tensor_copy_this_to_that(
             that_.copy_(this_)
 
 
+# FlagScale Begin
 param_group_identifier_keys = (
     'wd_mult',
     'lr_mult',
@@ -108,6 +111,7 @@ param_group_identifier_keys = (
     'is_vision_model_param',
     'is_engram_parallel',
 )  ####FlagScale add is_vision_model_param
+# FlagScale End
 
 
 class MegatronOptimizer(ABC):
@@ -373,7 +377,7 @@ class MegatronOptimizer(ABC):
                     if isinstance(v, torch.Tensor) and v.is_cuda:
                         state_dict[k] = v.cpu()
 
-            cur_platform.empty_cache()
+            cur_platform.empty_cache()  # FlagScale Add
 
     def restore_from_cpu(self):
         """Function used for RL training.
@@ -386,12 +390,12 @@ class MegatronOptimizer(ABC):
             for param_group in self.optimizer.param_groups:
                 for p in param_group['params']:
                     if isinstance(p, torch.Tensor) and not p.is_cuda:
-                        p.data = p.data.to(cur_platform.device())
+                        p.data = p.data.to(cur_platform.device())  # FlagScale Add
 
             for state_dict in self.optimizer.state.values():
                 for k, v in state_dict.items():
                     if isinstance(v, torch.Tensor) and not v.is_cuda:
-                        state_dict[k] = v.to(cur_platform.device())
+                        state_dict[k] = v.to(cur_platform.device())  # FlagScale Add
 
     @staticmethod
     def _filter_and_reorder_param_groups(
@@ -484,9 +488,11 @@ class MixedPrecisionOptimizer(MegatronOptimizer):
         # Note that we keep this for the cases that grad scaler is none.
         # We still record nan/inf if we have a bfloat16 with a grad scaler.
         if self.grad_scaler:
+            # FlagScale Begin
             self.found_inf = torch.tensor(
                 [0.0], dtype=torch.float, device=cur_platform.device_name()
             )
+            # FlagScale End
 
         # Dummy tensor needed for apex multi-apply tensor.
         # For bfloat, we don't have multi-tensor apply and for now
@@ -494,15 +500,19 @@ class MixedPrecisionOptimizer(MegatronOptimizer):
         if self.config.bf16:
             self._dummy_overflow_buf = None
         else:
+            # FlagScale Begin
             self._dummy_overflow_buf = torch.tensor(
                 [0], dtype=torch.int, device=cur_platform.device_name()
             )
+            # FlagScale End
 
         # In case grad scaler is not passed, define the unity scale.
         if self.grad_scaler is None:
+            # FlagScale Begin
             self._scale_one = torch.tensor(
                 [1.0], dtype=torch.float, device=cur_platform.device_name()
             )
+            # FlagScale End
 
     def get_loss_scale(self):
         if self.grad_scaler is None:
@@ -513,7 +523,7 @@ class MixedPrecisionOptimizer(MegatronOptimizer):
         if self.param_groups:
             self._copy_model_params_to_main_params(state_dict=state_dict)
 
-    @overridable
+    @overridable  # FlagScale Add
     def _unscale_main_grads_and_check_for_nan(self):
 
         # Collect main grads.
@@ -689,11 +699,13 @@ class Float16OptimizerWithFloat16Params(MixedPrecisionOptimizer):
                     if param.requires_grad:
 
                         # float16 params:
+                        # FlagScale Begin
                         # cuda check -> platform check
                         if param.device.type == cur_platform.device_name() and param.dtype in (
                             torch.float16,
                             torch.bfloat16,
                         ):
+                        # FlagScale End
                             float16_params_this_group.append(param)
                             # Create a copy
                             main_param = param.detach().clone().float()
@@ -712,17 +724,19 @@ class Float16OptimizerWithFloat16Params(MixedPrecisionOptimizer):
                             if param in self.optimizer.state:
                                 self.optimizer.state[main_param] = self.optimizer.state.pop(param)
                         # fp32 params.
+                        # FlagScale Begin
                         elif (
                             param.device.type == cur_platform.device_name()
                             and param.dtype == torch.float32
                         ):
+                        # FlagScale End
                             fp32_params_this_group.append(param)
                             param_group['params'][i] = param
 
                         else:
                             raise TypeError(
                                 'Wrapped parameters must be one of '
-                                'accelerator FloatTensor, HalfTensor, or BFloat16Tensor. '
+                                'accelerator FloatTensor, HalfTensor, or BFloat16Tensor. '  # FlagScale Add
                                 'Received {}'.format(param.type())
                             )
 
@@ -930,7 +944,7 @@ class FP32Optimizer(MegatronOptimizer):
 
         super(FP32Optimizer, self).__init__(optimizer, config, init_state_fn)
 
-        self._scale = torch.tensor([1.0], dtype=torch.float, device=cur_platform.device_name())
+        self._scale = torch.tensor([1.0], dtype=torch.float, device=cur_platform.device_name())  # FlagScale Add
         self.is_stub_optimizer = True if optimizer is None else False
 
     def zero_grad(self, set_to_none=True):
@@ -1125,7 +1139,7 @@ class ChainedOptimizer(MegatronOptimizer):
             self.is_stub_optimizer = all(
                 getattr(optimizer, 'is_stub_optimizer', False) for optimizer in chained_optimizers
             )
-            self.convert_to_ep = False
+            self.convert_to_ep = False  # FlagScale Add
 
         else:
             self.is_stub_optimizer = True
@@ -1173,7 +1187,7 @@ class ChainedOptimizer(MegatronOptimizer):
         if self.chained_optimizers:
             return self.chained_optimizers[0].get_loss_scale()
         else:
-            return torch.tensor([1.0], dtype=torch.float32, device=cur_platform.current_device())
+            return torch.tensor([1.0], dtype=torch.float32, device=cur_platform.current_device())  # FlagScale Add
 
     def _split_state_dict(self, state_dict):
         """Split the state dict into sub-state dicts according to the chunks of each sub-optimizer
@@ -1217,11 +1231,13 @@ class ChainedOptimizer(MegatronOptimizer):
             return [optimizer.state_dict() for optimizer in self.chained_optimizers]
 
     def sharded_state_dict(
+        # FlagScale Begin
         self,
         model_sharded_state_dict: ShardedStateDict,
         is_loading: bool = False,
         convert_to_ep: bool = False,
         **kwargs,
+        # FlagScale End
     ):
         self.convert_to_ep = convert_to_ep  ########## FlagScale Add ########
         metadata = kwargs.get('metadata') or {}
@@ -1286,6 +1302,7 @@ class ChainedOptimizer(MegatronOptimizer):
                 self.mapping_idx = mapping_idx
                 return fake_sharded_state_dict
             ######### FlagScale End #########
+            # FlagScale Begin
             else:  # megatron source apply ep
                 self._synchronize_steps()
                 sharded_state_dict = {}
@@ -1297,8 +1314,9 @@ class ChainedOptimizer(MegatronOptimizer):
                         add_prefix_for_sharding(optim_state_dict, f'chained_{optimizer_idx}.')
                     sharded_state_dict[optimizer_idx] = optim_state_dict
                 return sharded_state_dict
+            # FlagScale End
 
-    @overridable
+    @overridable  # FlagScale Add
     def load_state_dict(self, state_dict):
         # If there is only one optimizer, we read the state dict as a single optimizer.
         if len(self.chained_optimizers) == 1:

--- a/megatron/core/optimizer_param_scheduler.py
+++ b/megatron/core/optimizer_param_scheduler.py
@@ -15,7 +15,7 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-from megatron.plugin.decorators import overridable
+from megatron.plugin.decorators import overridable  # FlagScale Add
 
 
 class ParamGroupOverride(TypedDict):
@@ -140,7 +140,7 @@ class OptimizerParamScheduler:
         override_opt_param_scheduler: Optional[bool] = False,
         wsd_decay_steps: Optional[int] = None,
         lr_wsd_decay_style: Optional[str] = None,
-        stablelm2_scheduler_config=None,
+        stablelm2_scheduler_config=None,  # FlagScale Add
     ) -> None:
 
         # Class values.
@@ -179,6 +179,7 @@ class OptimizerParamScheduler:
                 'both override and ' 'use-checkpoint are set.'
             )
 
+        # FlagScale Begin
         self.stablelm2_scheduler_config = stablelm2_scheduler_config
         if self.stablelm2_scheduler_config is not None:
             ## absolute samples
@@ -188,6 +189,7 @@ class OptimizerParamScheduler:
             ## N of consine
             if self.stablelm2_scheduler_config.cosine_period_samples == 0:
                 self.stablelm2_scheduler_config.cosine_period_samples = self.lr_decay_steps
+        # FlagScale End
 
         # Set the learning rate
         self.step(0)
@@ -227,7 +229,7 @@ class OptimizerParamScheduler:
 
         return start_wd + coeff * delta_wd
 
-    @overridable
+    @overridable  # FlagScale Add
     def get_lr(self, param_group: dict) -> float:
         """Learning rate decay functions from:
         https://openreview.net/pdf?id=BJYwwY9ll pg. 4

--- a/megatron/core/parallel_state.py
+++ b/megatron/core/parallel_state.py
@@ -13,7 +13,7 @@ import numpy as np
 import torch
 
 from megatron.core.inference.symmetric_memory import SymmetricMemoryManager
-from megatron.plugin.hetero.parallel_context import get_parallel_context
+from megatron.plugin.hetero.parallel_context import get_parallel_context  # FlagScale Add
 
 from .utils import GlobalMemoryBuffer, is_torch_min_version
 
@@ -224,7 +224,7 @@ def update_pg_timeout(
     """
     if hasattr(torch.distributed.distributed_c10d, "_set_pg_timeout"):
         torch.distributed.barrier(pg)
-        cur_platform.synchronize()
+        cur_platform.synchronize()  # FlagScale Add
         try:
             if pg is None:
                 global _global_process_group_list
@@ -584,7 +584,7 @@ def initialize_model_parallel(
     hierarchical_context_parallel_sizes: Optional[List[int]] = None,
     hybrid_context_parallel: bool = False,
     expert_model_parallel_size: int = 1,
-    engram_embedding_parallel_size: Optional[int] = None,
+    engram_embedding_parallel_size: Optional[int] = None,  # FlagScale Add
     num_distributed_optimizer_instances: int = 1,
     expert_tensor_parallel_size: Optional[int] = None,
     nccl_communicator_config_path: Optional[str] = None,
@@ -598,7 +598,7 @@ def initialize_model_parallel(
     create_all_gather_group: Optional[bool] = False,
     rank_offset: int = 0,
     local_world_size: Optional[int] = None,
-    create_dualpipev_parallel_size: bool = False,
+    create_dualpipev_parallel_size: bool = False,  # FlagScale Add
 ) -> None:
     """Initialize model data parallel groups.
 
@@ -991,9 +991,9 @@ def initialize_model_parallel(
         # Therefore, we need to perform a nccl call to ensure that the communicator group is created.
         torch.distributed.barrier(
             group=get_data_parallel_group(with_context_parallel=True),
-            device_ids=[cur_platform.current_device()],
+            device_ids=[cur_platform.current_device()],  # FlagScale Add
         )
-        cur_platform.synchronize()
+        cur_platform.synchronize()  # FlagScale Add
         # Set `NCCL_COLLNET_ENABLE=0` to restrict SHARP application to the dp group.
         if "NCCL_COLLNET_ENABLE" in os.environ:
             del os.environ["NCCL_COLLNET_ENABLE"]
@@ -1382,9 +1382,9 @@ def initialize_model_parallel(
                 if _INTER_PARTIAL_EXPERT_DATA_PARALLEL_GROUP is not None:
                     torch.distributed.barrier(
                         group=_INTER_PARTIAL_EXPERT_DATA_PARALLEL_GROUP,
-                        device_ids=[cur_platform.current_device()],
+                        device_ids=[cur_platform.current_device()],  # FlagScale Add
                     )
-                    cur_platform.synchronize()
+                    cur_platform.synchronize()  # FlagScale Add
                 # Set NCCL_COLLNET_ENABLE to 0 to restrict SHARP application to the dp_replica group.
                 if "NCCL_COLLNET_ENABLE" in os.environ:
                     del os.environ["NCCL_COLLNET_ENABLE"]
@@ -1486,18 +1486,22 @@ def initialize_model_parallel(
 
 def is_initialized():
     """Useful for code segments that may be accessed with or without mpu initialization"""
+    # FlagScale Begin
     para_ctx = get_parallel_context()
     if para_ctx is not None:
         return True
+    # FlagScale End
 
     return _DATA_PARALLEL_GROUP is not None
 
 
 def model_parallel_is_initialized():
     """Check if model- and data-parallel groups are initialized."""
+    # FlagScale Begin
     para_ctx = get_parallel_context()
     if para_ctx is not None:
         return True
+    # FlagScale End
 
     if (
         _TENSOR_MODEL_PARALLEL_GROUP is None
@@ -1510,9 +1514,11 @@ def model_parallel_is_initialized():
 
 def get_model_parallel_group(check_initialized=True):
     """Get the model-parallel group the caller rank belongs to."""
+    # FlagScale Begin
     para_ctx = get_parallel_context()
     if para_ctx is not None:
         return para_ctx.get_model_parallel_group(check_initialized=check_initialized)
+    # FlagScale End
 
     if check_initialized:
         assert _MODEL_PARALLEL_GROUP is not None, "model parallel group is not initialized"
@@ -1521,9 +1527,11 @@ def get_model_parallel_group(check_initialized=True):
 
 def get_tensor_model_parallel_group(check_initialized=True):
     """Get the tensor-model-parallel group the caller rank belongs to."""
+    # FlagScale Begin
     para_ctx = get_parallel_context()
     if para_ctx is not None:
         return para_ctx.get_tensor_model_parallel_group(check_initialized)
+    # FlagScale End
 
     if check_initialized:
         assert (
@@ -1534,9 +1542,11 @@ def get_tensor_model_parallel_group(check_initialized=True):
 
 def get_pipeline_model_parallel_group(check_initialized=True):
     """Get the pipeline-model-parallel group the caller rank belongs to."""
+    # FlagScale Begin
     para_ctx = get_parallel_context()
     if para_ctx is not None:
         return para_ctx.get_pipeline_model_parallel_group(check_initialized=check_initialized)
+    # FlagScale End
 
     if check_initialized:
         assert (
@@ -1549,9 +1559,11 @@ def get_data_parallel_group(
     with_context_parallel=False, partial_data_parallel=False, independent_all_gather=False
 ):
     """Get the data-parallel group the caller rank belongs to."""
+    # FlagScale Begin
     para_ctx = get_parallel_context()
     if para_ctx is not None:
         return para_ctx.get_data_parallel_group(with_context_parallel, partial_data_parallel)
+    # FlagScale End
 
     if with_context_parallel:
         if partial_data_parallel:
@@ -1585,9 +1597,11 @@ def has_separate_all_gather_group() -> bool:
 
 def get_data_parallel_group_gloo(with_context_parallel=False, partial_data_parallel=False):
     """Get the Gloo data-parallel group the caller rank belongs to."""
+    # FlagScale Begin
     para_ctx = get_parallel_context()
     if para_ctx is not None:
         return para_ctx.get_data_parallel_group_gloo(with_context_parallel, partial_data_parallel)
+    # FlagScale End
 
     if with_context_parallel:
         if partial_data_parallel:
@@ -1607,9 +1621,11 @@ def get_data_parallel_group_gloo(with_context_parallel=False, partial_data_paral
 
 def get_context_parallel_group(check_initialized=True):
     """Get the context-parallel group the caller rank belongs to."""
+    # FlagScale Begin
     para_ctx = get_parallel_context()
     if para_ctx is not None:
         return para_ctx.get_context_parallel_group(check_initialized)
+    # FlagScale End
 
     if check_initialized:
         assert _CONTEXT_PARALLEL_GROUP is not None, "context parallel group is not initialized"
@@ -1618,9 +1634,11 @@ def get_context_parallel_group(check_initialized=True):
 
 def get_context_parallel_global_ranks(check_initialized=True):
     """Get all global ranks of the context-parallel group that the caller rank belongs to."""
+    # FlagScale Begin
     para_ctx = get_parallel_context()
     if para_ctx is not None:
         return para_ctx.get_context_parallel_global_ranks(check_initialized)
+    # FlagScale End
 
     if check_initialized:
         assert (
@@ -1631,9 +1649,11 @@ def get_context_parallel_global_ranks(check_initialized=True):
 
 def get_hierarchical_context_parallel_groups(check_initialized=True):
     """Get the inner ring of context parallel group the caller rank belongs to."""
+    # FlagScale Begin
     para_ctx = get_parallel_context()
     if para_ctx is not None:
         return para_ctx.get_hierarchical_context_parallel_groups(check_initialized)
+    # FlagScale End
 
     if check_initialized:
         assert _HIERARCHICAL_CONTEXT_PARALLEL_GROUPS is not None
@@ -1644,11 +1664,13 @@ def get_hybrid_data_context_parallel_groups(check_initialized=True, group_size=N
     """Get the hybrid context parallel groups the caller rank belongs to."""
     # If the group size is the same as the entire DPxCP group, return the original group
     if get_data_parallel_world_size(with_context_parallel=True) == group_size:
+        # FlagScale Begin
         para_ctx = get_parallel_context()
         if para_ctx is not None:
             return para_ctx.get_data_parallel_group(
                 with_context_parallel=True, partial_data_parallel=False
             )
+        # FlagScale End
         if check_initialized:
             assert _DATA_PARALLEL_GROUP_WITH_CP is not None
         return _DATA_PARALLEL_GROUP_WITH_CP
@@ -1659,9 +1681,11 @@ def get_hybrid_data_context_parallel_groups(check_initialized=True, group_size=N
 
 def get_embedding_group(check_initialized=True):
     """Get the embedding group the caller rank belongs to."""
+    # FlagScale Begin
     para_ctx = get_parallel_context()
     if para_ctx is not None:
         return para_ctx.get_embedding_group(check_initialized=check_initialized)
+    # FlagScale End
 
     if check_initialized:
         assert _EMBEDDING_GROUP is not None, "embedding group is not initialized"
@@ -1670,9 +1694,11 @@ def get_embedding_group(check_initialized=True):
 
 def get_position_embedding_group(check_initialized=True):
     """Get the position embedding group the caller rank belongs to."""
+    # FlagScale Begin
     para_ctx = get_parallel_context()
     if para_ctx is not None:
         return para_ctx.get_position_embedding_group(check_initialized=check_initialized)
+    # FlagScale End
 
     if check_initialized:
         assert _POSITION_EMBEDDING_GROUP is not None, "position embedding group is not initialized"
@@ -1681,9 +1707,11 @@ def get_position_embedding_group(check_initialized=True):
 
 def get_amax_reduction_group(with_context_parallel=False, tp_only_amax_red=False):
     """Get the FP8 amax reduction group the caller rank belongs to."""
+    # FlagScale Begin
     para_ctx = get_parallel_context()
     if para_ctx is not None:
         return para_ctx.get_amax_reduction_group(with_context_parallel, tp_only_amax_red)
+    # FlagScale End
 
     if with_context_parallel:
         if not tp_only_amax_red:
@@ -1711,9 +1739,11 @@ def get_amax_reduction_group(with_context_parallel=False, tp_only_amax_red=False
 
 def get_tensor_and_data_parallel_group(check_initialized=True, with_context_parallel=False):
     """Get the tensor- and data-parallel group the caller rank belongs to."""
+    # FlagScale Begin
     para_ctx = get_parallel_context()
     if para_ctx is not None:
         return para_ctx.get_tensor_and_data_parallel_group(with_context_parallel)
+    # FlagScale End
 
     if with_context_parallel:
         if check_initialized:
@@ -1731,9 +1761,11 @@ def get_tensor_and_data_parallel_group(check_initialized=True, with_context_para
 
 def get_tensor_and_context_parallel_group(check_initialized=True):
     """Get the tensor- and context-parallel group the caller rank belongs to."""
+    # FlagScale Begin
     para_ctx = get_parallel_context()
     if para_ctx is not None:
         return para_ctx.get_tensor_and_context_parallel_group(check_initialized=check_initialized)
+    # FlagScale End
 
     if check_initialized:
         assert (
@@ -1744,9 +1776,11 @@ def get_tensor_and_context_parallel_group(check_initialized=True):
 
 def set_tensor_model_parallel_world_size(world_size):
     """Set the tensor-model-parallel size"""
+    # FlagScale Begin
     para_ctx = get_parallel_context()
     if para_ctx is not None:
         para_ctx.set_tensor_model_parallel_world_size(world_size)
+    # FlagScale End
 
     global _MPU_TENSOR_MODEL_PARALLEL_WORLD_SIZE
     _MPU_TENSOR_MODEL_PARALLEL_WORLD_SIZE = world_size
@@ -1754,9 +1788,11 @@ def set_tensor_model_parallel_world_size(world_size):
 
 def set_pipeline_model_parallel_world_size(world_size):
     """Set the pipeline-model-parallel size"""
+    # FlagScale Begin
     para_ctx = get_parallel_context()
     if para_ctx is not None:
         para_ctx.set_pipeline_model_parallel_world_size(world_size)
+    # FlagScale End
 
     global _MPU_PIPELINE_MODEL_PARALLEL_WORLD_SIZE
     _MPU_PIPELINE_MODEL_PARALLEL_WORLD_SIZE = world_size
@@ -1764,9 +1800,11 @@ def set_pipeline_model_parallel_world_size(world_size):
 
 def set_virtual_pipeline_model_parallel_world_size(world_size):
     """Set the pipeline-model-parallel size"""
+    # FlagScale Begin
     para_ctx = get_parallel_context()
     if para_ctx is not None:
         para_ctx.set_virtual_pipeline_model_parallel_world_size(world_size)
+    # FlagScale End
 
     global _VIRTUAL_PIPELINE_MODEL_PARALLEL_WORLD_SIZE
     _VIRTUAL_PIPELINE_MODEL_PARALLEL_WORLD_SIZE = world_size
@@ -1774,9 +1812,11 @@ def set_virtual_pipeline_model_parallel_world_size(world_size):
 
 def get_tensor_model_parallel_world_size():
     """Return world size for the tensor-model-parallel group."""
+    # FlagScale Begin
     para_ctx = get_parallel_context()
     if para_ctx is not None:
         return para_ctx.get_tensor_model_parallel_world_size()
+    # FlagScale End
 
     global _MPU_TENSOR_MODEL_PARALLEL_WORLD_SIZE
     if _MPU_TENSOR_MODEL_PARALLEL_WORLD_SIZE is not None:
@@ -1784,11 +1824,13 @@ def get_tensor_model_parallel_world_size():
     return get_tensor_model_parallel_group().size()
 
 
-def get_pipeline_model_parallel_world_size(group=None):
+def get_pipeline_model_parallel_world_size(group=None):  # FlagScale Add
     """Return world size for the pipeline-model-parallel group."""
+    # FlagScale Begin
     para_ctx = get_parallel_context()
     if para_ctx is not None:
         return para_ctx.get_pipeline_model_parallel_world_size(group)
+    # FlagScale End
 
     global _MPU_PIPELINE_MODEL_PARALLEL_WORLD_SIZE
     if _MPU_PIPELINE_MODEL_PARALLEL_WORLD_SIZE is not None:
@@ -1798,9 +1840,11 @@ def get_pipeline_model_parallel_world_size(group=None):
 
 def set_tensor_model_parallel_rank(rank):
     """Set tensor-model-parallel rank."""
+    # FlagScale Begin
     para_ctx = get_parallel_context()
     if para_ctx is not None:
         para_ctx.set_tensor_model_parallel_rank(rank)
+    # FlagScale End
 
     global _MPU_TENSOR_MODEL_PARALLEL_RANK
     _MPU_TENSOR_MODEL_PARALLEL_RANK = rank
@@ -1808,9 +1852,11 @@ def set_tensor_model_parallel_rank(rank):
 
 def set_pipeline_model_parallel_rank(rank):
     """Set pipeline-model-parallel rank."""
+    # FlagScale Begin
     para_ctx = get_parallel_context()
     if para_ctx is not None:
         para_ctx.set_pipeline_model_parallel_rank(rank)
+    # FlagScale End
 
     global _MPU_PIPELINE_MODEL_PARALLEL_RANK
     _MPU_PIPELINE_MODEL_PARALLEL_RANK = rank
@@ -1818,9 +1864,11 @@ def set_pipeline_model_parallel_rank(rank):
 
 def get_tensor_model_parallel_rank():
     """Return caller's rank for the tensor-model-parallel group."""
+    # FlagScale Begin
     para_ctx = get_parallel_context()
     if para_ctx is not None:
         return para_ctx.get_tensor_model_parallel_rank()
+    # FlagScale End
 
     global _MPU_TENSOR_MODEL_PARALLEL_RANK
     if _MPU_TENSOR_MODEL_PARALLEL_RANK is not None:
@@ -1828,11 +1876,13 @@ def get_tensor_model_parallel_rank():
     return get_tensor_model_parallel_group().rank()
 
 
-def get_pipeline_model_parallel_rank(group=None):
+def get_pipeline_model_parallel_rank(group=None):  # FlagScale Add
     """Return caller's rank for the pipeline-model-parallel group."""
+    # FlagScale Begin
     para_ctx = get_parallel_context()
     if para_ctx is not None:
         return para_ctx.get_pipeline_model_parallel_rank(group)
+    # FlagScale End
 
     global _MPU_PIPELINE_MODEL_PARALLEL_RANK
     if _MPU_PIPELINE_MODEL_PARALLEL_RANK is not None:
@@ -1840,11 +1890,13 @@ def get_pipeline_model_parallel_rank(group=None):
     return torch.distributed.get_rank(group=get_pipeline_model_parallel_group())
 
 
-def is_pipeline_first_stage(ignore_virtual=True, vp_stage=None, group=None):
+def is_pipeline_first_stage(ignore_virtual=True, vp_stage=None, group=None):  # FlagScale Add
     """Return True if in the first pipeline model-parallel stage, False otherwise."""
+    # FlagScale Begin
     para_ctx = get_parallel_context()
     if para_ctx is not None:
         return para_ctx.is_pipeline_first_stage(ignore_virtual, group)
+    # FlagScale End
 
     if not ignore_virtual and get_virtual_pipeline_model_parallel_world_size() is not None:
         assert vp_stage is not None, "vp_stage must be passed if virtual pipeline is enabled"
@@ -1854,11 +1906,13 @@ def is_pipeline_first_stage(ignore_virtual=True, vp_stage=None, group=None):
     return get_pipeline_model_parallel_rank() == 0
 
 
-def is_pipeline_last_stage(ignore_virtual=True, vp_stage=None, group=None):
+def is_pipeline_last_stage(ignore_virtual=True, vp_stage=None, group=None):  # FlagScale Add
     """Return True if in the last pipeline-model-parallel stage, False otherwise."""
+    # FlagScale Begin
     para_ctx = get_parallel_context()
     if para_ctx is not None:
         return para_ctx.is_pipeline_last_stage(ignore_virtual, group)
+    # FlagScale End
 
     if not ignore_virtual and get_virtual_pipeline_model_parallel_world_size() is not None:
         assert vp_stage is not None, "vp_stage must be passed if virtual pipeline is enabled"
@@ -1868,11 +1922,13 @@ def is_pipeline_last_stage(ignore_virtual=True, vp_stage=None, group=None):
     return get_pipeline_model_parallel_rank() == (get_pipeline_model_parallel_world_size() - 1)
 
 
-def is_rank_in_embedding_group(ignore_virtual=True, vp_stage=None, group=None):
+def is_rank_in_embedding_group(ignore_virtual=True, vp_stage=None, group=None):  # FlagScale Add
     """Return true if current rank is in embedding group, False otherwise."""
+    # FlagScale Begin
     para_ctx = get_parallel_context()
     if para_ctx is not None:
         return para_ctx.is_rank_in_embedding_group(ignore_virtual, group)
+    # FlagScale End
 
     rank = torch.distributed.get_rank()
     global _EMBEDDING_GLOBAL_RANKS
@@ -1890,11 +1946,13 @@ def is_rank_in_embedding_group(ignore_virtual=True, vp_stage=None, group=None):
     return False
 
 
-def is_rank_in_position_embedding_group(group=None):
+def is_rank_in_position_embedding_group(group=None):  # FlagScale Add
     """Return true if current rank is in position embedding group, False otherwise."""
+    # FlagScale Begin
     para_ctx = get_parallel_context()
     if para_ctx is not None:
         return para_ctx.is_rank_in_position_embedding_group(group)
+    # FlagScale End
 
     rank = torch.distributed.get_rank()
     global _POSITION_EMBEDDING_GLOBAL_RANKS
@@ -1903,9 +1961,11 @@ def is_rank_in_position_embedding_group(group=None):
 
 def get_virtual_pipeline_model_parallel_rank():
     """Return the virtual pipeline-parallel rank."""
+    # FlagScale Begin
     para_ctx = get_parallel_context()
     if para_ctx is not None:
         return para_ctx.get_virtual_pipeline_model_parallel_rank()
+    # FlagScale End
 
     global _VIRTUAL_PIPELINE_MODEL_PARALLEL_RANK
     return _VIRTUAL_PIPELINE_MODEL_PARALLEL_RANK
@@ -1913,9 +1973,11 @@ def get_virtual_pipeline_model_parallel_rank():
 
 def set_virtual_pipeline_model_parallel_rank(rank):
     """Set the virtual pipeline-parallel rank."""
+    # FlagScale Begin
     para_ctx = get_parallel_context()
     if para_ctx is not None:
         para_ctx.set_virtual_pipeline_model_parallel_rank(rank)
+    # FlagScale End
 
     warnings.warn(
         "set_virtual_pipeline_model_parallel_rank in global scope is deprecated. "
@@ -1928,9 +1990,11 @@ def set_virtual_pipeline_model_parallel_rank(rank):
 
 def get_virtual_pipeline_model_parallel_world_size():
     """Return the virtual pipeline-parallel world size."""
+    # FlagScale Begin
     para_ctx = get_parallel_context()
     if para_ctx is not None:
         return para_ctx.get_virtual_pipeline_model_parallel_world_size()
+    # FlagScale End
 
     global _VIRTUAL_PIPELINE_MODEL_PARALLEL_WORLD_SIZE
     return _VIRTUAL_PIPELINE_MODEL_PARALLEL_WORLD_SIZE
@@ -1962,9 +2026,11 @@ def get_last_rank_when_using_pipeline():
 def get_tensor_model_parallel_src_rank():
     """Calculate the global rank corresponding to the first local rank
     in the tensor model parallel group."""
+    # FlagScale Begin
     para_ctx = get_parallel_context()
     if para_ctx is not None:
         return para_ctx.get_tensor_model_parallel_src_rank()
+    # FlagScale End
 
     assert (
         _TENSOR_MODEL_PARALLEL_GLOBAL_RANKS is not None
@@ -1975,9 +2041,11 @@ def get_tensor_model_parallel_src_rank():
 def get_model_parallel_src_rank():
     """Calculate the global rank corresponding to the first local rank
     in the model parallel group."""
+    # FlagScale Begin
     para_ctx = get_parallel_context()
     if para_ctx is not None:
         return para_ctx.get_model_parallel_src_rank()
+    # FlagScale End
 
     assert _MODEL_PARALLEL_GLOBAL_RANKS is not None, "Model parallel group is not initialized"
     return _MODEL_PARALLEL_GLOBAL_RANKS[0]
@@ -1986,9 +2054,11 @@ def get_model_parallel_src_rank():
 def get_data_parallel_src_rank(with_context_parallel=False):
     """Calculate the global rank corresponding to the first local rank
     in the data parallel group."""
+    # FlagScale Begin
     para_ctx = get_parallel_context()
     if para_ctx is not None:
         return para_ctx.get_data_parallel_src_rank(with_context_parallel)
+    # FlagScale End
 
     if with_context_parallel:
         assert (
@@ -2000,32 +2070,38 @@ def get_data_parallel_src_rank(with_context_parallel=False):
         return _DATA_PARALLEL_GLOBAL_RANKS[0]
 
 
-def get_pipeline_model_parallel_first_rank(group=None):
+def get_pipeline_model_parallel_first_rank(group=None):  # FlagScale Add
     """Return the global rank of the first stage in the current rank's pipeline."""
+    # FlagScale Begin
     para_ctx = get_parallel_context()
     if para_ctx is not None:
         return para_ctx.get_pipeline_model_parallel_first_rank(group)
+    # FlagScale End
 
     assert _PIPELINE_GLOBAL_RANKS is not None, "Pipeline parallel group is not initialized"
     return _PIPELINE_GLOBAL_RANKS[0]
 
 
-def get_pipeline_model_parallel_last_rank(group=None):
+def get_pipeline_model_parallel_last_rank(group=None):  # FlagScale Add
     """Return the global rank of the last stage in the current rank's pipeline."""
+    # FlagScale Begin
     para_ctx = get_parallel_context()
     if para_ctx is not None:
         return para_ctx.get_pipeline_model_parallel_last_rank(group)
+    # FlagScale End
 
     assert _PIPELINE_GLOBAL_RANKS is not None, "Pipeline parallel group is not initialized"
     last_rank_local = get_pipeline_model_parallel_world_size() - 1
     return _PIPELINE_GLOBAL_RANKS[last_rank_local]
 
 
-def get_pipeline_model_parallel_next_rank(group=None):
+def get_pipeline_model_parallel_next_rank(group=None):  # FlagScale Add
     """Return the global rank that follows the caller in the pipeline."""
+    # FlagScale Begin
     para_ctx = get_parallel_context()
     if para_ctx is not None:
         return para_ctx.get_pipeline_model_parallel_next_rank(group)
+    # FlagScale End
 
     assert _PIPELINE_GLOBAL_RANKS is not None, "Pipeline parallel group is not initialized"
     rank_in_pipeline = get_pipeline_model_parallel_rank()
@@ -2033,11 +2109,13 @@ def get_pipeline_model_parallel_next_rank(group=None):
     return _PIPELINE_GLOBAL_RANKS[(rank_in_pipeline + 1) % world_size]
 
 
-def get_pipeline_model_parallel_prev_rank(group=None):
+def get_pipeline_model_parallel_prev_rank(group=None):  # FlagScale Add
     """Return the global rank that precedes the caller in the pipeline."""
+    # FlagScale Begin
     para_ctx = get_parallel_context()
     if para_ctx is not None:
         return para_ctx.get_pipeline_model_parallel_prev_rank(group)
+    # FlagScale End
 
     assert _PIPELINE_GLOBAL_RANKS is not None, "Pipeline parallel group is not initialized"
     rank_in_pipeline = get_pipeline_model_parallel_rank()
@@ -2047,12 +2125,14 @@ def get_pipeline_model_parallel_prev_rank(group=None):
 
 def get_data_parallel_world_size(with_context_parallel=False, partial_data_parallel=False):
     """Return world size for the data parallel group."""
+    # FlagScale Begin
     para_ctx = get_parallel_context()
     if para_ctx is not None:
         return para_ctx.get_data_parallel_world_size(
             with_context_parallel=with_context_parallel,
             partial_data_parallel=partial_data_parallel,
         )
+    # FlagScale End
 
     global _MPU_DATA_PARALLEL_WORLD_SIZE
     if _MPU_DATA_PARALLEL_WORLD_SIZE is not None:
@@ -2067,9 +2147,11 @@ def get_data_parallel_world_size(with_context_parallel=False, partial_data_paral
 
 def set_data_parallel_rank(rank):
     """Return world size for the data parallel group."""
+    # FlagScale Begin
     para_ctx = get_parallel_context()
     if para_ctx is not None:
         para_ctx.set_data_parallel_rank(rank)
+    # FlagScale End
 
     global _MPU_DATA_PARALLEL_RANK
     _MPU_DATA_PARALLEL_RANK = rank
@@ -2077,12 +2159,14 @@ def set_data_parallel_rank(rank):
 
 def get_data_parallel_rank(with_context_parallel=False, partial_data_parallel=False):
     """Return caller's rank in the data-parallel group."""
+    # FlagScale Begin
     para_ctx = get_parallel_context()
     if para_ctx is not None:
         return para_ctx.get_data_parallel_rank(
             with_context_parallel=with_context_parallel,
             partial_data_parallel=partial_data_parallel,
         )
+    # FlagScale End
 
     global _MPU_DATA_PARALLEL_RANK
     if _MPU_DATA_PARALLEL_RANK is not None:
@@ -2097,9 +2181,11 @@ def get_data_parallel_rank(with_context_parallel=False, partial_data_parallel=Fa
 
 def get_context_parallel_world_size():
     """Return world size for the context parallel group."""
+    # FlagScale Begin
     para_ctx = get_parallel_context()
     if para_ctx is not None:
         return para_ctx.get_context_parallel_world_size()
+    # FlagScale End
 
     if torch.distributed.is_available() and torch.distributed.is_initialized():
         return get_context_parallel_group().size()
@@ -2109,9 +2195,11 @@ def get_context_parallel_world_size():
 
 def get_context_parallel_rank():
     """Return caller's rank in the context-parallel group."""
+    # FlagScale Begin
     para_ctx = get_parallel_context()
     if para_ctx is not None:
         return para_ctx.get_context_parallel_rank()
+    # FlagScale End
 
     if torch.distributed.is_available() and torch.distributed.is_initialized():
         return get_context_parallel_group().rank()
@@ -2121,9 +2209,11 @@ def get_context_parallel_rank():
 
 def get_tensor_and_context_parallel_world_size():
     """Return world size for the tensor and context-parallel group."""
+    # FlagScale Begin
     para_ctx = get_parallel_context()
     if para_ctx is not None:
         return para_ctx.get_tensor_and_context_parallel_world_size()
+    # FlagScale End
 
     if torch.distributed.is_available() and torch.distributed.is_initialized():
         return get_tensor_and_context_parallel_group().size()
@@ -2133,9 +2223,11 @@ def get_tensor_and_context_parallel_world_size():
 
 def get_tensor_and_context_parallel_rank():
     """Return caller's rank in the joint tensor-model-parallel and context-parallel group."""
+    # FlagScale Begin
     para_ctx = get_parallel_context()
     if para_ctx is not None:
         return para_ctx.get_tensor_and_context_parallel_rank()
+    # FlagScale End
 
     if torch.distributed.is_available() and torch.distributed.is_initialized():
         return get_tensor_and_context_parallel_group().rank()
@@ -2146,9 +2238,11 @@ def get_tensor_and_context_parallel_rank():
 ### Expert-related parallel states functions
 def get_expert_model_parallel_group(check_initialized=True):
     """Get the expert-model-parallel group the caller rank belongs to."""
+    # FlagScale Begin
     para_ctx = get_parallel_context()
     if para_ctx is not None:
         return para_ctx.get_expert_model_parallel_group(check_initialized)
+    # FlagScale End
 
     if check_initialized:
         assert (
@@ -2168,9 +2262,11 @@ def get_expert_model_parallel_src_rank():
 
 def get_expert_model_parallel_world_size():
     """Return world size for the expert-model-parallel group."""
+    # FlagScale Begin
     para_ctx = get_parallel_context()
     if para_ctx is not None:
         return para_ctx.get_expert_model_parallel_world_size()
+    # FlagScale End
 
     if _MPU_EXPERT_MODEL_PARALLEL_WORLD_SIZE is not None:
         return _MPU_EXPERT_MODEL_PARALLEL_WORLD_SIZE
@@ -2182,9 +2278,11 @@ def get_expert_model_parallel_world_size():
 
 def set_expert_model_parallel_world_size(world_size):
     """Sets the expert-model-parallel world size."""
+    # FlagScale Begin
     para_ctx = get_parallel_context()
     if para_ctx is not None:
         para_ctx.set_expert_model_parallel_world_size(world_size)
+    # FlagScale End
 
     global _MPU_EXPERT_MODEL_PARALLEL_WORLD_SIZE
     _MPU_EXPERT_MODEL_PARALLEL_WORLD_SIZE = world_size
@@ -2192,9 +2290,11 @@ def set_expert_model_parallel_world_size(world_size):
 
 def get_expert_model_parallel_rank():
     """Return caller's rank in the expert-model-parallel group."""
+    # FlagScale Begin
     para_ctx = get_parallel_context()
     if para_ctx is not None:
         return para_ctx.get_expert_model_parallel_rank()
+    # FlagScale End
 
     if _MPU_EXPERT_MODEL_PARALLEL_RANK is not None:
         return _MPU_EXPERT_MODEL_PARALLEL_RANK
@@ -2206,9 +2306,11 @@ def get_expert_model_parallel_rank():
 
 def set_expert_model_parallel_rank(rank):
     """Set expert-model-parallel rank."""
+    # FlagScale Begin
     para_ctx = get_parallel_context()
     if para_ctx is not None:
         para_ctx.set_expert_model_parallel_rank(rank)
+    # FlagScale End
 
     global _MPU_EXPERT_MODEL_PARALLEL_RANK
     _MPU_EXPERT_MODEL_PARALLEL_RANK = rank
@@ -2216,9 +2318,11 @@ def set_expert_model_parallel_rank(rank):
 
 def get_expert_tensor_parallel_group(check_initialized=True):
     """Get the expert-tensor-parallel group the caller rank belongs to."""
+    # FlagScale Begin
     para_ctx = get_parallel_context()
     if para_ctx is not None:
         return para_ctx.get_expert_tensor_parallel_group(check_initialized)
+    # FlagScale End
 
     if check_initialized:
         assert (
@@ -2229,9 +2333,11 @@ def get_expert_tensor_parallel_group(check_initialized=True):
 
 def get_expert_tensor_parallel_world_size():
     """Return world size for the expert tensor parallel group."""
+    # FlagScale Begin
     para_ctx = get_parallel_context()
     if para_ctx is not None:
         return para_ctx.get_expert_tensor_parallel_world_size()
+    # FlagScale End
 
     global _MPU_EXPERT_TENSOR_PARALLEL_WORLD_SIZE
     if _MPU_EXPERT_TENSOR_PARALLEL_WORLD_SIZE is not None:
@@ -2245,9 +2351,11 @@ def get_expert_tensor_parallel_world_size():
 
 def set_expert_tensor_parallel_world_size(world_size):
     "Set expert tensor model parallel size"
+    # FlagScale Begin
     para_ctx = get_parallel_context()
     if para_ctx is not None:
         para_ctx.set_expert_tensor_parallel_world_size(world_size)
+    # FlagScale End
 
     global _MPU_EXPERT_TENSOR_PARALLEL_WORLD_SIZE
     _MPU_EXPERT_TENSOR_PARALLEL_WORLD_SIZE = world_size
@@ -2255,9 +2363,11 @@ def set_expert_tensor_parallel_world_size(world_size):
 
 def get_expert_tensor_parallel_rank():
     """Return my rank for the expert tensor parallel group."""
+    # FlagScale Begin
     para_ctx = get_parallel_context()
     if para_ctx is not None:
         return para_ctx.get_expert_tensor_parallel_rank()
+    # FlagScale End
 
     global _MPU_EXPERT_TENSOR_PARALLEL_RANK
     if _MPU_EXPERT_TENSOR_PARALLEL_RANK is not None:
@@ -2271,9 +2381,11 @@ def get_expert_tensor_parallel_rank():
 
 def set_expert_tensor_parallel_rank(rank):
     "Set expert tensor model parallel rank"
+    # FlagScale Begin
     para_ctx = get_parallel_context()
     if para_ctx is not None:
         para_ctx.set_expert_tensor_parallel_rank(rank)
+    # FlagScale End
 
     global _MPU_EXPERT_TENSOR_PARALLEL_RANK
     _MPU_EXPERT_TENSOR_PARALLEL_RANK = rank
@@ -2281,9 +2393,11 @@ def set_expert_tensor_parallel_rank(rank):
 
 def get_expert_tensor_and_model_parallel_group(check_initialized=True):
     """Get the expert-tensor and expert-model group the caller rank belongs to."""
+    # FlagScale Begin
     para_ctx = get_parallel_context()
     if para_ctx is not None:
         return para_ctx.get_expert_tensor_and_model_parallel_group(check_initialized)
+    # FlagScale End
 
     if check_initialized:
         assert (
@@ -2294,9 +2408,11 @@ def get_expert_tensor_and_model_parallel_group(check_initialized=True):
 
 def get_expert_tensor_and_model_parallel_world_size():
     """Return world size for the expert model parallel group times expert tensor parallel group."""
+    # FlagScale Begin
     para_ctx = get_parallel_context()
     if para_ctx is not None:
         return para_ctx.get_expert_tensor_and_model_parallel_world_size()
+    # FlagScale End
 
     if torch.distributed.is_available() and torch.distributed.is_initialized():
         world_size = get_expert_tensor_and_model_parallel_group().size()
@@ -2307,9 +2423,11 @@ def get_expert_tensor_and_model_parallel_world_size():
 
 def get_expert_tensor_and_model_parallel_rank():
     """Return caller's rank in the joint tensor- and expert-model-parallel group."""
+    # FlagScale Begin
     para_ctx = get_parallel_context()
     if para_ctx is not None:
         return para_ctx.get_expert_tensor_and_model_parallel_rank()
+    # FlagScale End
 
     if torch.distributed.is_available() and torch.distributed.is_initialized():
         return get_expert_tensor_and_model_parallel_group().rank()
@@ -2319,11 +2437,13 @@ def get_expert_tensor_and_model_parallel_rank():
 
 def get_expert_tensor_model_pipeline_parallel_group(check_initialized=True):
     """Get expert tensor-model-pipeline parallel group."""
+    # FlagScale Begin
     para_ctx = get_parallel_context()
     if para_ctx is not None:
         return para_ctx.get_expert_tensor_model_pipeline_parallel_group(
             check_initialized=check_initialized
         )
+    # FlagScale End
 
     if check_initialized:
         assert (
@@ -2334,9 +2454,11 @@ def get_expert_tensor_model_pipeline_parallel_group(check_initialized=True):
 
 def get_expert_data_parallel_group(check_initialized=True, partial_expert_data_parallel=False):
     """Get expert data parallel group."""
+    # FlagScale Begin
     para_ctx = get_parallel_context()
     if para_ctx is not None:
         return para_ctx.get_expert_data_parallel_group()
+    # FlagScale End
 
     if partial_expert_data_parallel:
         if check_initialized:
@@ -2354,9 +2476,11 @@ def get_expert_data_parallel_group(check_initialized=True, partial_expert_data_p
 
 def get_expert_data_parallel_group_gloo(partial_expert_data_parallel=False):
     """Get expert data parallel group-gloo."""
+    # FlagScale Begin
     para_ctx = get_parallel_context()
     if para_ctx is not None:
         return para_ctx.get_expert_data_parallel_group_gloo()
+    # FlagScale End
 
     if partial_expert_data_parallel:
         assert (
@@ -2372,9 +2496,11 @@ def get_expert_data_parallel_group_gloo(partial_expert_data_parallel=False):
 
 def get_expert_data_parallel_rank(partial_expert_data_parallel=False):
     """Return caller's rank in the expert data parallel group."""
+    # FlagScale Begin
     para_ctx = get_parallel_context()
     if para_ctx is not None:
         return para_ctx.get_expert_data_parallel_rank()
+    # FlagScale End
 
     if torch.distributed.is_available() and torch.distributed.is_initialized():
         return get_expert_data_parallel_group(
@@ -2386,9 +2512,11 @@ def get_expert_data_parallel_rank(partial_expert_data_parallel=False):
 
 def get_expert_data_parallel_world_size(partial_expert_data_parallel=False):
     """Return world size for the expert data parallel group."""
+    # FlagScale Begin
     para_ctx = get_parallel_context()
     if para_ctx is not None:
         return para_ctx.get_expert_data_parallel_world_size()
+    # FlagScale End
 
     if torch.distributed.is_available() and torch.distributed.is_initialized():
         return get_expert_data_parallel_group(
@@ -2400,9 +2528,11 @@ def get_expert_data_parallel_world_size(partial_expert_data_parallel=False):
 
 def get_intra_distributed_optimizer_instance_group(check_initialized=True):
     """Get the group of all GPUs in a distributed optimizer instance."""
+    # FlagScale Begin
     para_ctx = get_parallel_context()
     if para_ctx is not None:
         return para_ctx.get_intra_distributed_optimizer_instance_group()
+    # FlagScale End
 
     if check_initialized:
         assert (
@@ -2464,9 +2594,11 @@ def get_engram_data_parallel_group_gloo():
 
 def _set_global_memory_buffer():
     """Initialize global buffer."""
+    # FlagScale Begin
     para_ctx = get_parallel_context()
     if para_ctx is not None:
         para_ctx.set_global_memory_buffer()
+    # FlagScale End
 
     global _GLOBAL_MEMORY_BUFFER
     assert _GLOBAL_MEMORY_BUFFER is None, "global memory buffer is already initialized"
@@ -2475,9 +2607,11 @@ def _set_global_memory_buffer():
 
 def get_global_memory_buffer():
     """Return the global GlobalMemoryBuffer object"""
+    # FlagScale Begin
     para_ctx = get_parallel_context()
     if para_ctx is not None:
         return para_ctx.get_global_memory_buffer()
+    # FlagScale End
 
     assert _GLOBAL_MEMORY_BUFFER is not None, "global memory buffer is not initialized"
     return _GLOBAL_MEMORY_BUFFER
@@ -2485,9 +2619,11 @@ def get_global_memory_buffer():
 
 def destroy_global_memory_buffer():
     """Sets the global memory buffer to None"""
+    # FlagScale Begin
     para_ctx = get_parallel_context()
     if para_ctx is not None:
         para_ctx.destroy_global_memory_buffer()
+    # FlagScale End
 
     global _GLOBAL_MEMORY_BUFFER
     _GLOBAL_MEMORY_BUFFER = None

--- a/megatron/core/parallel_state.py
+++ b/megatron/core/parallel_state.py
@@ -1644,6 +1644,11 @@ def get_hybrid_data_context_parallel_groups(check_initialized=True, group_size=N
     """Get the hybrid context parallel groups the caller rank belongs to."""
     # If the group size is the same as the entire DPxCP group, return the original group
     if get_data_parallel_world_size(with_context_parallel=True) == group_size:
+        para_ctx = get_parallel_context()
+        if para_ctx is not None:
+            return para_ctx.get_data_parallel_group(
+                with_context_parallel=True, partial_data_parallel=False
+            )
         if check_initialized:
             assert _DATA_PARALLEL_GROUP_WITH_CP is not None
         return _DATA_PARALLEL_GROUP_WITH_CP
@@ -1678,7 +1683,7 @@ def get_amax_reduction_group(with_context_parallel=False, tp_only_amax_red=False
     """Get the FP8 amax reduction group the caller rank belongs to."""
     para_ctx = get_parallel_context()
     if para_ctx is not None:
-        return para_ctx.get_amax_reduction_group(with_context_parallel)
+        return para_ctx.get_amax_reduction_group(with_context_parallel, tp_only_amax_red)
 
     if with_context_parallel:
         if not tp_only_amax_red:
@@ -1761,7 +1766,7 @@ def set_virtual_pipeline_model_parallel_world_size(world_size):
     """Set the pipeline-model-parallel size"""
     para_ctx = get_parallel_context()
     if para_ctx is not None:
-        para_ctx = para_ctx.set_virtual_pipeline_model_parallel_world_size(world_size)
+        para_ctx.set_virtual_pipeline_model_parallel_world_size(world_size)
 
     global _VIRTUAL_PIPELINE_MODEL_PARALLEL_WORLD_SIZE
     _VIRTUAL_PIPELINE_MODEL_PARALLEL_WORLD_SIZE = world_size
@@ -1769,6 +1774,10 @@ def set_virtual_pipeline_model_parallel_world_size(world_size):
 
 def get_tensor_model_parallel_world_size():
     """Return world size for the tensor-model-parallel group."""
+    para_ctx = get_parallel_context()
+    if para_ctx is not None:
+        return para_ctx.get_tensor_model_parallel_world_size()
+
     global _MPU_TENSOR_MODEL_PARALLEL_WORLD_SIZE
     if _MPU_TENSOR_MODEL_PARALLEL_WORLD_SIZE is not None:
         return _MPU_TENSOR_MODEL_PARALLEL_WORLD_SIZE
@@ -2038,6 +2047,13 @@ def get_pipeline_model_parallel_prev_rank(group=None):
 
 def get_data_parallel_world_size(with_context_parallel=False, partial_data_parallel=False):
     """Return world size for the data parallel group."""
+    para_ctx = get_parallel_context()
+    if para_ctx is not None:
+        return para_ctx.get_data_parallel_world_size(
+            with_context_parallel=with_context_parallel,
+            partial_data_parallel=partial_data_parallel,
+        )
+
     global _MPU_DATA_PARALLEL_WORLD_SIZE
     if _MPU_DATA_PARALLEL_WORLD_SIZE is not None:
         return _MPU_DATA_PARALLEL_WORLD_SIZE
@@ -2051,12 +2067,23 @@ def get_data_parallel_world_size(with_context_parallel=False, partial_data_paral
 
 def set_data_parallel_rank(rank):
     """Return world size for the data parallel group."""
+    para_ctx = get_parallel_context()
+    if para_ctx is not None:
+        para_ctx.set_data_parallel_rank(rank)
+
     global _MPU_DATA_PARALLEL_RANK
     _MPU_DATA_PARALLEL_RANK = rank
 
 
 def get_data_parallel_rank(with_context_parallel=False, partial_data_parallel=False):
     """Return caller's rank in the data-parallel group."""
+    para_ctx = get_parallel_context()
+    if para_ctx is not None:
+        return para_ctx.get_data_parallel_rank(
+            with_context_parallel=with_context_parallel,
+            partial_data_parallel=partial_data_parallel,
+        )
+
     global _MPU_DATA_PARALLEL_RANK
     if _MPU_DATA_PARALLEL_RANK is not None:
         return _MPU_DATA_PARALLEL_RANK
@@ -2218,6 +2245,10 @@ def get_expert_tensor_parallel_world_size():
 
 def set_expert_tensor_parallel_world_size(world_size):
     "Set expert tensor model parallel size"
+    para_ctx = get_parallel_context()
+    if para_ctx is not None:
+        para_ctx.set_expert_tensor_parallel_world_size(world_size)
+
     global _MPU_EXPERT_TENSOR_PARALLEL_WORLD_SIZE
     _MPU_EXPERT_TENSOR_PARALLEL_WORLD_SIZE = world_size
 
@@ -2240,6 +2271,10 @@ def get_expert_tensor_parallel_rank():
 
 def set_expert_tensor_parallel_rank(rank):
     "Set expert tensor model parallel rank"
+    para_ctx = get_parallel_context()
+    if para_ctx is not None:
+        para_ctx.set_expert_tensor_parallel_rank(rank)
+
     global _MPU_EXPERT_TENSOR_PARALLEL_RANK
     _MPU_EXPERT_TENSOR_PARALLEL_RANK = rank
 

--- a/megatron/core/pipeline_parallel/bridge_communicator.py
+++ b/megatron/core/pipeline_parallel/bridge_communicator.py
@@ -401,7 +401,7 @@ class BridgeCommunicator:
             for src_rank, shape in zip(rank_info.recv_from_ranks, recv_forward_shapes):
                 tensor_to_recv = torch.empty(
                     shape,
-                    device=cur_platform.current_device(),
+                    device=cur_platform.current_device(),  # FlagScale Add
                     dtype=self.comm_dtype,
                     requires_grad=True,
                 )
@@ -437,7 +437,7 @@ class BridgeCommunicator:
         ):
             # Non-leader rank - participate in broadcast
             shape_tensor = torch.empty(
-                (self.tensor_ndim,), device=cur_platform.current_device(), dtype=torch.int64
+                (self.tensor_ndim,), device=cur_platform.current_device(), dtype=torch.int64  # FlagScale Add
             )
             dist.broadcast(
                 shape_tensor, src=self.dest_local_leader_rank, group=self.dest_grid_broadcast_pg
@@ -446,7 +446,7 @@ class BridgeCommunicator:
             received_shape = tuple(shape_tensor.tolist())
             received_tensor = torch.empty(
                 received_shape,
-                device=cur_platform.current_device(),
+                device=cur_platform.current_device(),  # FlagScale Add
                 dtype=self.comm_dtype,
                 requires_grad=True,
             )
@@ -532,7 +532,7 @@ class BridgeCommunicator:
             for dest_rank, grad_shape in zip(rank_info.send_to_ranks, recv_grad_shapes):
                 # The destination rank that we sent to will send us gradients back
                 grad_tensor = torch.empty(
-                    grad_shape, device=cur_platform.current_device(), dtype=self.comm_dtype
+                    grad_shape, device=cur_platform.current_device(), dtype=self.comm_dtype  # FlagScale Add
                 )
                 dist.recv(grad_tensor, src=dest_rank)
                 logging.debug(
@@ -550,7 +550,7 @@ class BridgeCommunicator:
             )
 
             shape_tensor = torch.tensor(
-                aggregated_gradient.shape, device=cur_platform.current_device(), dtype=torch.int64
+                aggregated_gradient.shape, device=cur_platform.current_device(), dtype=torch.int64  # FlagScale Add
             )
             dist.broadcast(shape_tensor, src=self.current_rank, group=self.src_grid_broadcast_pg)
 
@@ -566,7 +566,7 @@ class BridgeCommunicator:
             # Non-leader rank - participate in gather for gradients
             # Receive broadcasted tensor shape from leader rank
             shape_tensor = torch.empty(
-                (self.tensor_ndim,), device=cur_platform.current_device(), dtype=torch.int64
+                (self.tensor_ndim,), device=cur_platform.current_device(), dtype=torch.int64  # FlagScale Add
             )
             dist.broadcast(
                 shape_tensor, src=self.src_local_leader_rank, group=self.src_grid_broadcast_pg
@@ -578,7 +578,7 @@ class BridgeCommunicator:
             )
             received_shape = tuple(shape_tensor.tolist())
             received_gradient = torch.empty(
-                received_shape, device=cur_platform.current_device(), dtype=self.comm_dtype
+                received_shape, device=cur_platform.current_device(), dtype=self.comm_dtype  # FlagScale Add
             )
 
             dist.broadcast(
@@ -637,7 +637,7 @@ class BridgeCommunicator:
                 received_gradients_list = []
                 for i, recv_grad_shape in enumerate(recv_grad_shapes):
                     grad_tensor = torch.empty(
-                        recv_grad_shape, device=cur_platform.current_device(), dtype=self.comm_dtype
+                        recv_grad_shape, device=cur_platform.current_device(), dtype=self.comm_dtype  # FlagScale Add
                     )
                     received_gradients_list.append(grad_tensor)
 
@@ -674,9 +674,11 @@ class BridgeCommunicator:
                 # Broadcast tensor shape to all ranks in scatter_pg
                 tensor_shape_to_broadcast = aggregated_gradient.shape
                 shape_tensor = torch.tensor(
+                    # FlagScale Begin
                     tensor_shape_to_broadcast,
                     device=cur_platform.current_device(),
                     dtype=torch.int64,
+                    # FlagScale End
                 )
                 dist.broadcast(
                     shape_tensor, src=self.current_rank, group=self.src_grid_broadcast_pg
@@ -695,7 +697,7 @@ class BridgeCommunicator:
             # participate in both gather for gradients
             # Receive gradient from leader using broadcast
             shape_tensor = torch.empty(
-                (self.tensor_ndim,), device=cur_platform.current_device(), dtype=torch.int64
+                (self.tensor_ndim,), device=cur_platform.current_device(), dtype=torch.int64  # FlagScale Add
             )
             dist.broadcast(
                 shape_tensor, src=self.src_local_leader_rank, group=self.src_grid_broadcast_pg
@@ -704,7 +706,7 @@ class BridgeCommunicator:
             # Use the received shape to create tensor for broadcast
             received_shape = tuple(shape_tensor.tolist())
             received_gradient = torch.empty(
-                received_shape, device=cur_platform.current_device(), dtype=self.comm_dtype
+                received_shape, device=cur_platform.current_device(), dtype=self.comm_dtype  # FlagScale Add
             )
             dist.broadcast(
                 received_gradient, src=self.src_local_leader_rank, group=self.src_grid_broadcast_pg
@@ -759,7 +761,7 @@ class BridgeCommunicator:
                 for i, recv_forward_shape in enumerate(recv_forward_shapes):
                     activation_tensor = torch.empty(
                         recv_forward_shape,
-                        device=cur_platform.current_device(),
+                        device=cur_platform.current_device(),  # FlagScale Add
                         dtype=self.comm_dtype,
                         requires_grad=True,
                     )
@@ -801,7 +803,7 @@ class BridgeCommunicator:
                 # Broadcast tensor shape to all ranks in scatter_pg
                 tensor_shape_to_scatter = aggregated_activation.shape
                 shape_tensor = torch.tensor(
-                    tensor_shape_to_scatter, device=cur_platform.current_device(), dtype=torch.int64
+                    tensor_shape_to_scatter, device=cur_platform.current_device(), dtype=torch.int64  # FlagScale Add
                 )
                 dist.broadcast(
                     shape_tensor, src=self.current_rank, group=self.dest_grid_broadcast_pg
@@ -818,7 +820,7 @@ class BridgeCommunicator:
             and self.current_rank in self.dest_grid_broadcast_ranks
         ):
             shape_tensor = torch.empty(
-                (self.tensor_ndim,), device=cur_platform.current_device(), dtype=torch.int64
+                (self.tensor_ndim,), device=cur_platform.current_device(), dtype=torch.int64  # FlagScale Add
             )
             dist.broadcast(
                 shape_tensor, src=self.dest_local_leader_rank, group=self.dest_grid_broadcast_pg
@@ -828,7 +830,7 @@ class BridgeCommunicator:
             received_shape = tuple(shape_tensor.tolist())
             received_activation = torch.empty(
                 received_shape,
-                device=cur_platform.current_device(),
+                device=cur_platform.current_device(),  # FlagScale Add
                 dtype=self.comm_dtype,
                 requires_grad=True,
             )
@@ -886,7 +888,7 @@ class BridgeCommunicator:
             if tensor_to_send_next is not None:
                 send_shape = tensor_to_send_next.shape
                 send_shape_tensor = torch.tensor(
-                    send_shape, device=cur_platform.current_device(), dtype=torch.int64
+                    send_shape, device=cur_platform.current_device(), dtype=torch.int64  # FlagScale Add
                 )
                 # Add send operations for each destination
                 for dest_rank in rank_info.send_to_ranks:
@@ -900,7 +902,7 @@ class BridgeCommunicator:
             if recv_next:
                 for dest_rank in rank_info.send_to_ranks:
                     grad_shape_tensor = torch.empty(
-                        (self.tensor_ndim,), device=cur_platform.current_device(), dtype=torch.int64
+                        (self.tensor_ndim,), device=cur_platform.current_device(), dtype=torch.int64  # FlagScale Add
                     )
                     recv_grad_shape_tensors.append(grad_shape_tensor)
                     ops.append(
@@ -914,7 +916,7 @@ class BridgeCommunicator:
             if recv_prev:
                 for src_rank in rank_info.recv_from_ranks:
                     forward_shape_tensor = torch.empty(
-                        (self.tensor_ndim,), device=cur_platform.current_device(), dtype=torch.int64
+                        (self.tensor_ndim,), device=cur_platform.current_device(), dtype=torch.int64  # FlagScale Add
                     )
                     recv_forward_shape_tensors.append(forward_shape_tensor)
                     ops.append(
@@ -928,7 +930,7 @@ class BridgeCommunicator:
 
                 grad_shape = tensor_to_send_prev.shape
                 grad_shape_tensor = torch.tensor(
-                    grad_shape, device=cur_platform.current_device(), dtype=torch.int64
+                    grad_shape, device=cur_platform.current_device(), dtype=torch.int64  # FlagScale Add
                 )
 
                 for src_rank in rank_info.recv_from_ranks:

--- a/megatron/core/pipeline_parallel/fine_grained_activation_offload.py
+++ b/megatron/core/pipeline_parallel/fine_grained_activation_offload.py
@@ -11,9 +11,11 @@ DEBUG = False
 DEBUG_RANK = 0
 
 from megatron.core.transformer.cuda_graphs import is_graph_capturing
+# FlagScale Begin
 from megatron.plugin.platform import get_platform
 
 cur_platform = get_platform()
+# FlagScale End
 
 
 def debug_rank(message):
@@ -321,8 +323,10 @@ class GPUTensorPool:
         self._stats['current_in_use'] = 0
 
         # Trigger GPU cache cleanup
+        # FlagScale Begin
         if cur_platform.is_available():
             cur_platform.empty_cache()
+        # FlagScale End
 
         debug_rank("GPUTensorPool: Clear complete")
 
@@ -339,8 +343,10 @@ class OffloadTensorGroup:
     def __init__(self, name):
         self._name = name
         self._tensors = {}
+        # FlagScale Begin
         self._offload_event = cur_platform.Event()
         self._reload_event = cur_platform.Event()
+        # FlagScale End
         self.offload = True
         self.total_offload_bytes = 0
         self.total_tensor_count = 0
@@ -411,8 +417,10 @@ class PipelineOffloadManager:
         # Cache chunk handlers for each virtual pipeline stage
         self._stages = None
         # allocate streams and events for synchronization
+        # FlagScale Begin
         self._d2h_stream = cur_platform.Stream()
         self._h2d_stream = cur_platform.Stream()
+        # FlagScale End
         # Shared CPU tensor pool for all chunks to improve reuse efficiency
         self._cpu_tensor_pool = GPUTensorPool(device="cpu", pin_memory=True)
 
@@ -877,7 +885,7 @@ class ChunkOffloadHandler:
         debug_rank("------bulk_offload_group")
         group_to_offload = self._groups_to_offload[-1]
         torch.cuda.nvtx.range_push("activation offloading " + group_to_offload._name)
-        with cur_platform.stream(self.d2h_stream):
+        with cur_platform.stream(self.d2h_stream):  # FlagScale Add
             for tensor_tag, tensor_on_device in group_to_offload._tensors.items():
                 if self.tensor_need_offloading_checker(tensor_on_device):
                     state = self.offload(
@@ -904,7 +912,7 @@ class ChunkOffloadHandler:
         debug_rank("----bulk_reload_group")
         group_to_reload = self._groups_to_reload[-1]
         torch.cuda.nvtx.range_push("activation reloading " + group_to_reload._name)
-        with cur_platform.stream(self.h2d_stream):
+        with cur_platform.stream(self.h2d_stream):  # FlagScale Add
             # Wait for offload to complete before reloading
             if not is_graph_capturing():
                 group_to_reload.wait_offload_event(self.h2d_stream)
@@ -960,7 +968,7 @@ class ChunkOffloadHandler:
             self.bulk_offload_group()
             # Manually release tensors not auto-freed by torch GC
             if len(forced_released_tensors) > 0:
-                cur_stream = cur_platform.current_stream()
+                cur_stream = cur_platform.current_stream()  # FlagScale Add
                 for release_tensor in forced_released_tensors:
                     if self.tensor_need_offloading_checker(release_tensor):
                         # Ensure tensor is not in use before freeing
@@ -973,7 +981,7 @@ class ChunkOffloadHandler:
             return
         debug_rank("--on_group_commit_forward")
         # Wait for compute to finish before starting offload
-        self.d2h_stream.wait_stream(cur_platform.current_stream())
+        self.d2h_stream.wait_stream(cur_platform.current_stream())  # FlagScale Add
         self.bulk_offload(forced_released_tensors)
 
     def bulk_reload(self):
@@ -1011,7 +1019,7 @@ class ChunkOffloadHandler:
         if not is_graph_capturing() and len(self._reloading_group) > 0:
             for reloading_group in self._reloading_group:
                 if reloading_group._name == name:
-                    reloading_group.wait_reload_event(cur_platform.current_stream())
+                    reloading_group.wait_reload_event(cur_platform.current_stream())  # FlagScale Add
                     self._reloading_group.remove(reloading_group)
                     break
 
@@ -1046,7 +1054,7 @@ class ChunkOffloadHandler:
             return
         debug_rank(f"--on_group_start_backward {self}")
         # Wait for compute to finish before starting reload
-        self.h2d_stream.wait_stream(cur_platform.current_stream())
+        self.h2d_stream.wait_stream(cur_platform.current_stream())  # FlagScale Add
         self.bulk_reload()
 
 
@@ -1178,8 +1186,10 @@ def fine_grained_offloading_group_start(tensor, name=None):
 def fine_grained_offloading_forward_record(event: torch.cuda.Event) -> None:
     """Record the forward event for cuda graph capture."""
     d2h_stream = PipelineOffloadManager.get_instance().d2h_stream
+    # FlagScale Begin
     cur_platform.current_stream().record_event(event)
     cur_platform.current_stream().wait_stream(d2h_stream)
+    # FlagScale End
 
 
 class FineGrainedOffloadingBackwardRecordFunction(torch.autograd.Function):
@@ -1198,8 +1208,10 @@ class FineGrainedOffloadingBackwardRecordFunction(torch.autograd.Function):
     def backward(ctx, grad_output):
         """Record the backward event and wait for the h2d stream on cuda graph stream."""
         h2d_stream = PipelineOffloadManager.get_instance().h2d_stream
+        # FlagScale Begin
         cur_platform.current_stream().record_event(ctx.event)
         cur_platform.current_stream().wait_stream(h2d_stream)
+        # FlagScale End
         return grad_output, None
 
 
@@ -1256,8 +1268,10 @@ class FineGrainedActivationOffloadingInterface:
     def forward_record(event: torch.cuda.Event) -> None:
         """Record the forward event for cuda graph capture."""
         d2h_stream = PipelineOffloadManager.get_instance().d2h_stream
+        # FlagScale Begin
         cur_platform.current_stream().record_event(event)
         cur_platform.current_stream().wait_stream(d2h_stream)
+        # FlagScale End
 
     @staticmethod
     def reset():

--- a/megatron/core/pipeline_parallel/hybrid_cp_schedule.py
+++ b/megatron/core/pipeline_parallel/hybrid_cp_schedule.py
@@ -8,9 +8,11 @@ from typing import Callable, List, Optional, Tuple
 import torch
 
 from megatron.core import parallel_state
+# FlagScale Begin
 from megatron.plugin.platform import get_platform
 
 cur_platform = get_platform()
+# FlagScale End
 from megatron.core.rerun_state_machine import RerunDataIterator
 
 
@@ -521,7 +523,7 @@ def hybrid_context_parallel_forward_backward(
             )
 
     def _broadcast_num_samples_this_group(num_samples_this_group):
-        dev = cur_platform.current_device()
+        dev = cur_platform.current_device()  # FlagScale Add
         torch.distributed.barrier()
 
         n = 0 if num_samples_this_group is None else int(num_samples_this_group.numel())

--- a/megatron/core/pipeline_parallel/p2p_communication.py
+++ b/megatron/core/pipeline_parallel/p2p_communication.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 
 
-from functools import partial
+from functools import partial  # FlagScale Add
 from typing import List, Optional, Tuple, Union
 
 import torch
@@ -9,6 +9,7 @@ import torch.distributed as dist
 
 from megatron.core.model_parallel_config import ModelParallelConfig
 from megatron.core.pipeline_parallel.utils import is_pp_first_stage, is_pp_last_stage
+# FlagScale Begin
 from megatron.core.utils import get_pg_rank, get_pg_size, nvtx_decorator
 from megatron.plugin.hetero.p2p_communication import (
     recv_backward_hetero,
@@ -18,13 +19,16 @@ from megatron.plugin.hetero.p2p_communication import (
     send_forward_hetero,
     send_forward_recv_backward_hetero,
 )
+# FlagScale End
 
 # Types
 Shape = Union[List[int], torch.Size]
 
+# FlagScale Begin
 from megatron.plugin.platform import get_platform
 
 cur_platform = get_platform()
+# FlagScale End
 
 
 def _batched_p2p_ops(
@@ -161,6 +165,7 @@ class P2PCommunicator:
         # Basic attrs
         self.pp_group = pp_group
         self.config = config
+        # FlagScale Begin
         if not isinstance(self.pp_group, list):
             world_size = self.pp_group.size()
             curr_rank_in_pg = self.pp_group.rank()
@@ -175,6 +180,7 @@ class P2PCommunicator:
                 if config.virtual_pipeline_model_parallel_size is not None
                 else None
             )
+        # FlagScale End
 
     @property
     def is_pp_first_stage(self) -> bool:
@@ -189,12 +195,12 @@ class P2PCommunicator:
     @property
     def total_stages(self) -> int:
         """Return total number of pipeline stages."""
-        return get_pg_size(self.pp_group)
+        return get_pg_size(self.pp_group)  # FlagScale Add
 
     @property
     def current_stage(self) -> int:
         """Return current pipeline stage index (0-indexed)."""
-        return get_pg_rank(self.pp_group)
+        return get_pg_rank(self.pp_group)  # FlagScale Add
 
     def _communicate_shapes(self, tensor_send_next, tensor_send_prev, recv_prev, recv_next):
         """Communicate tensor shapes between stages. Used to communicate
@@ -221,19 +227,19 @@ class P2PCommunicator:
         send_next_shape_tensor = None
         if recv_prev:
             recv_prev_shape_tensor = torch.empty(
-                (3,), device=cur_platform.current_device(), dtype=torch.int64
+                (3,), device=cur_platform.current_device(), dtype=torch.int64  # FlagScale Add
             )
         if recv_next:
             recv_next_shape_tensor = torch.empty(
-                (3,), device=cur_platform.current_device(), dtype=torch.int64
+                (3,), device=cur_platform.current_device(), dtype=torch.int64  # FlagScale Add
             )
         if tensor_send_prev is not None:
             send_prev_shape_tensor = torch.tensor(
-                tensor_send_prev.size(), device=cur_platform.current_device(), dtype=torch.int64
+                tensor_send_prev.size(), device=cur_platform.current_device(), dtype=torch.int64  # FlagScale Add
             )
         if tensor_send_next is not None:
             send_next_shape_tensor = torch.tensor(
-                tensor_send_next.size(), device=cur_platform.current_device(), dtype=torch.int64
+                tensor_send_next.size(), device=cur_platform.current_device(), dtype=torch.int64  # FlagScale Add
             )
 
         if config.use_ring_exchange_p2p:
@@ -273,7 +279,7 @@ class P2PCommunicator:
 
             # To protect against race condition when using batch_isend_irecv().
             # should take this out once the bug with batch_isend_irecv is resolved.
-            cur_platform.synchronize()
+            cur_platform.synchronize()  # FlagScale Add
 
         recv_prev_shape = [0, 0, 0]
         if recv_prev_shape_tensor is not None:
@@ -345,7 +351,7 @@ class P2PCommunicator:
             return torch.empty(
                 recv_prev_shape,
                 requires_grad=True,
-                device=cur_platform.current_device(),
+                device=cur_platform.current_device(),  # FlagScale Add
                 dtype=config.pipeline_dtype,
             )
 
@@ -353,7 +359,7 @@ class P2PCommunicator:
             return torch.empty(
                 recv_next_shape,
                 requires_grad=True,
-                device=cur_platform.current_device(),
+                device=cur_platform.current_device(),  # FlagScale Add
                 dtype=config.pipeline_dtype,
             )
 
@@ -401,10 +407,12 @@ class P2PCommunicator:
             next_rank: int | None = dist.get_global_rank(pp_group, next_rank_pg)
             prev_rank: int | None = dist.get_global_rank(pp_group, prev_rank_pg)
         ######### FlagScale End #########
+        # FlagScale Begin
         else:
             pp_group = self.pp_group
             next_rank = self.next_rank
             prev_rank = self.prev_rank
+        # FlagScale End
 
         if config.use_ring_exchange_p2p or config.batch_p2p_comm:
             reqs = []
@@ -441,7 +449,7 @@ class P2PCommunicator:
         if config.batch_p2p_comm and config.batch_p2p_sync:
             # To protect against race condition when using batch_isend_irecv().
             # User should assert that we have a modern enough PyTorch to not need this
-            cur_platform.synchronize()
+            cur_platform.synchronize()  # FlagScale Add
 
         return tensor_recv_prev, tensor_recv_next, reqs
 
@@ -450,10 +458,12 @@ class P2PCommunicator:
         self, tensor_shapes, is_first_stage: bool
     ) -> Union[torch.Tensor, list[torch.Tensor]]:
         """Receive tensor from previous rank in pipeline (forward receive)."""
+        # FlagScale Begin
         if self.config.enable_hetero:
             return recv_forward_hetero(
                 tensor_shapes, is_first_stage, self.config, partial(self._communicate)
             )
+        # FlagScale End
         unwrap_tensor_shapes = False
         if is_single_shape(tensor_shapes):
             unwrap_tensor_shapes = True
@@ -485,10 +495,12 @@ class P2PCommunicator:
         self, tensor_shapes, is_last_stage: bool
     ) -> Union[torch.Tensor, list[torch.Tensor]]:
         """Receive tensor from next rank in pipeline (backward receive)."""
+        # FlagScale Begin
         if self.config.enable_hetero:
             return recv_backward_hetero(
                 tensor_shapes, is_last_stage, self.config, partial(self._communicate)
             )
+        # FlagScale End
         unwrap_tensor_shapes = False
         if is_single_shape(tensor_shapes):
             unwrap_tensor_shapes = True
@@ -518,10 +530,12 @@ class P2PCommunicator:
     @nvtx_decorator()
     def send_forward(self, output_tensors, is_last_stage: bool) -> None:
         """Send tensor to next rank in pipeline (forward send)."""
+        # FlagScale Begin
         if self.config.enable_hetero:
             return send_forward_hetero(
                 output_tensors, is_last_stage, self.config, partial(self._communicate)
             )
+        # FlagScale End
         config = self.config
         if not isinstance(output_tensors, list):
             output_tensors = [output_tensors]
@@ -543,10 +557,12 @@ class P2PCommunicator:
     @nvtx_decorator()
     def send_backward(self, input_tensor_grads, is_first_stage: bool) -> None:
         """Send tensor to previous rank in pipeline (backward send)."""
+        # FlagScale Begin
         if self.config.enable_hetero:
             return send_backward_hetero(
                 input_tensor_grads, is_first_stage, self.config, partial(self._communicate)
             )
+        # FlagScale End
         if not isinstance(input_tensor_grads, list):
             input_tensor_grads = [input_tensor_grads]
         config = self.config
@@ -569,6 +585,7 @@ class P2PCommunicator:
         self, output_tensors, tensor_shapes, is_last_stage: bool
     ) -> Union[torch.Tensor, list[torch.Tensor]]:
         """Batched send and recv with next rank in pipeline."""
+        # FlagScale Begin
         if self.config.enable_hetero:
             return send_forward_recv_backward_hetero(
                 output_tensors,
@@ -577,6 +594,7 @@ class P2PCommunicator:
                 self.config,
                 partial(self._communicate),
             )
+        # FlagScale End
         config = self.config
         unwrap_output_tensors = False
         if not isinstance(output_tensors, list):
@@ -610,6 +628,7 @@ class P2PCommunicator:
         self, input_tensor_grads, tensor_shapes, is_first_stage: bool
     ) -> Union[torch.Tensor, list[torch.Tensor]]:
         """Batched send and recv with previous rank in pipeline."""
+        # FlagScale Begin
         if self.config.enable_hetero:
             return send_backward_recv_forward_hetero(
                 input_tensor_grads,
@@ -618,6 +637,7 @@ class P2PCommunicator:
                 self.config,
                 partial(self._communicate),
             )
+        # FlagScale End
         config = self.config
         unwrap_input_tensor_grads = False
         if not isinstance(input_tensor_grads, list):

--- a/megatron/core/pipeline_parallel/schedules.py
+++ b/megatron/core/pipeline_parallel/schedules.py
@@ -159,7 +159,7 @@ def get_forward_backward_func(pp_size: Optional[int] = None, vp_size: Optional[i
 
             forward_backward_func = forward_backward_pipelining_with_dualpipev
         ######### FlagScale End #########
-        elif vp_size is not None:
+        elif vp_size is not None:  # FlagScale Add
             forward_backward_func = forward_backward_pipelining_with_interleaving
         else:
             forward_backward_func = forward_backward_pipelining_without_interleaving
@@ -266,7 +266,7 @@ def forward_step_calc_loss(
         if is_last_stage:
             assert cp_group_size is not None, "cp_group_size must be provided on last stage"
 
-    num_tokens = torch.tensor(0, dtype=torch.int, device=cur_platform.device_name())
+    num_tokens = torch.tensor(0, dtype=torch.int, device=cur_platform.device_name())  # FlagScale Add
     if is_last_stage:
         if loss_func is None:
             forward_data_store.append(output_tensor)
@@ -657,7 +657,7 @@ def forward_backward_no_pipelining(
 
     forward_data_store = []
     input_tensor, output_tensor_grad = None, None
-    total_num_tokens = torch.zeros([], dtype=torch.int, device=cur_platform.device_name())
+    total_num_tokens = torch.zeros([], dtype=torch.int, device=cur_platform.device_name())  # FlagScale Add
 
     if config.overlap_moe_expert_parallel_comm and not forward_only:
         forward_data_store, total_num_tokens = combined_1f1b_schedule_for_no_pipelining(
@@ -1025,7 +1025,7 @@ def forward_backward_pipelining_with_interleaving(
 
     input_tensors = [[] for _ in range(len(model))]
     output_tensors = [[] for _ in range(len(model))]
-    total_num_tokens = torch.zeros([], dtype=torch.int, device=cur_platform.device_name())
+    total_num_tokens = torch.zeros([], dtype=torch.int, device=cur_platform.device_name())  # FlagScale Add
 
     forward_data_store = []
     output_tensor_grads = None
@@ -2199,7 +2199,7 @@ def forward_backward_pipelining_without_interleaving(
     # Input, output tensors only need to be saved when doing backward passes
     input_tensors = None
     output_tensors = None
-    total_num_tokens = torch.zeros([], dtype=torch.int, device=cur_platform.device_name())
+    total_num_tokens = torch.zeros([], dtype=torch.int, device=cur_platform.device_name())  # FlagScale Add
 
     if not forward_only:
         input_tensors = []

--- a/megatron/core/pipeline_parallel/utils.py
+++ b/megatron/core/pipeline_parallel/utils.py
@@ -150,8 +150,10 @@ class ScheduleNode:
     def __init__(
         self,
         forward_func: Callable,
+        # FlagScale Begin
         stream: cur_platform.Stream,
         event: cur_platform.Event,
+        # FlagScale End
         backward_func: Optional[Callable] = None,
         free_input: bool = False,
         name: str = "schedule_node",
@@ -297,13 +299,13 @@ class ScheduleNode:
         """
         self.event.wait(self.stream)
         if name:
-            cur_platform.range_push(name)
+            cur_platform.range_push(name)  # FlagScale Add
         try:
-            with cur_platform.stream(self.stream):
+            with cur_platform.stream(self.stream):  # FlagScale Add
                 yield
         finally:
             if name:
-                cur_platform.range_pop()
+                cur_platform.range_pop()  # FlagScale Add
             self.event.record(self.stream)
 
     def _release_state(self):
@@ -347,13 +349,13 @@ def set_streams(comm_stream=None):
     # Set communication stream
     if _COMM_STREAM is None:
         if comm_stream is None:
-            comm_stream = cur_platform.Stream(device=cur_platform.device_name())
+            comm_stream = cur_platform.Stream(device=cur_platform.device_name())  # FlagScale Add
         _COMM_STREAM = comm_stream
 
 
 def get_comp_stream():
     """Get the stream for computation"""
-    return cur_platform.current_stream()
+    return cur_platform.current_stream()  # FlagScale Add
 
 
 def get_comm_stream():

--- a/megatron/core/process_groups_config.py
+++ b/megatron/core/process_groups_config.py
@@ -2,7 +2,7 @@
 
 """Dataclasses for organizing model parallelism and gradient communication process groups."""
 
-import logging
+import logging  # FlagScale Add
 from dataclasses import dataclass, field, fields
 from functools import partial
 from typing import Dict, List, Optional
@@ -10,9 +10,11 @@ from typing import Dict, List, Optional
 import torch
 
 from megatron.core import parallel_state
+# FlagScale Begin
 from megatron.core.utils import log_single_rank
 
 logger = logging.getLogger(__name__)
+# FlagScale End
 
 
 class ProcessGroupHelperMeta(type):
@@ -137,6 +139,7 @@ class ProcessGroupCollection:
     # _INTRA_DISTRIBUTED_OPTIMIZER_INSTANCE_GROUP
     intra_dist_opt: torch.distributed.ProcessGroup = field(init=False)
 
+    # FlagScale Begin
     # _ENGRAM_DATA_PARALLEL_GROUP
     engram_dp: torch.distributed.ProcessGroup = field(init=False)
 
@@ -145,6 +148,7 @@ class ProcessGroupCollection:
 
     # _ENGRAM_MODEL_PARALLEL_GROUP
     engram_mp: torch.distributed.ProcessGroup = field(init=False)
+    # FlagScale End
 
     def __init__(self, **kwargs):
         for key in kwargs:
@@ -250,10 +254,12 @@ class ProcessGroupCollection:
                 check_initialized=False,
                 with_context_parallel=True,
             ),
+            # FlagScale Begin
             # TODO: check_initialize
             'engram_dp': parallel_state.get_engram_data_parallel_group,
             'engram_embed': parallel_state.get_engram_embedding_parallel_group,
             'engram_mp': parallel_state.get_engram_model_parallel_group,
+            # FlagScale End
         }
 
         assert all(
@@ -315,7 +321,7 @@ class ProcessGroupCollection:
             )
             intra_dist_opt_group = parallel_state.get_intra_distributed_optimizer_instance_group()
 
-            engram_dp_group = parallel_state.get_engram_data_parallel_group()
+            engram_dp_group = parallel_state.get_engram_data_parallel_group()  # FlagScale Add
 
             # Gloo groups
             if use_gloo_process_groups:
@@ -325,17 +331,19 @@ class ProcessGroupCollection:
                 intra_expt_dp_group_gloo = parallel_state.get_expert_data_parallel_group_gloo(
                     partial_expert_data_parallel=True
                 )
-                engram_dp_group_gloo = parallel_state.get_engram_data_parallel_group_gloo()
+                engram_dp_group_gloo = parallel_state.get_engram_data_parallel_group_gloo()  # FlagScale Add
             else:
                 intra_dp_cp_group_gloo = None
                 intra_expt_dp_group_gloo = None
-                engram_dp_group_gloo = None
+                engram_dp_group_gloo = None  # FlagScale Add
 
             # Model communication groups
             mp_group = parallel_state.get_model_parallel_group()
             expt_tp_pp_group = parallel_state.get_expert_tensor_model_pipeline_parallel_group()
+            # FlagScale Begin
             engram_embed_group = parallel_state.get_engram_embedding_parallel_group()
             engram_mp_group = parallel_state.get_engram_model_parallel_group()
+            # FlagScale End
 
             # Inter distributed optimizer group
             if hasattr(model_chunks[0], 'ddp_config'):
@@ -448,6 +456,7 @@ class ProcessGroupCollection:
                 )
             intra_dp_cp_group_gloo = None
             intra_expt_dp_group_gloo = None
+            # FlagScale Begin
             # Engram data parallel group and embedding_parallel_group
             if not hasattr(pg_collection, "engram_dp"):
                 pg_collection.engram_dp = None
@@ -474,6 +483,7 @@ class ProcessGroupCollection:
                 )
             engram_mp_group = pg_collection.engram_mp
             engram_dp_group_gloo = None
+            # FlagScale End
 
         return {
             'dp_group': dp_group,
@@ -487,10 +497,12 @@ class ProcessGroupCollection:
             'intra_dist_opt_group': intra_dist_opt_group,
             'intra_dp_cp_group_gloo': intra_dp_cp_group_gloo,
             'intra_expt_dp_group_gloo': intra_expt_dp_group_gloo,
+            # FlagScale Begin
             'engram_dp_group': engram_dp_group,
             'engram_embed_group': engram_embed_group,
             'engram_dp_group_gloo': engram_dp_group_gloo,
             'engram_mp_group': engram_mp_group,
+            # FlagScale End
         }
 
     @staticmethod
@@ -546,9 +558,11 @@ class ProcessGroupCollection:
                     if ddp_config.use_distributed_optimizer
                     else None
                 ),
+                # FlagScale Begin
                 'engram_dp_group': parallel_state.get_engram_data_parallel_group(),
                 'engram_embed_group': parallel_state.get_engram_embedding_parallel_group(),
                 'engram_mp_group': parallel_state.get_engram_model_parallel_group(),
+                # FlagScale End
             }
         else:
             # Use provided process group collection with validation and fallbacks
@@ -623,6 +637,7 @@ class ProcessGroupCollection:
             result['tp_group'] = pg_collection.tp
             result['pp_group'] = pg_collection.pp
             result['ep_group'] = pg_collection.ep
+            # FlagScale Begin
             # 6. Engram data parallel group and embedding_parallel_group
             if not hasattr(pg_collection, "engram_dp"):
                 pg_collection.engram_dp = None
@@ -648,6 +663,7 @@ class ProcessGroupCollection:
             result['engram_dp_group'] = pg_collection.engram_dp
             result['engram_embed_group'] = pg_collection.engram_embed
             result['engram_mp_group'] = pg_collection.engram_mp
+            # FlagScale End
             return result
 
 

--- a/megatron/core/rerun_state_machine.py
+++ b/megatron/core/rerun_state_machine.py
@@ -531,7 +531,7 @@ class RerunStateMachine:
                 )
                 rank: int = safe_get_rank()
                 node: str = os.uname()[1]
-                device: int = cur_platform.current_device()
+                device: int = cur_platform.current_device()  # FlagScale Add
                 full_message: str = (
                     f"Rank {rank}, node {node}, device {device}, "
                     f"iteration {self.current_iteration + 1}: "
@@ -573,7 +573,7 @@ class RerunStateMachine:
         def log_failure(message: str, fatal: bool = True) -> None:
             rank: int = safe_get_rank()
             node: str = os.uname()[1]
-            device: int = cur_platform.current_device()
+            device: int = cur_platform.current_device()  # FlagScale Add
             if fatal:
                 logger.error(
                     f"Rank {rank}, node {node}, device {device}, "
@@ -650,7 +650,7 @@ class RerunStateMachine:
                     # Remember the node and device we're running on so that we can check we're not
                     # rerunning on the same GPU when we resume from the checkpoint.
                     self.suspicious_node = os.uname()[1]
-                    self.suspicious_device = cur_platform.current_device()
+                    self.suspicious_device = cur_platform.current_device()  # FlagScale Add
                     self._log_validation_error_to_file(
                         status=RerunValidationStatus.FIRST_RERUN_REPRODUCIBLE,
                         result=result,
@@ -666,7 +666,7 @@ class RerunStateMachine:
             elif self.state == RerunState.RERUNNING_FROM_CHECKPOINT:
                 # Ensure we're not on the same GPU as the first rerun.
                 node = os.uname()[1]
-                device = cur_platform.current_device()
+                device = cur_platform.current_device()  # FlagScale Add
                 if node == self.suspicious_node and device == self.suspicious_device:
                     logger.error(
                         f"Got rescheduled on the same GPU. Need to resume again from the same "
@@ -963,7 +963,7 @@ class RerunStateMachine:
                 "random_rng_state": random.getstate(),
                 "np_rng_state": np.random.get_state(),
                 "torch_rng_state": torch.get_rng_state(),
-                "cuda_rng_state": cur_platform.get_rng_state(),
+                "cuda_rng_state": cur_platform.get_rng_state(),  # FlagScale Add
             },
             "other_state": self.state_save_func() if self.state_save_func else None,
             # any other state to save to guarantee deterministic execution?
@@ -976,7 +976,7 @@ class RerunStateMachine:
         random.setstate(rng_state["random_rng_state"])
         np.random.set_state(rng_state["np_rng_state"])
         torch.set_rng_state(rng_state["torch_rng_state"])
-        cur_platform.set_rng_state(rng_state["cuda_rng_state"])
+        cur_platform.set_rng_state(rng_state["cuda_rng_state"])  # FlagScale Add
         if self.saved_state["other_state"] and self.state_restore_func:
             self.state_restore_func(self.saved_state["other_state"])
 
@@ -1015,7 +1015,7 @@ class RerunStateMachine:
             try:
                 rank: int = safe_get_rank()
                 node: str = os.uname()[1]
-                device: int = cur_platform.current_device()
+                device: int = cur_platform.current_device()  # FlagScale Add
                 with open(self.result_rejected_tracker_filename, "a") as f:
                     f.write(
                         f"ts={datetime.datetime.now()} node={node} device={device} "

--- a/megatron/core/tensor_parallel/data.py
+++ b/megatron/core/tensor_parallel/data.py
@@ -1,6 +1,6 @@
 # Copyright (c) 2022, NVIDIA CORPORATION. All rights reserved.
 
-from gettext import ngettext
+from gettext import ngettext  # FlagScale Add
 
 import torch
 
@@ -8,9 +8,11 @@ from megatron.core.utils import get_tensor_model_parallel_group_if_none
 
 _MAX_DATA_DIM = 5
 
+# FlagScale Begin
 from megatron.plugin.platform import get_platform
 
 cur_platform = get_platform()
+# FlagScale End
 
 
 def _check_data_types(keys, data, target_dtype):
@@ -40,7 +42,7 @@ def _build_key_size_numel_dictionaries(keys, data, tp_group=None):
             offset += max_dim
 
     # Move to GPU and broadcast.
-    sizes_cuda = torch.tensor(sizes, dtype=torch.long, device=cur_platform.device_name())
+    sizes_cuda = torch.tensor(sizes, dtype=torch.long, device=cur_platform.device_name())  # FlagScale Add
     group_ranks = torch.distributed.get_process_group_ranks(group=tp_group)
     torch.distributed.broadcast(sizes_cuda, group_ranks[0], group=tp_group)
 
@@ -87,14 +89,18 @@ def broadcast_data(keys, data, datatype, tp_group=None):
         # Check that all keys have the same data type.
         _check_data_types(keys, data, datatype)
         # Flatten the data associated with the keys
+        # FlagScale Begin
         flatten_data = torch.cat(
             [data[key].to(cur_platform.current_device()).contiguous().view(-1) for key in keys],
             dim=0,
         )
+        # FlagScale End
     else:
+        # FlagScale Begin
         flatten_data = torch.empty(
             total_numel, device=cur_platform.current_device(), dtype=datatype
         )
+        # FlagScale End
 
     # Broadcast
     group_ranks = torch.distributed.get_process_group_ranks(group=tp_group)

--- a/megatron/core/tensor_parallel/layers.py
+++ b/megatron/core/tensor_parallel/layers.py
@@ -65,20 +65,26 @@ _MODEL_PARALLEL_ATTRIBUTE_DEFAULTS = {
     "partition_stride": 1,
 }
 
+# FlagScale Begin
 from megatron.plugin.platform import get_platform
 
 cur_platform = get_platform()
+# FlagScale End
 
 try:
     if is_torch_min_version("2.4.0a0"):
         custom_fwd = partial(torch.amp.custom_fwd, device_type="cuda")
         custom_bwd = partial(torch.amp.custom_bwd, device_type="cuda")
     else:
+        # FlagScale Begin
         custom_fwd = cur_platform.amp.custom_fwd
         custom_bwd = cur_platform.amp.custom_bwd
+        # FlagScale End
 except:
+    # FlagScale Begin
     custom_fwd = cur_platform.amp.custom_fwd
     custom_bwd = cur_platform.amp.custom_bwd
+    # FlagScale End
 
 try:
     if is_torch_min_version("1.13.0"):
@@ -264,7 +270,7 @@ class VocabParallelEmbedding(torch.nn.Module):
                 torch.empty(
                     self.num_embeddings_per_partition,
                     self.embedding_dim,
-                    device=cur_platform.current_device(),
+                    device=cur_platform.current_device(),  # FlagScale Add
                     dtype=config.params_dtype,
                 )
             )
@@ -450,7 +456,7 @@ class LinearWithGradAccumulationAndAsyncCommunication(torch.autograd.Function):
         grad_output_buffer,
         wgrad_deferral_limit,
         tp_group,
-        te_fl_prefer,
+        te_fl_prefer,  # FlagScale Add
     ):
         """Forward."""
         if gradient_accumulation_fusion and hasattr(weight, "main_grad"):
@@ -469,7 +475,7 @@ class LinearWithGradAccumulationAndAsyncCommunication(torch.autograd.Function):
         ctx.wgrad_deferral_limit = wgrad_deferral_limit
         ctx.grad_output_buffer = grad_output_buffer
         ctx.tp_group = tp_group
-        ctx.te_fl_prefer = te_fl_prefer
+        ctx.te_fl_prefer = te_fl_prefer  # FlagScale Add
 
         if sequence_parallel:
             dim_size = list(input.size())
@@ -545,10 +551,12 @@ class LinearWithGradAccumulationAndAsyncCommunication(torch.autograd.Function):
             assert not ctx.allreduce_dgrad
             dim_size = list(input.size())
             sub_grad_input = torch.empty(
+                # FlagScale Begin
                 dim_size,
                 dtype=input.dtype,
                 device=cur_platform.current_device(),
                 requires_grad=False,
+                # FlagScale End
             )
             # reduce_scatter
             handle = dist_reduce_scatter_func(
@@ -564,6 +572,7 @@ class LinearWithGradAccumulationAndAsyncCommunication(torch.autograd.Function):
                     weight.main_grad = weight.get_main_grad()
                     torch.matmul(grad_output.t(), total_input, out=weight.main_grad)
                 else:
+                    # FlagScale Begin
                     if not (ctx.te_fl_prefer == 'flagos' or ctx.te_fl_prefer == 'reference'):
                         if weight.main_grad.dtype == torch.float32:
                             fused_weight_gradient_mlp_cuda.wgrad_gemm_accum_fp32(
@@ -577,7 +586,9 @@ class LinearWithGradAccumulationAndAsyncCommunication(torch.autograd.Function):
                             raise RuntimeError(
                                 "Unsupported gradient type for gradient accumulation fusion"
                             )
+                    # FlagScale End
                     else:
+                        # FlagScale Begin
                         if weight.main_grad.dtype in (torch.float32, torch.float16, torch.bfloat16):
                             grad_weight = torch.matmul(grad_output.t(), total_input)
                             weight.main_grad += grad_weight.view_as(weight.main_grad)
@@ -585,6 +596,7 @@ class LinearWithGradAccumulationAndAsyncCommunication(torch.autograd.Function):
                             raise RuntimeError(
                                 "Unsupported gradient type for gradient accumulation fusion"
                             )
+                        # FlagScale End
 
             if hasattr(weight, "grad_added_to_main_grad"):
                 # When overlap_grad_reduce is True, need to ensure that backward hooks
@@ -602,7 +614,7 @@ class LinearWithGradAccumulationAndAsyncCommunication(torch.autograd.Function):
                         grad_weight = torch.zeros(
                             weight.main_grad.shape,
                             dtype=input.dtype,
-                            device=cur_platform.current_device(),
+                            device=cur_platform.current_device(),  # FlagScale Add
                             requires_grad=False,
                         )
                 else:
@@ -612,7 +624,7 @@ class LinearWithGradAccumulationAndAsyncCommunication(torch.autograd.Function):
                         grad_weight = torch.empty(
                             weight.main_grad.shape,
                             dtype=input.dtype,
-                            device=cur_platform.current_device(),
+                            device=cur_platform.current_device(),  # FlagScale Add
                             requires_grad=False,
                         )
                 weight.grad_added_to_main_grad = True
@@ -626,6 +638,7 @@ class LinearWithGradAccumulationAndAsyncCommunication(torch.autograd.Function):
             handle.wait()
             # Need to return None's as gradient has to flow for all the input arguments
             # provided during forward
+            # FlagScale Begin
             return (
                 sub_grad_input,
                 grad_weight,
@@ -638,11 +651,12 @@ class LinearWithGradAccumulationAndAsyncCommunication(torch.autograd.Function):
                 None,
                 None,
             )
+            # FlagScale End
 
         if ctx.allreduce_dgrad:
             handle.wait()
 
-        return grad_input, grad_weight, grad_bias, None, None, None, None, None, None, None
+        return grad_input, grad_weight, grad_bias, None, None, None, None, None, None, None  # FlagScale Add
 
 
 def linear_with_grad_accumulation_and_async_allreduce(
@@ -655,7 +669,7 @@ def linear_with_grad_accumulation_and_async_allreduce(
     grad_output_buffer: Optional[List[torch.Tensor]] = None,
     wgrad_deferral_limit: Optional[int] = 0,
     tp_group: Optional[torch.distributed.ProcessGroup] = None,
-    te_fl_prefer: Optional[str] = 'vendor',
+    te_fl_prefer: Optional[str] = 'vendor',  # FlagScale Add
 ) -> torch.Tensor:
     """Linear layer execution with asynchronous communication and
     gradient accumulation fusion in backprop.
@@ -732,7 +746,7 @@ def linear_with_grad_accumulation_and_async_allreduce(
         grad_output_buffer,
         wgrad_deferral_limit,
         tp_group,
-        te_fl_prefer,
+        te_fl_prefer,  # FlagScale Add
     ]
 
     if not linear_with_grad_accumulation_and_async_allreduce.warned:
@@ -881,7 +895,7 @@ class ColumnParallelLinear(torch.nn.Module):
                     torch.empty(
                         self.output_size_per_partition,
                         self.input_size,
-                        device=cur_platform.current_device(),
+                        device=cur_platform.current_device(),  # FlagScale Add
                         dtype=config.params_dtype,
                     )
                 )
@@ -907,7 +921,7 @@ class ColumnParallelLinear(torch.nn.Module):
                 self.bias = Parameter(
                     torch.empty(
                         self.output_size_per_partition,
-                        device=cur_platform.current_device(),
+                        device=cur_platform.current_device(),  # FlagScale Add
                         dtype=config.params_dtype,
                     )
                 )
@@ -960,7 +974,7 @@ class ColumnParallelLinear(torch.nn.Module):
         if not weight.requires_grad:
             return linear_with_frozen_weight(input, weight, *args, **kwargs)
         else:
-            kwargs['te_fl_prefer'] = self.config.te_fl_prefer
+            kwargs['te_fl_prefer'] = self.config.te_fl_prefer  # FlagScale Add
             return linear_with_grad_accumulation_and_async_allreduce(input, weight, *args, **kwargs)
 
     def forward(
@@ -1210,7 +1224,7 @@ class RowParallelLinear(torch.nn.Module):
                 torch.empty(
                     self.output_size,
                     self.input_size_per_partition,
-                    device=cur_platform.current_device(),
+                    device=cur_platform.current_device(),  # FlagScale Add
                     dtype=config.params_dtype,
                 )
             )
@@ -1231,7 +1245,7 @@ class RowParallelLinear(torch.nn.Module):
                 self.bias = Parameter(
                     torch.empty(
                         self.output_size,
-                        device=cur_platform.current_device(),
+                        device=cur_platform.current_device(),  # FlagScale Add
                         dtype=config.params_dtype,
                     )
                 )

--- a/megatron/core/tensor_parallel/mappings.py
+++ b/megatron/core/tensor_parallel/mappings.py
@@ -18,9 +18,11 @@ except:
     dist_all_gather_func = torch.distributed._all_gather_base
     dist_reduce_scatter_func = torch.distributed._reduce_scatter_base
 
+# FlagScale Begin
 from megatron.plugin.platform import get_platform
 
 cur_platform = get_platform()
+# FlagScale End
 
 
 def _reduce(input_, group):
@@ -92,7 +94,7 @@ def _gather_along_last_dim(input_, group):
     dim_size = list(input_.size())
     dim_size[0] = dim_size[0] * world_size
 
-    output = torch.empty(dim_size, dtype=input_.dtype, device=cur_platform.current_device())
+    output = torch.empty(dim_size, dtype=input_.dtype, device=cur_platform.current_device())  # FlagScale Add
     dist_all_gather_func(output, input_.contiguous(), group=group)
     tensor_list = output.chunk(world_size, dim=0)
     output = torch.cat(tensor_list, dim=-1).contiguous()
@@ -142,14 +144,14 @@ def _gather_along_first_dim(input_, group, output_split_sizes=None, use_global_b
         if use_global_buffer:
             output = get_global_memory_buffer().get_tensor(dim_size, input_.dtype, "mpu")
         else:
-            output = torch.empty(dim_size, dtype=input_.dtype, device=cur_platform.current_device())
+            output = torch.empty(dim_size, dtype=input_.dtype, device=cur_platform.current_device())  # FlagScale Add
         dist_all_gather_func(output, input_.contiguous(), group=group)
     else:
         dim_size[0] = sum(output_split_sizes)
         if use_global_buffer:
             output = get_global_memory_buffer().get_tensor(dim_size, input_.dtype, "mpu")
         else:
-            output = torch.empty(dim_size, dtype=input_.dtype, device=cur_platform.current_device())
+            output = torch.empty(dim_size, dtype=input_.dtype, device=cur_platform.current_device())  # FlagScale Add
         output_tensor_list = list(torch.split(output, output_split_sizes, dim=0))
         torch.distributed.all_gather(output_tensor_list, input_, group=group)
 
@@ -182,7 +184,7 @@ def _reduce_scatter_along_first_dim(input_, group, input_split_sizes=None, use_g
         if use_global_buffer:
             output = get_global_memory_buffer().get_tensor(dim_size, input_.dtype, "mpu")
         else:
-            output = torch.empty(dim_size, dtype=input_.dtype, device=cur_platform.current_device())
+            output = torch.empty(dim_size, dtype=input_.dtype, device=cur_platform.current_device())  # FlagScale Add
         dist_reduce_scatter_func(output, input_.contiguous(), group=group)
     else:
         rank = group.rank()
@@ -443,7 +445,7 @@ class _AllToAll(torch.autograd.Function):
             output = input.new_empty(
                 size=[sum(output_split_sizes)] + list(input.size()[1:]),
                 dtype=input.dtype,
-                device=cur_platform.current_device(),
+                device=cur_platform.current_device(),  # FlagScale Add
             )
         torch.distributed.all_to_all_single(
             output,

--- a/megatron/core/tensor_parallel/random.py
+++ b/megatron/core/tensor_parallel/random.py
@@ -86,9 +86,11 @@ try:
 except ModuleNotFoundError:
     HAVE_TE = False
 
+# FlagScale Begin
 from megatron.plugin.platform import get_platform
 
 cur_platform = get_platform()
+# FlagScale End
 
 # Default name for the model parallel rng tracker.
 _MODEL_PARALLEL_RNG_TRACKER_NAME = 'model-parallel-rng'
@@ -110,7 +112,7 @@ def _get_cuda_rng_state(
 
     # if not using cuda graphs, just use the builtin pytorch function
     if not graph_safe:
-        return cur_platform.get_rng_state(device=device)
+        return cur_platform.get_rng_state(device=device)  # FlagScale Add
 
     _lazy_init()
     if isinstance(device, str):
@@ -119,9 +121,9 @@ def _get_cuda_rng_state(
         device = torch.device("cuda", device)
     idx = device.index
     if idx is None:
-        idx = cur_platform.current_device()
+        idx = cur_platform.current_device()  # FlagScale Add
 
-    default_generator = cur_platform.default_generators[idx]
+    default_generator = cur_platform.default_generators[idx]  # FlagScale Add
     if clone:
         return default_generator.clone_state()
     return default_generator.graphsafe_get_state()
@@ -157,8 +159,10 @@ def _set_cuda_rng_state(new_state: torch.Tensor, device: int = -1, graph_safe: b
         def cb():
             idx = device.index
             if idx is None:
+                # FlagScale Begin
                 idx = cur_platform.current_device()
             default_generator = cur_platform.default_generators[idx]
+                # FlagScale End
 
             # if graph capturing, set the rng state in a cudagraphable way
             if graph_safe:
@@ -290,10 +294,12 @@ class CudaRNGStatesTracker:
             self.states_[name] = new_state
         else:
             # Get the current rng state.
-            orig_rng_state = cur_platform.get_rng_state()
+            orig_rng_state = cur_platform.get_rng_state()  # FlagScale Add
             # Set the new state and store it.
+            # FlagScale Begin
             cur_platform.manual_seed(seed)
             self.states_[name] = cur_platform.get_rng_state()
+            # FlagScale End
             # Reset rng state to what it was.
             _set_cuda_rng_state(orig_rng_state)
 
@@ -477,7 +483,7 @@ def model_parallel_cuda_manual_seed(
     )
     _CUDA_RNG_STATE_TRACKER.reset()
     # Set the default state.
-    cur_platform.manual_seed(data_parallel_seed)
+    cur_platform.manual_seed(data_parallel_seed)  # FlagScale Add
     _CUDA_RNG_STATE_TRACKER.add(_DATA_PARALLEL_RNG_TRACKER_NAME, data_parallel_seed)
 
     # and model parallel state.

--- a/megatron/core/tensor_parallel/utils.py
+++ b/megatron/core/tensor_parallel/utils.py
@@ -18,9 +18,11 @@ try:
 except Exception:
     dist_all_gather_func = torch.distributed._all_gather_base
 
+# FlagScale Begin
 from megatron.plugin.platform import get_platform
 
 cur_platform = get_platform()
+# FlagScale End
 
 
 def split_tensor_along_last_dim(
@@ -71,7 +73,7 @@ def split_tensor_into_1d_equal_chunks(tensor, new_buffer=False, tp_group=None):
         data = torch.empty(
             partition_size,
             dtype=tensor.dtype,
-            device=cur_platform.current_device(),
+            device=cur_platform.current_device(),  # FlagScale Add
             requires_grad=False,
         )
         data.copy_(tensor.view(-1)[start_index:end_index])
@@ -92,10 +94,12 @@ def gather_split_1d_tensor(tensor, tp_group=None):
     tp_group = get_tensor_model_parallel_group_if_none(tp_group)
     numel_gathered = torch.numel(tensor) * tp_group.size()
     gathered = torch.empty(
+        # FlagScale Begin
         numel_gathered,
         dtype=tensor.dtype,
         device=cur_platform.current_device(),
         requires_grad=False,
+        # FlagScale End
     )
     dist_all_gather_func(gathered, tensor, group=tp_group)
     return gathered

--- a/megatron/core/timers.py
+++ b/megatron/core/timers.py
@@ -31,9 +31,11 @@ except:
 
 logger = logging.getLogger(__name__)
 
+# FlagScale Begin
 from megatron.plugin.platform import get_platform
 
 cur_platform = get_platform()
+# FlagScale End
 
 
 class TimerBase(ABC):
@@ -153,7 +155,7 @@ class Timer(TimerBase):
         assert not self._started, 'timer has already been started'
         if barrier:
             torch.distributed.barrier(group=self._barrier_group)
-        cur_platform.synchronize()
+        cur_platform.synchronize()  # FlagScale Add
         self._start_time = time.time()
         self._started = True
 
@@ -166,7 +168,7 @@ class Timer(TimerBase):
         assert self._started, 'timer is not started'
         if barrier:
             torch.distributed.barrier(group=self._barrier_group)
-        cur_platform.synchronize()
+        cur_platform.synchronize()  # FlagScale Add
         elapsed = time.time() - self._start_time
         self._elapsed += elapsed
         self._active_time += elapsed
@@ -304,7 +306,7 @@ class Timers:
         # and since we are only gathering a small amount of data,
         # it should be ok to use all-gather instead of gather.
         rank_name_to_time = torch.zeros(
-            (world_size, len(names)), dtype=torch.float, device=cur_platform.current_device()
+            (world_size, len(names)), dtype=torch.float, device=cur_platform.current_device()  # FlagScale Add
         )
         for i, name in enumerate(names):
             if name in self._timers:
@@ -314,8 +316,10 @@ class Timers:
                 # groups inside their class.
                 rank_name_to_time[rank, i] = self._timers[name].elapsed(reset=reset)
 
+        # FlagScale Begin
         if "cpu:gloo" == torch.distributed.get_backend():
             rank_name_to_time = rank_name_to_time.cpu()
+        # FlagScale End
         # See the note above for why we are not using gather.
         dist_all_gather_func(rank_name_to_time.view(-1), rank_name_to_time[rank, :].view(-1))
 

--- a/megatron/core/transformer/attention.py
+++ b/megatron/core/transformer/attention.py
@@ -433,7 +433,7 @@ class Attention(MegatronModule, ABC):
             self.num_query_groups_per_partition,
             dim,
             dtype=dtype,
-            device=cur_platform.current_device(),
+            device=cur_platform.current_device(),  # FlagScale Add
         )
 
     def _get_pp_layer_offset_for_inference(self):

--- a/megatron/core/transformer/cuda_graphs.py
+++ b/megatron/core/transformer/cuda_graphs.py
@@ -377,7 +377,7 @@ class _CudagraphGlobalRecord:
 
         progress_bar = enumerate(cls.cudagraph_record)
         time_start = time.time()
-        mem_stats_start = cur_platform.memory_stats()
+        mem_stats_start = cur_platform.memory_stats()  # FlagScale Add
 
         if torch.distributed.get_rank() == 0:
             if HAVE_TQDM:
@@ -398,7 +398,7 @@ class _CudagraphGlobalRecord:
                 )
 
         gc.collect()
-        cur_platform.empty_cache()
+        cur_platform.empty_cache()  # FlagScale Add
 
         _set_capture_start()
         if has_te_modules:
@@ -415,7 +415,7 @@ class _CudagraphGlobalRecord:
 
         for g_idx, g in progress_bar:
             if torch.distributed.get_rank() == 0:
-                mem_stats = cur_platform.memory_stats()
+                mem_stats = cur_platform.memory_stats()  # FlagScale Add
                 progress_str = "create cuda graphs | mem: alloc %s, res %s" % (
                     format_mem_bytes(mem_stats["allocated_bytes.all.current"]),
                     format_mem_bytes(mem_stats["reserved_bytes.all.current"]),
@@ -435,7 +435,7 @@ class _CudagraphGlobalRecord:
 
         # Memory usage.
         time_end = time.time()
-        mem_stats_end = cur_platform.memory_stats()
+        mem_stats_end = cur_platform.memory_stats()  # FlagScale Add
         capture_stats = {
             "time": time_end - time_start,
             "allocated_bytes": (
@@ -519,7 +519,7 @@ def delete_cuda_graphs():
 
     # TODO: Optional?: Force garbage collection to clean up memory
     gc.collect()
-    cur_platform.empty_cache()
+    cur_platform.empty_cache()  # FlagScale Add
 
     CudaGraphManager.global_mempool = None
 
@@ -940,11 +940,11 @@ class _CudaGraphRunner(torch.nn.Module):
             _set_warmup_end()
 
             with self.get_quantization_context():
-                cur_platform.synchronize()
+                cur_platform.synchronize()  # FlagScale Add
                 # Register default CUDA generators ourselves (fixed in-place to have normal tensors)
                 # before capture begins, to avoid inference-tensor state issues during capture.
                 with torch.inference_mode(mode=False):
-                    for device_idx in range(cur_platform.device_count()):
+                    for device_idx in range(cur_platform.device_count()):  # FlagScale Add
                         default_gen = torch.cuda.default_generators[device_idx]
                         self.fwd_graph.register_generator_state(
                             _ensure_generator_state_is_cudagraph_safe(default_gen)
@@ -1464,7 +1464,7 @@ class CudaGraphManager(torch.nn.Module):
             CudaGraphManager.global_mempool = torch.cuda.graph_pool_handle()
             # Cudagraph stream capture requires no operations on the default stream prior to the
             # capture, so change to a side stream.
-            cur_platform.set_stream(cur_platform.Stream())
+            cur_platform.set_stream(cur_platform.Stream())  # FlagScale Add
 
     def call_ddp_preforward_hook(self, module):
         """Call any DDP pre-forward hooks which are used to launch async data parallel
@@ -2237,9 +2237,9 @@ class TECudaGraphHelper:
         """
         assert not self._capture_finished, "CUDA Graph capture has already been finished."
 
-        cur_platform.synchronize()
+        cur_platform.synchronize()  # FlagScale Add
         gc.collect()
-        cur_platform.empty_cache()
+        cur_platform.empty_cache()  # FlagScale Add
         if FREEZE_GC:
             gc.freeze()
 
@@ -2273,12 +2273,12 @@ class TECudaGraphHelper:
         )
         _set_capture_end()
 
-        cur_platform.synchronize()
+        cur_platform.synchronize()  # FlagScale Add
         self._reset_after_capture()
         if FREEZE_GC:
             gc.unfreeze()
         gc.collect()
-        cur_platform.empty_cache()
+        cur_platform.empty_cache()  # FlagScale Add
 
         self._capture_finished = True
 

--- a/megatron/core/transformer/custom_layers/batch_invariant_kernels.py
+++ b/megatron/core/transformer/custom_layers/batch_invariant_kernels.py
@@ -28,9 +28,11 @@ except ImportError:
     tl = MagicMock()
     HAVE_TRITON = False
 
+# FlagScale Begin
 from megatron.plugin.platform import get_platform
 
 cur_platform = get_platform()
+# FlagScale End
 
 __all__ = [
     "set_batch_invariant_mode",
@@ -110,7 +112,7 @@ def matmul_kernel_persistent(
     offs_k_for_mask = tl.arange(0, BLOCK_SIZE_K)
     num_pid_in_group = GROUP_SIZE_M * num_pid_n
 
-    for tile_id in tl.range(start_pid, num_tiles, NUM_SMS):
+    for tile_id in tl.range(start_pid, num_tiles, NUM_SMS):  # FlagScale Add
         pid_m, pid_n = _compute_pid(tile_id, num_pid_in_group, num_pid_m, GROUP_SIZE_M, NUM_SMS)
         start_m = pid_m * BLOCK_SIZE_M
         start_n = pid_n * BLOCK_SIZE_N
@@ -166,7 +168,7 @@ def get_compute_units():
     # Use match/case for device-specific logic (Python 3.10+)
     match device_type:
         case "cuda":
-            device_properties = cur_platform.get_device_properties(0)
+            device_properties = cur_platform.get_device_properties(0)  # FlagScale Add
             NUM_SMS = device_properties.multi_processor_count
         case "xpu":
             device_properties = torch.xpu.get_device_properties(0)

--- a/megatron/core/transformer/dot_product_attention.py
+++ b/megatron/core/transformer/dot_product_attention.py
@@ -21,9 +21,11 @@ from megatron.core.transformer.utils import (
     make_sharded_tensors_for_checkpoint,
 )
 from megatron.core.utils import divide
+# FlagScale Begin
 from megatron.plugin.platform import get_platform
 
 cur_platform = get_platform()
+# FlagScale End
 
 
 class DotProductAttention(MegatronModule):
@@ -123,7 +125,7 @@ class DotProductAttention(MegatronModule):
         elif self.config.softmax_type == "off-by-one":
             self.softmax_offset = torch.zeros(
                 self.num_attention_heads_per_partition,
-                device=cur_platform.current_device(),
+                device=cur_platform.current_device(),  # FlagScale Add
                 dtype=self.config.params_dtype,
             )
         elif self.config.softmax_type == "learnable":
@@ -132,7 +134,7 @@ class DotProductAttention(MegatronModule):
                 torch.nn.Parameter(
                     torch.empty(
                         self.num_attention_heads_per_partition,
-                        device=cur_platform.current_device(),
+                        device=cur_platform.current_device(),  # FlagScale Add
                         dtype=self.config.params_dtype,
                     )
                 ),

--- a/megatron/core/transformer/experimental_attention_variant/dsa.py
+++ b/megatron/core/transformer/experimental_attention_variant/dsa.py
@@ -20,9 +20,11 @@ from megatron.core.transformer.enums import AttnMaskType
 from megatron.core.transformer.module import MegatronModule
 from megatron.core.transformer.spec_utils import ModuleSpec, build_module
 from megatron.core.transformer.transformer_config import TransformerConfig
+# FlagScale Begin
 from megatron.plugin.platform import get_platform
 
 cur_platform = get_platform()
+# FlagScale End
 
 try:
     from fast_hadamard_transform import hadamard_transform
@@ -77,7 +79,7 @@ class DSAIndexerLossLoggingHelper:
 
         tracker = DSAIndexerLossLoggingHelper.tracker
         if "values" not in tracker:
-            tracker["values"] = torch.zeros(num_layers, device=cur_platform.current_device())
+            tracker["values"] = torch.zeros(num_layers, device=cur_platform.current_device())  # FlagScale Add
         tracker["values"][layer_number - 1] += loss.detach()
         tracker["reduce_group"] = reduce_group
         tracker["avg_group"] = avg_group

--- a/megatron/core/transformer/mlp.py
+++ b/megatron/core/transformer/mlp.py
@@ -44,9 +44,11 @@ except ImportError:
 
 logger = logging.getLogger(__name__)
 
+# FlagScale Begin
 from megatron.plugin.platform import get_platform
 
 cur_platform = get_platform()
+# FlagScale End
 
 
 class LinearFc1Interface(Protocol):
@@ -442,7 +444,7 @@ def apply_swiglu_sharded_factory(
                 )
                 merged_sub_state_dict = torch.cat([t.cpu() for t in sub_state_dict])
                 gc.collect()
-                cur_platform.empty_cache()
+                cur_platform.empty_cache()  # FlagScale Add
                 return merged_sub_state_dict
 
     return ShardedTensorFactory(

--- a/megatron/core/transformer/module.py
+++ b/megatron/core/transformer/module.py
@@ -17,13 +17,15 @@ from megatron.core.transformer.utils import (
     make_sharded_tensors_for_checkpoint,
     sharded_state_dict_default,
 )
-from megatron.plugin.platform import get_platform
+from megatron.plugin.platform import get_platform  # FlagScale Add
 
+# FlagScale Begin
 cur_platform = get_platform()
 
 _FLOAT_TYPES = (torch.FloatTensor, cur_platform.FloatTensor)
 _HALF_TYPES = (torch.HalfTensor, cur_platform.HalfTensor)
 _BF16_TYPES = (torch.BFloat16Tensor, cur_platform.BFloat16Tensor)
+# FlagScale End
 
 
 def param_is_not_shared(param):  # pylint: disable=missing-function-docstring
@@ -253,7 +255,7 @@ class GraphableMegatronModule(MegatronModule):
             (slen_per_cptp, micro_batch_size, self.config.hidden_size),
             dtype=torch.bfloat16,
             requires_grad=True,
-            device=cur_platform.current_device(),
+            device=cur_platform.current_device(),  # FlagScale Add
         )
         return static_inputs
 

--- a/megatron/core/transformer/moe/moe_utils.py
+++ b/megatron/core/transformer/moe/moe_utils.py
@@ -1185,7 +1185,7 @@ def maybe_move_tensor_to_cpu(
         if as_numpy:
             cpu_tensor = cpu_tensor.numpy()
         if record_stream:
-            tensor.record_stream(cur_platform.current_stream())
+            tensor.record_stream(cur_platform.current_stream())  # FlagScale Add
         tensor = cpu_tensor
     return tensor
 

--- a/megatron/core/transformer/moe/router.py
+++ b/megatron/core/transformer/moe/router.py
@@ -99,9 +99,9 @@ class Router(ABC, MegatronModule):
         """
         if self.weight.device.type == 'cpu':
             # move weights to GPU
-            self.weight.data = self.weight.data.to(device=cur_platform.current_device())
+            self.weight.data = self.weight.data.to(device=cur_platform.current_device())  # FlagScale Add
         if self.bias is not None and self.bias.device.type == 'cpu':
-            self.bias.data = self.bias.data.to(device=cur_platform.current_device())
+            self.bias.data = self.bias.data.to(device=cur_platform.current_device())  # FlagScale Add
 
         # Convert to specified datatype for routing computation if enabled
         router_dtype = input.dtype
@@ -182,7 +182,7 @@ class TopKRouter(Router):
                 torch.zeros(
                     self.config.num_moe_experts,
                     dtype=torch.float32,
-                    device=cur_platform.current_device(),
+                    device=cur_platform.current_device(),  # FlagScale Add
                 ),
                 persistent=False,
             )
@@ -191,7 +191,7 @@ class TopKRouter(Router):
                 torch.zeros(
                     self.config.num_moe_experts,
                     dtype=torch.float32,
-                    device=cur_platform.current_device(),
+                    device=cur_platform.current_device(),  # FlagScale Add
                 ),
             )
         else:
@@ -205,13 +205,13 @@ class TopKRouter(Router):
                 torch.zeros(
                     self.config.num_moe_experts,
                     dtype=torch.float32,
-                    device=cur_platform.current_device(),
+                    device=cur_platform.current_device(),  # FlagScale Add
                 ),
                 persistent=False,
             )
             self.register_buffer(
                 'ga_steps',
-                torch.tensor(0, dtype=torch.float32, device=cur_platform.current_device()),
+                torch.tensor(0, dtype=torch.float32, device=cur_platform.current_device()),  # FlagScale Add
                 persistent=False,
             )
         else:

--- a/megatron/core/transformer/moe/shared_experts.py
+++ b/megatron/core/transformer/moe/shared_experts.py
@@ -27,9 +27,11 @@ from megatron.core.utils import (
     is_torch_min_version,
     make_sharded_tensor_for_checkpoint,
 )
+# FlagScale Begin
 from megatron.plugin.platform import get_platform
 
 cur_platform = get_platform()
+# FlagScale End
 
 if HAVE_TE:
     from megatron.core.extensions.transformer_engine import TELinear, set_save_original_input
@@ -119,7 +121,7 @@ class SharedExpertMLP(MLP):
             self.gate_score = None
 
             if self.stream is None:
-                self.stream = cur_platform.Stream()
+                self.stream = cur_platform.Stream()  # FlagScale Add
 
     def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
         """Forward function"""
@@ -158,8 +160,10 @@ class SharedExpertMLP(MLP):
         """
         assert self.config.moe_shared_expert_overlap
         assert self.cached_output is None
+        # FlagScale Begin
         self.stream.wait_stream(cur_platform.current_stream())
         with cur_platform.stream(self.stream):
+        # FlagScale End
             if self.use_shared_expert_gate:
                 logits = torch.nn.functional.linear(input, self.gate_weight)
                 self.gate_score = torch.nn.functional.sigmoid(logits)
@@ -181,7 +185,7 @@ class SharedExpertMLP(MLP):
         assert self.cached_fc1_input is not None
         if overlapped_comm_output is not None:
             set_tensor_grad_fn_sequence_sr(overlapped_comm_output, torch.iinfo(torch.int).max)
-        with cur_platform.stream(self.stream):
+        with cur_platform.stream(self.stream):  # FlagScale Add
             # [s, b, 4 * h/p]
             intermediate_parallel, bias_parallel = apply_module(self.linear_fc1)(
                 self.cached_fc1_input
@@ -234,7 +238,7 @@ class SharedExpertMLP(MLP):
         assert self.cached_fc2_input is not None
         if overlapped_comm_output is not None:
             set_tensor_grad_fn_sequence_sr(overlapped_comm_output, torch.iinfo(torch.int).max)
-        with cur_platform.stream(self.stream):
+        with cur_platform.stream(self.stream):  # FlagScale Add
             # [s, b, h]
             self.cached_fc2_output, _ = apply_module(self.linear_fc2)(self.cached_fc2_input)
             self.cached_fc2_input = None
@@ -247,7 +251,7 @@ class SharedExpertMLP(MLP):
         """
         assert self.config.moe_shared_expert_overlap
         assert self.cached_fc2_output is not None
-        with cur_platform.stream(self.stream):
+        with cur_platform.stream(self.stream):  # FlagScale Add
             if self.config.sequence_parallel:
                 self.cached_output = reduce_scatter_to_sequence_parallel_region(
                     self.cached_fc2_output
@@ -267,7 +271,7 @@ class SharedExpertMLP(MLP):
         """
         assert self.config.moe_shared_expert_overlap
         assert self.cached_output is not None
-        with cur_platform.stream(self.stream):
+        with cur_platform.stream(self.stream):  # FlagScale Add
             if self.use_shared_expert_gate:
                 assert self.gate_score is not None
                 output = self.cached_output * self.gate_score
@@ -275,7 +279,7 @@ class SharedExpertMLP(MLP):
             else:
                 output = self.cached_output
             self.cached_output = None
-        cur_platform.current_stream().wait_stream(self.stream)
+        cur_platform.current_stream().wait_stream(self.stream)  # FlagScale Add
         return output
 
 

--- a/megatron/core/transformer/moe/token_dispatcher.py
+++ b/megatron/core/transformer/moe/token_dispatcher.py
@@ -2,7 +2,7 @@
 
 import logging
 from abc import ABC, abstractmethod
-from re import M
+from re import M  # FlagScale Add
 from typing import List, Optional, Tuple
 
 import torch
@@ -50,9 +50,11 @@ from megatron.core.transformer.transformer_config import TransformerConfig
 
 logger = logging.getLogger(__name__)
 
+# FlagScale Begin
 from megatron.plugin.platform import get_platform
 
 cur_platform = get_platform()
+# FlagScale End
 
 
 class MoETokenDispatcher:
@@ -408,9 +410,11 @@ class MoEAlltoAllTokenDispatcher(MoETokenDispatcher):
         # [tp_size]. Represents the number of tokens received by the current rank from
         # other TP ranks.
         self.output_splits_tp = None
+        # FlagScale Begin
         self.permute_idx_device = (
             torch.device(cur_platform.device_name()) if self.config.moe_permute_fusion else "cpu"
         )
+        # FlagScale End
         input_chunk_idxs = torch.arange(
             self.num_experts * self.tp_size, device=self.permute_idx_device
         )
@@ -451,7 +455,7 @@ class MoEAlltoAllTokenDispatcher(MoETokenDispatcher):
         ):
             self.cuda_dtoh_point = "before_ep_alltoall"
         if MoEAlltoAllTokenDispatcher.cuda_dtoh_stream is None:
-            MoEAlltoAllTokenDispatcher.cuda_dtoh_stream = cur_platform.Stream()
+            MoEAlltoAllTokenDispatcher.cuda_dtoh_stream = cur_platform.Stream()  # FlagScale Add
 
         # Attributes that need to be captured in cudagraph. These attributes are returned
         # as cudagraph outputs when the cuda_graph_scope contains moe_preprocess.
@@ -880,10 +884,12 @@ class MoEAlltoAllTokenDispatcher(MoETokenDispatcher):
         if not self.drop_and_pad:
             if point == self.cuda_dtoh_point:
                 # Move all possible GPU tensors to CPU at self.cuda_dtoh_point.
-                on_side_stream = cur_platform.current_stream() != self.cuda_dtoh_stream
+                on_side_stream = cur_platform.current_stream() != self.cuda_dtoh_stream  # FlagScale Add
                 if on_side_stream:
+                    # FlagScale Begin
                     self.cuda_dtoh_stream.wait_stream(cur_platform.current_stream())
                 with cur_platform.stream(self.cuda_dtoh_stream):
+                    # FlagScale End
                     # TODO: use MemcpyBatchAsync instead.
                     tokens_per_expert = maybe_move_tensor_to_cpu(
                         tokens_per_expert, record_stream=on_side_stream

--- a/megatron/core/transformer/multi_token_prediction.py
+++ b/megatron/core/transformer/multi_token_prediction.py
@@ -185,7 +185,7 @@ def roll_tensor(tensor, shifts=-1, dims=-1, cp_group=None, packed_seq_params=Non
         empty_tensor = torch.empty(
             tensor_send_list[i].shape,
             dtype=tensor_send_list[i].dtype,
-            device=cur_platform.current_device(),
+            device=cur_platform.current_device(),  # FlagScale Add
         )
         tensor_recv_list.append(empty_tensor)
 
@@ -362,7 +362,7 @@ class MTPLossLoggingHelper:
 
         tracker = MTPLossLoggingHelper.tracker
         if "values" not in tracker:
-            tracker["values"] = torch.zeros(num_layers, device=cur_platform.current_device())
+            tracker["values"] = torch.zeros(num_layers, device=cur_platform.current_device())  # FlagScale Add
         tracker["values"][layer_number] += loss.detach()
         tracker["reduce_group"] = reduce_group
         tracker["avg_group"] = avg_group

--- a/megatron/core/transformer/transformer_block.py
+++ b/megatron/core/transformer/transformer_block.py
@@ -69,10 +69,12 @@ logger = logging.getLogger(__name__)
 
 
 def get_num_layers_to_build(
+    # FlagScale Begin
     config: TransformerConfig,
     vp_stage: Optional[int] = None,
     pp_rank: Optional[int] = None,
     is_dualpipev_first_chunk: Optional[bool] = False,
+    # FlagScale End
 ) -> int:
     """
     Determine the number of transformer layers to build for the current pipeline stage.

--- a/megatron/core/transformer/transformer_config.py
+++ b/megatron/core/transformer/transformer_config.py
@@ -116,6 +116,7 @@ class TransformerConfig(ModelParallelConfig):
     """If set, the loss layer will be treated as a standard transformer
     layer in the context of partition and placement for pipeline parallelism."""
 
+    # FlagScale Begin
     use_dualpipev: bool = False
     """Enable DualPipeV pipeline scheduling for MoE models."""
 
@@ -124,6 +125,7 @@ class TransformerConfig(ModelParallelConfig):
 
     te_fl_prefer: Optional[str] = "vendor"
     """TE-FL backend preference: 'flagos', 'vendor', or 'reference'."""
+    # FlagScale End
 
     hidden_size: int = field(default=0, metadata={"argparse_meta": {"default": None}})
     """Transformer hidden size."""
@@ -232,8 +234,10 @@ class TransformerConfig(ModelParallelConfig):
     qk_layernorm: bool = False
     """Whether to apply `normalization` type of normalization to the query and key embeddings."""
 
+    # FlagScale Begin
     qk_layernorm_hidden_dim: bool = False
     """Whether to layer normalize q and k on hidden dimension rather than head dimension."""
+    # FlagScale End
 
     qk_l2_norm: bool = False
     """Whether to apply llama 4-style qk L2 norm."""
@@ -489,6 +493,7 @@ class TransformerConfig(ModelParallelConfig):
     the number of transformer layers to recompute within each pipeline stage.  Must be None for
     'selective' activation checkpointing."""
 
+    # FlagScale Begin
     recompute_granularity_per_stage_micro_batch: Optional[List] = None
     """Fine-grained recompute granularity control per pipeline stage and micro-batch."""
 
@@ -497,6 +502,7 @@ class TransformerConfig(ModelParallelConfig):
 
     recompute_num_layers_per_stage_micro_batch: Optional[List] = None
     """Fine-grained recompute num_layers control per pipeline stage and micro-batch."""
+    # FlagScale End
 
     distribute_saved_activations: Optional[bool] = False
     """If True, distribute recomputed activations across the model parallel group."""
@@ -1032,6 +1038,7 @@ class TransformerConfig(ModelParallelConfig):
     min_offloaded_tensor_size: int = 1024 * 1024
     """The minimum size of the tensor to be offloaded."""
 
+    # FlagScale Begin
     # FlagScale PEFT/LoRA configuration
     peft_type: Optional[str] = None
     """PEFT type (e.g., 'lora'). None means no PEFT."""
@@ -1056,6 +1063,7 @@ class TransformerConfig(ModelParallelConfig):
 
     lora_out_init_method: str = "zero"
     """Initialization method for LoRA B matrix."""
+    # FlagScale End
 
     def __post_init__(self):
         """Python dataclass method that is used to modify attributes after initialization.

--- a/megatron/core/transformer/transformer_layer.py
+++ b/megatron/core/transformer/transformer_layer.py
@@ -49,10 +49,12 @@ logger = logging.getLogger(__name__)
 
 
 def get_transformer_layer_offset(
+    # FlagScale Begin
     config: TransformerConfig,
     vp_stage: Optional[int] = None,
     pp_rank: Optional[int] = None,
     is_dualpipev_first_chunk: Optional[bool] = False,
+    # FlagScale End
 ):
     """Get the index offset of current pipeline stage, given the level of pipelining."""
     if pp_rank is None:
@@ -1006,7 +1008,7 @@ class TransformerLayer(GraphableMegatronModule, BaseTransformerLayer):
             slen_per_cp = seq_length // self.config.context_parallel_size
             static_inputs["attention_mask"] = (
                 ~(torch.tril(torch.ones((slen_per_cp, seq_length))).bool())
-                .to(cur_platform.current_device())
+                .to(cur_platform.current_device())  # FlagScale Add
                 .reshape(1, 1, slen_per_cp, seq_length)
                 .tile(micro_batch_size, 1, 1, 1)
             )
@@ -1226,7 +1228,7 @@ class TransformerLayer(GraphableMegatronModule, BaseTransformerLayer):
                 return torch.zeros(
                     (micro_batch_size, 1, slen_per_cp, slen),
                     dtype=torch.bool,
-                    device=cur_platform.current_device(),
+                    device=cur_platform.current_device(),  # FlagScale Add
                 )
 
             if not is_te_min_version("1.10.0"):
@@ -1353,7 +1355,7 @@ class MoETransformerLayer(TransformerLayer):
                 and self.config.cuda_graph_impl == "local"
             )
             if not hasattr(self, '_router_dtoh_event'):
-                self._router_dtoh_event = cur_platform.Event()
+                self._router_dtoh_event = cur_platform.Event()  # FlagScale Add
             if not hasattr(self, 'cudagraph_manager_router'):
                 self.cudagraph_manager_router = CudaGraphManager(
                     self.config, self, function_name="_forward_mlp_router"

--- a/megatron/core/transformer/utils.py
+++ b/megatron/core/transformer/utils.py
@@ -15,9 +15,11 @@ from megatron.core.utils import (
     make_sharded_tensor_for_checkpoint,
     make_tp_sharded_tensor_for_checkpoint,
 )
+# FlagScale Begin
 from megatron.plugin.platform import get_platform
 
 cur_platform = get_platform()
+# FlagScale End
 
 if TYPE_CHECKING:
     from megatron.core.transformer import TransformerConfig
@@ -35,12 +37,12 @@ def get_linear_layer(rows, columns, init_method, perform_initialization=True):
 
 def get_default_causal_mask(sq: int) -> torch.Tensor:
     """Return the causal upper triangular mask for softmax input."""
-    return torch.triu(torch.ones(sq, sq, device=cur_platform.device_name()), diagonal=1).bool()
+    return torch.triu(torch.ones(sq, sq, device=cur_platform.device_name()), diagonal=1).bool()  # FlagScale Add
 
 
 def get_sliding_window_causal_mask(sq, skv, window_size):
     """Create the equivalent attention mask for SWA in [sq, skv] shape"""
-    m = torch.ones(sq, skv, dtype=torch.bool, device=cur_platform.device_name())
+    m = torch.ones(sq, skv, dtype=torch.bool, device=cur_platform.device_name())  # FlagScale Add
     mu = torch.triu(m, diagonal=skv - sq - window_size[0])
     ml = torch.tril(mu, diagonal=skv - sq + window_size[1])
     ml = ~ml

--- a/megatron/core/utils.py
+++ b/megatron/core/utils.py
@@ -339,7 +339,7 @@ def get_te_version():
     global _te_version
     if _te_version is None:
         if HAVE_TE:
-            _te_version = PkgVersion(parse_te_version_str(get_te_version_str()))
+            _te_version = PkgVersion(parse_te_version_str(get_te_version_str()))  # FlagScale Add
         else:
             _te_version = PkgVersion("0.0.0")
     return _te_version
@@ -671,7 +671,7 @@ class GlobalMemoryBuffer:
                 self.buffer[(name, dtype)] = torch.empty(
                     required_len,
                     dtype=dtype,
-                    device=cur_platform.current_device(),
+                    device=cur_platform.current_device(),  # FlagScale Add
                     requires_grad=False,
                 )
 
@@ -1398,10 +1398,12 @@ class StragglerDetector:
         self.bdata: bool = False
         self.dev: Union[torch.device, int, None] = None
         self.evt_q: Union[queue.LifoQueue, None] = None
+        # FlagScale Begin
         self.start_gemm_ev: List[cur_platform.Event] = []
         self.stop_gemm_ev: List[cur_platform.Event] = []
         self.start_data_ev: List[cur_platform.Event] = []
         self.stop_data_ev: List[cur_platform.Event] = []
+        # FlagScale End
         self.start_gemm_tm: List[int] = []
         self.stop_gemm_tm: List[int] = []
         self.start_data_tm: List[int] = []
@@ -1451,7 +1453,7 @@ class StragglerDetector:
         self.stop = self.null_method
         self._off = True
         # No CUDA, No Support
-        if cur_platform.is_available():
+        if cur_platform.is_available():  # FlagScale Add
             self._off = not enabled
             self.world = world
             self.rank = rank
@@ -1471,12 +1473,12 @@ class StragglerDetector:
             self.stop_data_tm = []
             backend = torch.distributed.get_backend()
             if backend == "nccl":
-                self.dev = cur_platform.current_device()
+                self.dev = cur_platform.current_device()  # FlagScale Add
             else:
                 self.dev = torch.device("cpu")
             # cache some events
             for _ in range(prefill):
-                self.evt_q.put(cur_platform.Event(enable_timing=True))
+                self.evt_q.put(cur_platform.Event(enable_timing=True))  # FlagScale Add
             if self.rank == 0:
                 # Start the controller
                 self._controller()
@@ -1521,8 +1523,10 @@ class StragglerDetector:
             sev = self.evt_q.get()  # no try-catch
             eev = self.evt_q.get()  # no try-catch
         else:
+            # FlagScale Begin
             sev = cur_platform.Event(enable_timing=True)
             eev = cur_platform.Event(enable_timing=True)
+            # FlagScale End
         # First check if this start is for data
         if self.bdata:
             self.start_data_ev.append(sev)
@@ -1593,11 +1597,13 @@ class StragglerDetector:
         elif ls_bs != ls_be:
             logger.warning(f"get_batch Start/Stop out of sync {ls_bs}/{ls_be}")
         else:
+            # FlagScale Begin
             temp = cur_platform.temperature()
             power = cur_platform.power_draw()
             util = cur_platform.utilization()
             clock = cur_platform.clock_rate()
             cur_platform.synchronize()
+            # FlagScale End
             # Process Events
             for i in range(ls_ev):
                 e_ev = self.start_gemm_ev[i].elapsed_time(self.stop_gemm_ev[i])
@@ -2187,7 +2193,7 @@ def nvtx_range_push(msg=None, suffix=None) -> None:
     _nvtx_range_messages.append(msg)
 
     # Push NVTX range
-    cur_platform.range_push(msg)
+    cur_platform.range_push(msg)  # FlagScale Add
 
 
 def nvtx_range_pop(msg=None, suffix=None) -> None:
@@ -2216,7 +2222,7 @@ def nvtx_range_pop(msg=None, suffix=None) -> None:
         )
 
     # Pop NVTX range
-    cur_platform.range_pop()
+    cur_platform.range_pop()  # FlagScale Add
 
 
 @lru_cache(maxsize=None)

--- a/megatron/plugin/hetero/parallel_context.py
+++ b/megatron/plugin/hetero/parallel_context.py
@@ -992,6 +992,12 @@ class ParallelContext:
             assert group is not None, 'model parallel group is not initialized'
         return group
 
+    def get_model_parallel_src_rank(self):
+        """Calculate the global rank corresponding to the first local rank
+        in the model parallel group."""
+        ranks = self.get_global_group_ranks("tp-pp", is_expert=False, check_initialized=True)
+        return ranks[0]
+
     def get_tensor_model_parallel_group(self, check_initialized=True):
         """Get the tensor model parallel group the caller rank belongs to."""
         current_process_mesh = self._process_meshes[self._current_process_mesh_index]


### PR DESCRIPTION
Add annotations for FlagScale functionality in megatron.core, covering the following areas:

- platform & override
- hetero, p2p_communications, pipeline schedules
- dualpipev, transformer_block/transformer_layer offsets
- engram, process_groups
- te_fl_prefer
- other configs