### PR TITLE
[train]: feat, add compatibility between moe 1F1B overlap and MHC, while maintaining backward compatibility when MHC is disabled.

### DIFF
--- a/megatron/core/models/common/model_chunk_schedule_plan.py
+++ b/megatron/core/models/common/model_chunk_schedule_plan.py
@@ -19,6 +19,8 @@ from megatron.core.pipeline_parallel.utils import (
 from megatron.plugin.platform import get_platform
 
 cur_platform = get_platform()
+from megatron.core.transformer.hyper_connection import HyperConnectionModule
+from megatron.core.transformer.transformer_block import TransformerBlock
 ########## FlagScale End ##########
 
 
@@ -84,6 +86,8 @@ class TransformerLayerSchedulePlan:
         self.event = event
         self.comp_stream = comp_stream
         self.comm_stream = comm_stream
+        self.layer_state.mhc_recompute_manager = extra_args.get("mhc_recompute_manager", None)  # FlagScale Add
+        self.layer_state.mhc_is_last_layer_in_recompute_block = extra_args.get("mhc_is_last_layer_in_recompute_block", False)  # FlagScale Add
 
         # get callable nodes for transformer/mtp layer
         self._build_callable_nodes(event, comp_stream, comm_stream, extra_args)
@@ -344,6 +348,34 @@ class TransformerModelChunkSchedulePlan(AbstractSchedulePlan):
         self.pre_process = PreProcessNode(
             model, self._model_chunk_state, self._event, get_comp_stream
         )
+        ##### FlagScale Begin #####
+        self.enable_hyper_connections = getattr(model.config, "enable_hyper_connections", False)
+        self.num_residual_streams = getattr(model.config, "num_residual_streams", 1)
+        # Build mhc recompute manager like TransformerBlock. 
+        decoder = model.decoder
+        use_mhc_recompute = (
+            decoder.training
+            and decoder.config.enable_hyper_connections
+            and decoder.config.recompute_granularity == 'selective'
+            and "mhc" in decoder.config.recompute_modules
+        )
+        # If not enable_hyper_connections, the mhc_layer_managers will be all None and mhc_is_last_in_recompute_block will be all False, so it won't have effect on execution.
+        self.mhc_layer_managers, self.mhc_is_last_in_recompute_block = decoder._build_mhc_recompute_layer_plan(use_mhc_recompute)
+        if self.enable_hyper_connections:
+            self._model_chunk_state.hc_head_fn = decoder.hc_head_fn
+            self._model_chunk_state.hc_head_base = decoder.hc_head_base
+            self._model_chunk_state.hc_head_scale = decoder.hc_head_scale
+            self._model_chunk_state.num_residual_streams = self.num_residual_streams
+            self._model_chunk_state.layernorm_epsilon = decoder.config.layernorm_epsilon
+            self._model_chunk_state.enable_mtp = decoder.config.mtp_num_layers is not None
+        else:
+            self._model_chunk_state.hc_head_fn = None
+            self._model_chunk_state.hc_head_base = None
+            self._model_chunk_state.hc_head_scale = None
+            self._model_chunk_state.num_residual_streams = None
+            self._model_chunk_state.layernorm_epsilon = None
+            self._model_chunk_state.enable_mtp = False
+        ##### FlagScale End #####
 
         # build layer schedule plan for each layer.
         # The methods to obtain layers are different for MTP so we need the other build plan for
@@ -370,11 +402,22 @@ class TransformerModelChunkSchedulePlan(AbstractSchedulePlan):
                 "is_last_layer": layer_idx == num_layers - 1,
             }
             ########## FlagScale Begin ##########
-            if hasattr(layer, "engram"):
+            if layer.config.use_engram and hasattr(layer, "engram"):
                 extra_args["is_engram"] = True
                 extra_args["engram_hash_input_ids"] = self.state.extra_block_kwargs[
                     "engram_hash_input_ids"
                 ]
