### PR TITLE
change dataset Makefile

### DIFF
--- a/megatron/core/datasets/Makefile
+++ b/megatron/core/datasets/Makefile
@@ -1,6 +1,5 @@
 CXXFLAGS += -O3 -Wall -shared -std=c++17 -fPIC -fdiagnostics-color
-CPPFLAGS += $(shell python3 -m pybind11 --includes)
-
+CPPFLAGS += $(shell python3 -m pybind11 --includes 2>/dev/null | tail -n 1)
 LIBNAME = helpers_cpp
 LIBEXT = $(shell python3-config --extension-suffix)
 


### PR DESCRIPTION
# Description

During the compilation process, g++ sometimes treats warnings in the log as content to be compiled, polluting the compilation environment and causing errors. This modification simply forces the compiler to only take the last line, discarding all the preceding interfering information and allowing for normal compilation.

## Type of change

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Infra/Build change (changes to CI/CD workflows or build scripts)
- [ ] Code refactoring
- [ ] Documentation change
- [1] Bug fix
- [ ] Breaking change

## Changes

CPPFLAGS += $(shell python3 -m pybind11 --includes 2>/dev/null | tail -n 1)

## Checklist

- [1] I have read and followed the contributing guidelines
- [1] The functionality is complete
- [1] I have commented my code, particularly in coverage report uploading steps
- [1] I have made corresponding changes to the documentation
- [1] My changes generate no new warnings
- [1] I have added/updated tests that prove my feature works
- [1] New and existing unit tests pass locally