+            if self.enable_hyper_connections:
+                mhc_recompute_manager = self.mhc_layer_managers[layer_idx]
+                if mhc_recompute_manager is not None:
+                    mhc_recompute_manager.is_last_layer_in_recompute_block = self.mhc_is_last_in_recompute_block[layer_idx]
+                    extra_args["mhc_recompute_manager"] = mhc_recompute_manager
+                    extra_args["enable_hyper_connections"] = True
+                else:
+                    extra_args["mhc_recompute_manager"] = None
+                    extra_args["enable_hyper_connections"] = False
+                extra_args["mhc_is_last_layer_in_recompute_block"] = self.mhc_is_last_in_recompute_block[layer_idx]
+                
             ########## FlagScale End ##########
             layer_plan = TransformerLayerSchedulePlan(
                 layer,  # FlagScale Add
@@ -428,6 +471,15 @@ class TransformerModelChunkSchedulePlan(AbstractSchedulePlan):
         if self.post_process is not None:
             self.post_process.model_chunk_state = None
             self.post_process = None
+        ##### FlagScale Begin #####
+        if self.enable_hyper_connections:
+            self._model_chunk_state.hc_head_fn = None
+            self._model_chunk_state.hc_head_base = None
+            self._model_chunk_state.hc_head_scale = None
+            self._model_chunk_state.num_residual_streams = None
+            self._model_chunk_state.layernorm_epsilon = None
+            self._model_chunk_state.enable_mtp = None
+        ##### FlagScale End #####
 
     @staticmethod
     def run(
@@ -473,6 +525,10 @@ class TransformerModelChunkSchedulePlan(AbstractSchedulePlan):
                 pre_forward(f_schedule_plan.vp_stage)
             f_schedule_plan.record_current_stream()
             f_input = f_schedule_plan.pre_process.forward()
+            ##### FlagScale Begin #####
+            if f_schedule_plan.enable_hyper_connections:
+                f_input = HyperConnectionModule.input_expand(f_input, f_schedule_plan.num_residual_streams)
+            ########## FlagScale End ##########
 
         if b_schedule_plan:
             b_schedule_plan.record_current_stream()
@@ -501,6 +557,14 @@ class TransformerModelChunkSchedulePlan(AbstractSchedulePlan):
                 b_grad=b_grad,
                 is_last_layer_in_bwd=(i == b_num_layers - 1),
             )
+            ##### FlagScale #####
+            print(f"f_layer_{i}.mhc_recompute_manager = {f_layer.layer_state.mhc_recompute_manager}")
+            TransformerBlock._finalize_mhc_recompute_layer(
+                mhc_manager=f_layer.layer_state.mhc_recompute_manager,
+                hidden_states=f_input,
+                is_last_in_recompute_block=f_layer.layer_state.mhc_is_last_layer_in_recompute_block,
+            )
+            ##### FlagScale End #####
             if i < b_num_layers - 1:
                 b_layer.release_state()
             cur_platform.range_pop()  # FlagScale Add
@@ -522,6 +586,14 @@ class TransformerModelChunkSchedulePlan(AbstractSchedulePlan):
             cur_platform.range_push(f"layer_{i}f")  # FlagScale Add
             f_input, _ = TransformerLayerSchedulePlan.run(f_layer, None, f_input=f_input)
             cur_platform.range_pop()  # FlagScale Add
+            ##### FlagScale #####
+            print(f"f_layer_{i}.mhc_recompute_manager = {f_layer.layer_state.mhc_recompute_manager}")
+            TransformerBlock._finalize_mhc_recompute_layer(
+                mhc_manager=f_layer.layer_state.mhc_recompute_manager,
+                hidden_states=f_input,
+                is_last_in_recompute_block=f_layer.layer_state.mhc_is_last_layer_in_recompute_block,
+            )
+            ##### FlagScale End #####
 
         if f_schedule_plan is not None and post_forward is not None:
             # post_forward()/send_forward_recv_forward() is running in the communication stream,
@@ -548,6 +620,13 @@ class TransformerModelChunkSchedulePlan(AbstractSchedulePlan):
             f_input = f_schedule_plan.post_process.forward(f_input)
         # pre process backward
         if b_schedule_plan is not None:
+            # If using hyper connections, the gradient accumulated through layers is
+            # multi‑stream [s, b, n*C], but pre_process expects single‑stream [s, b, C].
+            # We manually reduce it (sum over streams) to match the forward expand.
+            if b_schedule_plan.enable_hyper_connections:
+                n = b_schedule_plan.num_residual_streams
+                C = b_grad.shape[-1] // n
+                b_grad = b_grad.view(*b_grad.shape[:-1], n, C).sum(dim=-2)
             b_schedule_plan.pre_process.backward(b_grad)
 
         if f_schedule_plan:

--- a/megatron/core/models/common/model_chunk_schedule_plan.py
+++ b/megatron/core/models/common/model_chunk_schedule_plan.py
@@ -558,7 +558,6 @@ class TransformerModelChunkSchedulePlan(AbstractSchedulePlan):
                 is_last_layer_in_bwd=(i == b_num_layers - 1),
             )
             ##### FlagScale #####
-            print(f"f_layer_{i}.mhc_recompute_manager = {f_layer.layer_state.mhc_recompute_manager}")
             TransformerBlock._finalize_mhc_recompute_layer(
                 mhc_manager=f_layer.layer_state.mhc_recompute_manager,
                 hidden_states=f_input,
@@ -587,7 +586,6 @@ class TransformerModelChunkSchedulePlan(AbstractSchedulePlan):
             f_input, _ = TransformerLayerSchedulePlan.run(f_layer, None, f_input=f_input)
             cur_platform.range_pop()  # FlagScale Add
             ##### FlagScale #####
-            print(f"f_layer_{i}.mhc_recompute_manager = {f_layer.layer_state.mhc_recompute_manager}")
             TransformerBlock._finalize_mhc_recompute_layer(
                 mhc_manager=f_layer.layer_state.mhc_recompute_manager,
                 hidden_states=f_input,
@@ -620,6 +618,7 @@ class TransformerModelChunkSchedulePlan(AbstractSchedulePlan):
             f_input = f_schedule_plan.post_process.forward(f_input)
         # pre process backward
         if b_schedule_plan is not None:
+            ##### FlagScale Begin #####
             # If using hyper connections, the gradient accumulated through layers is
             # multi‑stream [s, b, n*C], but pre_process expects single‑stream [s, b, C].
             # We manually reduce it (sum over streams) to match the forward expand.
@@ -627,6 +626,7 @@ class TransformerModelChunkSchedulePlan(AbstractSchedulePlan):
                 n = b_schedule_plan.num_residual_streams
                 C = b_grad.shape[-1] // n
                 b_grad = b_grad.view(*b_grad.shape[:-1], n, C).sum(dim=-2)
+            ##### FlagScale End #####
             b_schedule_plan.pre_process.backward(b_grad)
 
         if f_schedule_plan:

--- a/megatron/core/models/gpt/fine_grained_callables.py
+++ b/megatron/core/models/gpt/fine_grained_callables.py
@@ -21,7 +21,8 @@ from megatron.core.transformer.multi_token_prediction import (
     MultiTokenPredictionLayer,
     get_mtp_layer_offset,
 )
-from megatron.core.transformer.transformer_layer import TransformerLayer, make_viewless_tensor
+from megatron.core.transformer.transformer_layer import TransformerLayer, make_viewless_tensor, HyperConnectionTransformerLayer
+from megatron.core.transformer.hyper_connection import learned_output_contract
 from megatron.core.typed_torch import apply_module, copy_signature
 from megatron.core.utils import internal_api
 
@@ -150,6 +151,14 @@ class PreProcessNode(ScheduleNode):
         if not self.gpt_model.pre_process:
             self.chunk_state.decoder_input = self.gpt_model.decoder.input_tensor
         # Run GPTModel._preprocess
+        ##### FlagScale Begin ######
+        preproc_output = self.gpt_model._preprocess(
+            input_ids=self.chunk_state.input_ids,
+            position_ids=self.chunk_state.position_ids,
+            decoder_input=self.chunk_state.decoder_input,
+            packed_seq_params=self.chunk_state.packed_seq_params,
+            padding_mask=self.chunk_state.padding_mask,
+        )
         (
             decoder_input,
             rotary_pos_emb,
@@ -157,13 +166,9 @@ class PreProcessNode(ScheduleNode):
             rotary_pos_sin,
             sequence_len_offset,
             padding_mask,
-        ) = self.gpt_model._preprocess(
-            input_ids=self.chunk_state.input_ids,
-            position_ids=self.chunk_state.position_ids,
-            decoder_input=self.chunk_state.decoder_input,
-            packed_seq_params=self.chunk_state.packed_seq_params,
-            padding_mask=self.chunk_state.padding_mask,
-        )
+        ) = preproc_output[:6]
+        rotary_pos_cos_sin = preproc_output[6] if len(preproc_output) == 7 else None
+        ##### FlagScale End ######
 
         # Saved for later use
         self.chunk_state.decoder_input = decoder_input
@@ -172,6 +177,7 @@ class PreProcessNode(ScheduleNode):
         self.chunk_state.rotary_pos_sin = rotary_pos_sin
         self.chunk_state.sequence_len_offset = sequence_len_offset
         self.chunk_state.padding_mask = padding_mask
+        self.chunk_state.rotary_pos_cos_sin = rotary_pos_cos_sin    ##### FlagScale Add #####
         return decoder_input
 
 
@@ -413,7 +419,7 @@ class _BackwardDWWrapper:
         self.graphed_backward_dw_callable = graphed_backward_dw_callable
 
 
-def build_transformer_layer_callables(layer: TransformerLayer):
+def build_transformer_layer_callables(layer: TransformerLayer | HyperConnectionTransformerLayer):
     """Create callables for transformer layer nodes.
     Divides the transformer layer's operations into a sequence of smaller, independent
     functions. This decomposition separates computation-heavy tasks (e.g., self-attention,
@@ -449,6 +455,7 @@ def build_transformer_layer_callables(layer: TransformerLayer):
         layer.config.moe_token_dispatcher_type == "flex"
         and layer.config.moe_flex_dispatcher_backend == "hybridep"
     )
+    enable_mhc = layer.config.enable_hyper_connections
 
     def submodule_attn_forward(node: ScheduleNode, hidden_states: torch.Tensor):
         """
@@ -484,22 +491,54 @@ def build_transformer_layer_callables(layer: TransformerLayer):
                 rotary_pos_emb: Optional[Tensor] = None,
                 rotary_pos_cos: Optional[Tensor] = None,
                 rotary_pos_sin: Optional[Tensor] = None,
+                rotary_pos_cos_sin: Optional[Tensor] = None,    ##### FlagScale Add #####
                 packed_seq_params: Optional[PackedSeqParams] = None,
                 sequence_len_offset: Optional[Tensor] = None,
+                input_ids: Optional[Tensor] = None,    ##### FlagScale Add ######
+                mhc_recompute_manager: Optional[object] = None,    ##### FlagScale Add ######
             ):
-                hidden_states, _ = layer._forward_attention(
-                    hidden_states=hidden_states,
-                    attention_mask=attention_mask,
-                    rotary_pos_emb=rotary_pos_emb,
-                    rotary_pos_cos=rotary_pos_cos,
-                    rotary_pos_sin=rotary_pos_sin,
-                    packed_seq_params=packed_seq_params,
-                    sequence_len_offset=sequence_len_offset,
-                )
+                ##### FlagScale Begin ######
+                fwd_attn_kwargs = {
+                    "hidden_states": hidden_states,
+                    "attention_mask": attention_mask,
+                    "rotary_pos_emb": rotary_pos_emb,
+                    "rotary_pos_cos": rotary_pos_cos,
+                    "rotary_pos_sin": rotary_pos_sin,
+                    "rotary_pos_cos_sin": rotary_pos_cos_sin,
+                    "packed_seq_params": packed_seq_params,
+                    "sequence_len_offset": sequence_len_offset,
+                    "input_ids": input_ids,
+                }
+                if enable_mhc and mhc_recompute_manager is not None:
+                    fwd_attn_kwargs["mhc_recompute_manager"] = mhc_recompute_manager
+                hidden_states, _ = layer._forward_attention(**fwd_attn_kwargs)
                 if not isinstance(layer.mlp, MoELayer):
                     return hidden_states, None, None, None
-                if layer.recompute_pre_mlp_layernorm:
-                    layer.pre_mlp_norm_checkpoint = tensor_parallel.CheckpointWithoutOutput()
+                # Preprocess mhc for moe layers. Because these op are moved away layer._forward_mlp, we have to do it here.
+                if enable_mhc:
+                    # Save hidden_states and mhc scalar for later use.
+                    node.layer_state.residual = node.detach(hidden_states)
+                    hidden_states, mlp_h_res, mlp_h_post = layer.mlp_hyper_connection(
+                        hidden_states, mhc_recompute_manager=mhc_recompute_manager
+                    )
+                    node.layer_state.mlp_h_res = node.detach(mlp_h_res)
+                    node.layer_state.mlp_h_post = node.detach(mlp_h_post)
+                # Save bda_manager to register backward hook for moe forward output. If not enable_mhc, it is None and does not affect anything.
+                is_last_in_recompute_block = bool(
+                    mhc_recompute_manager is not None
+                    and getattr(mhc_recompute_manager, "is_last_layer_in_recompute_block", False)
+                )
+                mhc_mlp_bda_manager = None if is_last_in_recompute_block else mhc_recompute_manager
+                node.layer_state.mhc_mlp_bda_manager = mhc_mlp_bda_manager
+                ## NOTE: If not enable mhc, layer is an instance of TransformerLayer, it does not has attribute mhc_checkpoint_pre_mlp_layernorm.
+                # But mhc_recompute_manager is always None in this case. If enable mhc, layer is an instance of HyperConnectionTransformerLayer and has attribute mhc_checkpoint_pre_mlp_layernorm.
+                # So this statement can cover both cases and avoid attribute error.
+                checkpoint_pre_mlp_layernorm = layer.recompute_pre_mlp_layernorm or (
+                    mhc_recompute_manager is not None and layer.mhc_checkpoint_pre_mlp_layernorm
+                )
+                if checkpoint_pre_mlp_layernorm:
+                    layer.pre_mlp_norm_checkpoint = tensor_parallel.CheckpointWithoutOutput(ckpt_manager=mhc_recompute_manager)
+                ##### FlagScale End ######
                     with off_interface(
                         layer.offload_mlp_norm, hidden_states, "mlp_norm"
                     ) as hidden_states:
@@ -515,7 +554,7 @@ def build_transformer_layer_callables(layer: TransformerLayer):
                         )
 
                 shared_expert_output = layer.mlp.shared_experts_compute(pre_mlp_layernorm_output)
-                probs, routing_map = layer.mlp.route(pre_mlp_layernorm_output)
+                probs, routing_map = layer.mlp.route(pre_mlp_layernorm_output, input_ids=input_ids)    ##### FlagScale Add ######
                 local_tokens, probs = layer.mlp.preprocess(
                     pre_mlp_layernorm_output, probs, routing_map
                 )
@@ -527,14 +566,20 @@ def build_transformer_layer_callables(layer: TransformerLayer):
             rotary_pos_emb=node.chunk_state.rotary_pos_emb,
             rotary_pos_cos=node.chunk_state.rotary_pos_cos,
             rotary_pos_sin=node.chunk_state.rotary_pos_sin,
+            rotary_pos_cos_sin=node.chunk_state.rotary_pos_cos_sin,    ##### FlagScale Add #####
             packed_seq_params=node.chunk_state.packed_seq_params,
             sequence_len_offset=node.chunk_state.sequence_len_offset,
+            input_ids=node.chunk_state.input_ids,    ##### FlagScale Add ######
+            mhc_recompute_manager=node.layer_state.mhc_recompute_manager    ##### FlagScale Add ######
         )
         if not isinstance(layer.mlp, MoELayer):
             return hidden_states
 
-        # Detach here for mlp_bda residual connection
-        node.layer_state.residual = node.detach(hidden_states)
+        ##### FlagScale Begin #####
+        # Detach here for mlp_bda residual connection. If enable_mhc, residual is saved before mlp_hyper_connection.
+        if not enable_mhc:
+            node.layer_state.residual = node.detach(hidden_states)
+        ##### FlagScale End #####
         if layer.mlp.use_shared_expert and not layer.mlp.shared_expert_overlap:
             # Detach here for shared expert connection in moe_combine
             node.layer_state.shared_expert_output = node.detach(shared_expert_output)
@@ -581,7 +626,11 @@ def build_transformer_layer_callables(layer: TransformerLayer):
             tokens_per_expert = token_dispatcher._comm_manager.get_number_of_tokens_per_expert()
             node.layer_state.tokens_per_expert = tokens_per_expert
 
-        if layer.recompute_pre_mlp_layernorm:
+        ##### FlagScale Begin #####
+        if layer.recompute_pre_mlp_layernorm or (
+            node.layer_state.mhc_mlp_bda_manager is not None and layer.mhc_checkpoint_pre_mlp_layernorm
+        ):
+        ##### FlagScale End #####
             # discard the output of the pre-mlp layernorm and register the recompute
             # as a gradient hook of expert_output
             layer.pre_mlp_norm_checkpoint.discard_output_and_register_recompute(expert_output)
@@ -605,10 +654,27 @@ def build_transformer_layer_callables(layer: TransformerLayer):
         mlp_output_with_bias = (output, None)
         if hasattr(layer, 'cuda_graphs') and layer.cuda_graphs:
             layer.mlp.cudagraph_tensor_store.clear()
+        ##### FlagScale Begin #####
+        # If not enable_mhc, layers' mlp_bda is executed normally.
+        # If enable_mhc, mlp_bda is replaced with mhc_fused_bda.
         with layer.bias_dropout_add_exec_handler():
-            hidden_states = layer.mlp_bda(layer.training, layer.config.bias_dropout_fusion)(
-                mlp_output_with_bias, residual, layer.hidden_dropout
-            )
+            if not enable_mhc:
+                hidden_states = layer.mlp_bda(layer.training, layer.config.bias_dropout_fusion)(
+                    mlp_output_with_bias, residual, layer.hidden_dropout
+                )
+            else:
+                # mhc_fused_h_res_h_post_bda, see megatron/core/transformer/hyper_connection.py:HyperConnectionTransformerLayer for more details.
+                hidden_states = layer.mlp_hyper_connection.fused_h_res_h_post_bda(
+                    node.layer_state.mlp_h_res,
+                    residual,
+                    node.layer_state.mlp_h_post,
+                    mlp_output_with_bias,
+                    layer.hidden_dropout,
+                    layer.training,
+                    layer.config.bias_dropout_fusion,
+                    node.layer_state.mhc_mlp_bda_manager,
+                )
+        ##### FlagScale End #####
         # Delay the offload of the mlp norm until after the mlp_bda has been computed
         # because the residual is needed in the mlp_bda.
         if layer.offload_mlp_norm:
@@ -627,10 +693,28 @@ def build_transformer_layer_callables(layer: TransformerLayer):
         # release tensor reference after use
         node.layer_state.residual = None
         node.layer_state.shared_expert_output = None
+        ##### FlagScale Begin #####
+        node.layer_state.mlp_h_res = None
+        node.layer_state.mlp_h_post = None
+        node.layer_state.mhc_mlp_bda_manager = None
+        ##### FlagScale End #####
 
         # final layer norm from decoder
         final_layernorm = node.chunk_state.model.decoder.final_layernorm
         if not node.is_mtp and final_layernorm and node.is_last_layer:
+            # contract output of mhc.
+            # When MTP is enabled, save pre-contraction multi-stream for MTP input.
+            if enable_mhc:
+                if node.chunk_state.enable_mtp:
+                    node.chunk_state.mhc_multistream = output
+                output = learned_output_contract(
+                    output,
+                    node.chunk_state.hc_head_fn,
+                    node.chunk_state.hc_head_base,
+                    node.chunk_state.hc_head_scale,
+                    node.chunk_state.num_residual_streams,
+                    node.chunk_state.layernorm_epsilon
+                )
             output = final_layernorm(output)
             output = make_viewless_tensor(inp=output, requires_grad=True, keep_graph=True)
         return output
@@ -638,6 +722,11 @@ def build_transformer_layer_callables(layer: TransformerLayer):
     @copy_signature(layer._forward_mlp, handle_first_dst_param='preserve')
     def mlp_wrapper(node: ScheduleNode, *args, **kwargs):
         """Wrapper for Dense forward."""
+        ##### FlagScale Begin ######
+        kwargs["input_ids"] = node.chunk_state.input_ids
+        if isinstance(layer, HyperConnectionTransformerLayer) and node.layer_state.mhc_recompute_manager is not None:
+            kwargs["mhc_recompute_manager"] = node.layer_state.mhc_recompute_manager
+        ##### FlagScale End ######
         return layer._forward_mlp(*args, **kwargs)
 
     def raise_not_implemented(*args):

--- a/megatron/core/transformer/engram.py
+++ b/megatron/core/transformer/engram.py
@@ -658,6 +658,7 @@ class ShortConv(nn.Module):
         norm_eps: float = 1e-5,
         hc_mult: int = 4,
         activation: bool = True,
+        sequence_parallel: bool = False,
     ):
         super().__init__()
         self.hc_mult = hc_mult
@@ -680,6 +681,9 @@ class ShortConv(nn.Module):
 
         if self.activation:
             self.act_fn = nn.SiLU()
+        # Set sequence_parallel to enable grad is correctly reduce across tensor_parallel_group.
+        for param in self.parameters():
+            param.sequence_parallel = sequence_parallel
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         """
@@ -747,6 +751,7 @@ class EngramModule(nn.Module):
             kernel_size=config.engram_kernel_size,
             dilation=config.max_ngram_size,
             hc_mult=self.hc_mult,
+            sequence_parallel=self.config.sequence_parallel,
         )
         engram_hidden_size = (
             config.max_ngram_size - 1
@@ -772,6 +777,9 @@ class EngramModule(nn.Module):
                 for _ in range(self.hc_mult)
             ]
         )
+        for module in [self.value_proj] + list(self.key_projs) + list(self.norm1) + list(self.norm2):
+            for param in module.parameters():
+                param.sequence_parallel = self.config.sequence_parallel
 
     def forward(self, hidden_states, hash_input_ids):
         """
@@ -805,6 +813,8 @@ class EngramModule(nn.Module):
         # Pre-compute scaling factor for efficiency
         scale = 1.0 / math.sqrt(self.config.hidden_size)
         gates = []
+        tp_rank = parallel_state.get_tensor_model_parallel_rank()
+        print(f"[TP rank {tp_rank}]: engram.norm1 = {self.norm1}, engram.norm2 = {self.norm2}")
         for hc_idx in range(self.hc_mult):
             key = self.key_projs[hc_idx](embeddings)
             # [L/tp_size, B, HIDDEN_SIZE]

--- a/megatron/core/transformer/transformer_config.py
+++ b/megatron/core/transformer/transformer_config.py
@@ -593,7 +593,7 @@ class TransformerConfig(ModelParallelConfig):
 
     recompute_modules: Optional[List[str]] = None
     """The submodules to recompute.
-    choices: "core_attn", "moe_act", "layernorm", "mla_up_proj", "mlp", "moe", "shared_experts".
+    choices: "core_attn", "moe_act", "layernorm", "mla_up_proj", "mlp", "moe", "shared_experts", "mhc".
     default: ["core_attn"].
     "core_attn": recompute the core attention part of the transformer layer.
     "moe_act": recompute the MoE MLP activation function.
@@ -602,6 +602,7 @@ class TransformerConfig(ModelParallelConfig):
     "mlp": recompute the dense MLP submodule.
     "moe": recompute the MoE layer.
     "shared_experts": recompute the shared experts in the MoE layer.
+    "mhc": recompute the hyper connection part of the transformer layer.
     "moe_act", "layernorm", and "mla_up_proj" use output-discarding checkpointing,
     "core_attn", "mlp", "moe", and "shared_experts" use normal checkpointing.
     """
@@ -1560,6 +1561,7 @@ class TransformerConfig(ModelParallelConfig):
                     "mlp",
                     "moe",
                     "shared_experts",
+                    "mhc",
                 }
                 invalid_modules = set(self.recompute_modules) - allowed_modules
                 assert not invalid_modules, (

--- a/megatron/core/transformer/transformer_config.py
+++ b/megatron/core/transformer/transformer_config.py
@@ -1260,6 +1260,7 @@ class TransformerConfig(ModelParallelConfig):
             )
 
             # Check tensor parallelism compatibility
+            tp_cp_size = self.tensor_model_parallel_size * self.context_parallel_size
             assert (
                 self.linear_num_key_heads % self.tensor_model_parallel_size == 0
             ), "linear_num_key_heads must be a multiple of tensor_model_parallel_size."

--- a/megatron/core/transformer/transformer_layer.py
+++ b/megatron/core/transformer/transformer_layer.py
@@ -1460,8 +1460,7 @@ class HyperConnectionTransformerLayer(TransformerLayer):
     def forward(self, *args, **kwargs):
         """Forward pass with MHC recompute manager support."""
         kwargs.pop("dynamic_inference_decode_only", None)
-
-        mhc_recompute_manager = getattr(self, '_mhc_recompute_manager', None)
+        mhc_recompute_manager = kwargs.pop("mhc_recompute_manager", None)
 
         hidden_states, context = self._forward_attention(
             *args, mhc_recompute_manager=mhc_recompute_manager, **kwargs

--- a/tests/unit_tests/models/test_mamba_moe_model.py
+++ b/tests/unit_tests/models/test_mamba_moe_model.py
@@ -240,6 +240,7 @@ GOLDEN_CONFIG: Dict[str, Any] = {
     "mhc_init_gating_factor": 0.01,
     "mhc_recompute_layer_num": None,
     "mhc_sinkhorn_iterations": 10,
+    "moe_mlp_glu_interleave_size": None,
     ##### FlagScale End #####
     "nccl_all_reduce_for_prefill": False,
     "no_rope_freq": None,


### PR DESCRIPTION
# Description
PR Description
Add compatibility between moe 1F1B overlap and MHC, while maintaining backward compatibility when MHC is disabled.

Deepseek v4 uses dualpipe to overlap moe ep communication. Megatron uses interleaved 1f1b to do same. MHC adds new operators in pipeline. And there exists incompatibility between moe 1f1b overlap and mhc.

This PR resolves the incompatibility between the two.

Correctness:
I ran two simple training jobs for validation. I used DeepSeek-V3 with MHC enabled, and toggled `overlap_moe_expert_parallel_comm` for testing. Since enabling this option only splits the computation graph for manual scheduling, the training loss should theoretically stay consistent either way.

The experimental results below show that the loss values are identical across 10 consecutive iterations, which confirms the correctness.
<img width="3125" height="1473" alt="image" src="https://github.com/user-attachments/assets/d094183f-c3d3-42d8-a090-d7d0776f7aeb" />

## NOTE
~When testing with DeepSeek-V4, inconsistent loss values were observed. While the results remain consistent in most steps, a slight deviation occurs after a certain operation, eventually leading to discrepancies in loss. This issue will be further investigated later~.  DONE.

## Type of change

- [ ✅] New feature (non-breaking change which adds functionality)
- [ ] Infra/Build change (changes to CI/CD workflows or build scripts)
- [ ] Code refactoring
- [ ] Documentation change
- [ ] Bug fix
- [ ] Breaking change

## Changes

- fine_grained_callables.py. Add mhc related operations in attn and moe forward sub-functions.
- model_chunk_schedule_plan.py. Add mhc related operations in transformer_block.
- transformer_config.py. Add choice "mhc" to recompute_modules.

## Checklist

- [] I have read and followed the contributing guidelines
- [ ] The functionality is complete
- [ ] I have commented my code, particularly in coverage report uploading steps
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added/updated tests that prove my feature works
- [ ] New and existing unit tests pass locally
