### PR TITLE
Add context parallel support for dsv4 sparse attention

### DIFF
--- a/megatron/core/model_parallel_config.py
+++ b/megatron/core/model_parallel_config.py
@@ -53,6 +53,12 @@ class ModelParallelConfig:
        type.
     """
 
+    cp_seq_split_mode: str = "2chunk"
+    """How to split the sequence across CP ranks.
+    '2chunk': Default Megatron pattern (front + tail chunks per rank for load balance).
+    'contiguous': Simple contiguous split (rank_i gets [i*chunk, (i+1)*chunk)).
+    """
+
     max_seqlen_per_dp_cp_rank: Optional[int] = None
     """
     Maximum sequence length per DPxCP rank. This is the maximum sequence length each rank

--- a/megatron/core/models/common/embeddings/rope_utils.py
+++ b/megatron/core/models/common/embeddings/rope_utils.py
@@ -77,6 +77,32 @@ def get_pos_emb_on_this_cp_rank(
     return pos_emb
 
 
+def get_pos_emb_on_this_cp_rank_contiguous(
+    pos_emb: Tensor, seq_dim: int, cp_group: torch.distributed.ProcessGroup
+) -> Tensor:
+    """Get the position embedding on the current CP rank (contiguous split).
+
+    Unlike get_pos_emb_on_this_cp_rank which uses 2-chunk pattern,
+    this uses simple contiguous split: rank_i gets [i*chunk, (i+1)*chunk).
+
+    Args:
+        pos_emb (Tensor): Positional embedding tensor
+        seq_dim (int): Sequence dimension
+        cp_group (torch.distributed.ProcessGroup): The context parallel group
+    """
+    if cp_group is None:
+        raise ValueError("cp_group must be provided to get positional embedding per CP rank")
+    cp_size = cp_group.size()
+    cp_rank = cp_group.rank()
+
+    seq_len = pos_emb.shape[seq_dim]
+    chunk_size = seq_len // cp_size
+    start = cp_rank * chunk_size
+    end = start + chunk_size
+
+    return pos_emb.narrow(seq_dim, start, chunk_size)
+
+
 def _rotate_half(x: Tensor, rotary_interleaved: bool) -> Tensor:
     """Change sign so the last dimension becomes [-odd, +even]
 

--- a/megatron/core/models/common/embeddings/rotary_pos_embedding.py
+++ b/megatron/core/models/common/embeddings/rotary_pos_embedding.py
@@ -26,6 +26,7 @@ from megatron.core.models.common.embeddings.rope_utils import (  # for backward 
     get_pos_emb_on_this_cp_rank,
 )
 from megatron.core.utils import deprecate_inference_params, internal_api
+
 # FlagScale Begin
 from megatron.plugin.platform import get_platform
 
@@ -271,7 +272,9 @@ class RotaryEmbedding(nn.Module):
                 rotary_seq_len = transformer_input.size(0)
 
             if transformer_config.sequence_parallel:
-                rotary_seq_len *= parallel_state.get_tensor_model_parallel_world_size()  # FlagScale Add
+                rotary_seq_len *= (
+                    parallel_state.get_tensor_model_parallel_world_size()
+                )  # FlagScale Add
 
         rotary_seq_len *= transformer_config.context_parallel_size
 
@@ -317,7 +320,9 @@ class MultimodalRotaryEmbedding(nn.Module):
         self.inv_freq = 1.0 / (
             rotary_base
             ** (
-                torch.arange(0, dim, 2, dtype=torch.float32, device=cur_platform.current_device())  # FlagScale Add
+                torch.arange(
+                    0, dim, 2, dtype=torch.float32, device=cur_platform.current_device()
+                )  # FlagScale Add
                 / dim
             )
         )

--- a/megatron/core/models/common/embeddings/rotary_pos_embedding.py
+++ b/megatron/core/models/common/embeddings/rotary_pos_embedding.py
@@ -187,6 +187,7 @@ class RotaryEmbedding(nn.Module):
         offset: int = 0,
         packed_seq: bool = False,
         cp_group: Optional[torch.distributed.ProcessGroup] = None,
+        contiguous_split: bool = False,
     ) -> Tensor:
         """Forward pass of RoPE embedding.
 
@@ -196,6 +197,8 @@ class RotaryEmbedding(nn.Module):
             packed_seq (bool, optional): Whether to use packed sequence. Defaults to False.
             cp_group (torch.distributed.ProcessGroup, optional): Context parallel group.
                 Defaults to None.
+            contiguous_split (bool, optional): Use contiguous CP split instead of 2-chunk.
+                Defaults to False.
 
         Returns:
             Tensor: Embeddings after applying RoPE.
@@ -206,7 +209,14 @@ class RotaryEmbedding(nn.Module):
         if cp_group is not None and cp_group.size() > 1 and not packed_seq:
             # slice rotary_pos_emb along sequence dimension
             # and select the parition of the current CP rank
-            emb = get_pos_emb_on_this_cp_rank(emb, 0, cp_group)
+            if contiguous_split:
+                from megatron.core.models.common.embeddings.rope_utils import (
+                    get_pos_emb_on_this_cp_rank_contiguous,
+                )
+
+                emb = get_pos_emb_on_this_cp_rank_contiguous(emb, 0, cp_group)
+            else:
+                emb = get_pos_emb_on_this_cp_rank(emb, 0, cp_group)
 
         return emb
 

--- a/megatron/core/models/common/embeddings/yarn_rotary_pos_embedding.py
+++ b/megatron/core/models/common/embeddings/yarn_rotary_pos_embedding.py
@@ -169,6 +169,7 @@ class YarnRotaryEmbedding(RotaryEmbedding):
         offset: int = 0,
         packed_seq: bool = False,
         cp_group: Optional[torch.distributed.ProcessGroup] = None,
+        contiguous_split: bool = False,
     ) -> Tensor:
         """Forward pass of Yarn Rotary Embedding.
 
@@ -178,6 +179,8 @@ class YarnRotaryEmbedding(RotaryEmbedding):
             packed_seq (bool, optional): Whether to use packed sequence. Defaults to False.
             cp_group (torch.distributed.ProcessGroup, optional): Context parallel group.
                 Defaults to None.
+            contiguous_split (bool, optional): Use contiguous CP split instead of 2-chunk.
+                Defaults to False.
 
         Returns:
             Tensor: Embeddings after applying Yarn RoPE.
@@ -188,7 +191,14 @@ class YarnRotaryEmbedding(RotaryEmbedding):
         if cp_group is not None and cp_group.size() > 1 and not packed_seq:
             # slice rotary_pos_emb along sequence dimension
             # and select the parition of the current CP rank
-            emb = get_pos_emb_on_this_cp_rank(emb, 0, cp_group)
+            if contiguous_split:
+                from megatron.core.models.common.embeddings.rope_utils import (
+                    get_pos_emb_on_this_cp_rank_contiguous,
+                )
+
+                emb = get_pos_emb_on_this_cp_rank_contiguous(emb, 0, cp_group)
+            else:
+                emb = get_pos_emb_on_this_cp_rank(emb, 0, cp_group)
         return emb, _mscale
 
     def _set_cos_sin_cache(self, seq_len, offset, dtype, packed_seq=False):

--- a/megatron/core/transformer/experimental_attention_variant/csa.py
+++ b/megatron/core/transformer/experimental_attention_variant/csa.py
@@ -1,7 +1,6 @@
 # Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
 
 import copy
-import logging
 from dataclasses import dataclass
 from functools import lru_cache
 from typing import Optional, Tuple, Union
@@ -30,8 +29,6 @@ from megatron.core.transformer.module import MegatronModule
 from megatron.core.transformer.spec_utils import ModuleSpec, build_module
 from megatron.core.transformer.transformer_config import TransformerConfig
 from megatron.core.utils import nvtx_range_pop, nvtx_range_push
-
-logger = logging.getLogger(__name__)
 
 # ---------------------------------------------------------------------------
 # Helper functions for index computation
@@ -354,23 +351,17 @@ class Compressor(MegatronModule):
         new_tensor[1:, :ratio] = tensor[:-1, :, :, :d]
         return new_tensor
 
-    def forward(self, x: torch.Tensor) -> Optional[torch.Tensor]:
-        """Compress hidden states into shorter KV sequence.
+    def compress_local(self, x: torch.Tensor) -> Optional[torch.Tensor]:
+        """Halo exchange + local compression + RoPE. Returns local compressed KV.
 
-        When CP is active (cp_size > 1), this method internally handles:
-        1. Halo exchange (prepend boundary tokens from previous rank)
-        2. Local compression (discard halo group to avoid duplicates)
-        3. All-gather across CP ranks to produce the global compressed sequence
+        This is everything before the all-gather step.
 
         Args:
             x: [sq, b, hidden_size] — local hidden states (without halo).
 
         Returns:
-            cp_size == 1: [sq // ratio, b, head_dim] or None if too short.
-            cp_size > 1:  [n_compressed_global, b, head_dim] or None if too short.
+            [n_local_compressed, b, head_dim] or None if too short.
         """
-        nvtx_range_push("compressor")
-
         sq, b, _ = x.size()
         ratio = self.compress_ratio
         cp_group = self.pg_collection.cp
@@ -378,60 +369,69 @@ class Compressor(MegatronModule):
         cp_rank = cp_group.rank()
 
         # --- CP Step 1: Halo exchange for compression boundary ---
-        _rank = torch.distributed.get_rank()
         has_halo = False
         if cp_size > 1:
             need_halo = self.overlap or (sq % ratio != 0)
             if need_halo:
-                logger.debug(
-                    f"[rank {_rank}] Compressor(ratio={ratio}): "
-                    f"before halo exchange, x.shape={x.shape}"
-                )
                 x = _exchange_halo(x, ratio, cp_group)
-                logger.debug(
-                    f"[rank {_rank}] Compressor(ratio={ratio}): "
-                    f"after halo exchange, x.shape={x.shape}"
-                )
                 if cp_rank > 0:
                     has_halo = True
 
         sq_with_halo = x.size(0)
 
         if sq_with_halo < ratio:
-            nvtx_range_pop("compressor")
             return None
 
         # --- Core compression ---
-        kv, _ = self.linear_wkv(x)  # [sq_with_halo, b, coff * head_dim]
-        score, _ = self.linear_wgate(x)  # [sq_with_halo, b, coff * head_dim]
+        if self.config.enable_fused_compressor:
+            # Phase 1: Fuse two GEMMs into one
+            import torch.nn.functional as F
+            W_fused = torch.cat([self.linear_wkv.weight, self.linear_wgate.weight], dim=0)
+            kv_score = F.linear(x, W_fused)
+            proj_out_dim = self.coff * self.head_dim
+            kv, score = kv_score.split(proj_out_dim, dim=-1)
 
-        cutoff = (sq_with_halo // ratio) * ratio
-        if cutoff < sq_with_halo:
-            kv = kv[:cutoff]
-            score = score[:cutoff]
+            # Phase 2: Fused Triton kernel
+            from megatron.core.transformer.experimental_attention_variant.fused_compressor_kernel import (
+                fused_compressor_post_gemm,
+            )
+            norm_weight = self.norm.weight
+            kv = fused_compressor_post_gemm(
+                kv, score, self.ape, norm_weight,
+                ratio=ratio,
+                head_dim=self.head_dim,
+                has_halo=has_halo,
+                use_overlap=self.overlap,
+                eps=self.config.layernorm_epsilon,
+            )
+            n_compressed = kv.size(0)
+        else:
+            kv, _ = self.linear_wkv(x)
+            score, _ = self.linear_wgate(x)
 
-        n_compressed = cutoff // ratio
+            cutoff = (sq_with_halo // ratio) * ratio
+            if cutoff < sq_with_halo:
+                kv = kv[:cutoff]
+                score = score[:cutoff]
 
-        # Reshape: [n_compressed, ratio, b, coff * head_dim]
-        kv = kv.view(n_compressed, ratio, b, -1)
-        score = score.view(n_compressed, ratio, b, -1)
+            n_compressed = cutoff // ratio
 
-        # APE: [ratio, coff * head_dim] -> [1, ratio, 1, coff * head_dim]
-        score = score + self.ape.view(1, ratio, 1, -1)
+            kv = kv.view(n_compressed, ratio, b, -1)
+            score = score.view(n_compressed, ratio, b, -1)
 
-        if self.overlap:
-            kv = self._overlap_transform(kv, fill_value=0)
-            score = self._overlap_transform(score, fill_value=float("-inf"))
+            score = score + self.ape.view(1, ratio, 1, -1)
 
-        kv = (kv * torch.softmax(score, dim=1)).sum(dim=1)  # [n_compressed, b, head_dim]
+            if self.overlap:
+                kv = self._overlap_transform(kv, fill_value=0)
+                score = self._overlap_transform(score, fill_value=float("-inf"))
 
-        # Discard halo group: it only served as overlap context for group 1.
-        # The same tokens are already compressed by the previous rank.
-        if has_halo:
-            kv = kv[1:]
-            n_compressed = n_compressed - 1
+            kv = (kv * torch.softmax(score, dim=1)).sum(dim=1)
 
-        kv = self.norm(kv.to(x.dtype))
+            if has_halo:
+                kv = kv[1:]
+                n_compressed = n_compressed - 1
+
+            kv = self.norm(kv.to(x.dtype))
 
         kv = _apply_rope(
             kv,
@@ -447,17 +447,44 @@ class Compressor(MegatronModule):
         if self.rotate:
             kv = rotate_activation(kv)
 
-        # --- CP Step 2: All-gather to produce global compressed sequence ---
+        return kv
+
+    def forward(self, x: torch.Tensor, async_allgather: bool = False) -> Optional[torch.Tensor]:
+        """Compress hidden states into shorter KV sequence.
+
+        When CP is active (cp_size > 1), this method internally handles:
+        1. Halo exchange (prepend boundary tokens from previous rank)
+        2. Local compression (discard halo group to avoid duplicates)
+        3. All-gather across CP ranks to produce the global compressed sequence
+
+        Args:
+            x: [sq, b, hidden_size] — local hidden states (without halo).
+            async_allgather: If True, launch all-gather asynchronously.
+                Caller must call async_differentiable_all_gather_wait() before
+                reading the returned tensor.
+
+        Returns:
+            cp_size == 1: [sq // ratio, b, head_dim] or None if too short.
+            cp_size > 1:  [n_compressed_global, b, head_dim] or None if too short.
+        """
+        nvtx_range_push("compressor")
+
+        kv = self.compress_local(x)
+        if kv is None:
+            nvtx_range_pop("compressor")
+            return None
+
+        cp_group = self.pg_collection.cp
+        cp_size = cp_group.size()
+
         if cp_size > 1:
-            logger.debug(
-                f"[rank {_rank}] Compressor(ratio={ratio}): "
-                f"before all-gather, kv.shape={kv.shape}, expected_local={sq // ratio}"
-            )
-            kv = differentiable_all_gather(kv, cp_group)
-            logger.debug(
-                f"[rank {_rank}] Compressor(ratio={ratio}): "
-                f"after all-gather, kv.shape={kv.shape}"
-            )
+            if async_allgather:
+                from megatron.core.transformer.experimental_attention_variant.csa_utils import (
+                    async_differentiable_all_gather_start,
+                )
+                kv = async_differentiable_all_gather_start(kv, cp_group)
+            else:
+                kv = differentiable_all_gather(kv, cp_group)
 
         nvtx_range_pop("compressor")
         return kv
@@ -575,10 +602,19 @@ class CSAIndexer(MegatronModule):
         q = rotate_activation(q)
 
         # K path: own compressor
-        k = self.compressor(x)  # [sq//ratio, b, index_head_dim]
-
-        weights, _ = self.linear_weights_proj(x)  # [sq, b, n_heads]
-        weights = weights * (self.index_n_heads**-0.5)
+        if self.config.enable_compressor_allgather_overlap and self.pg_collection.cp.size() > 1:
+            k = self.compressor(x, async_allgather=True)
+            # Overlap: weights projection runs while all-gather is in flight
+            weights, _ = self.linear_weights_proj(x)  # [sq, b, n_heads]
+            weights = weights * (self.index_n_heads**-0.5)
+            from megatron.core.transformer.experimental_attention_variant.csa_utils import (
+                async_differentiable_all_gather_wait,
+            )
+            async_differentiable_all_gather_wait()
+        else:
+            k = self.compressor(x)  # [sq//ratio, b, index_head_dim]
+            weights, _ = self.linear_weights_proj(x)  # [sq, b, n_heads]
+            weights = weights * (self.index_n_heads**-0.5)
 
         nvtx_range_pop("indexer_before_topk")
         return q, k, weights
@@ -729,41 +765,18 @@ class CompressedSparseAttention(MegatronModule):
 
         cp_size = self.pg_collection.cp.size()
         cp_rank = self.pg_collection.cp.rank()
-        _rank = torch.distributed.get_rank()
-
-        logger.debug(
-            f"[rank {_rank}] CSA Layer {self.layer_number} START: "
-            f"query.shape={query.shape}, key.shape={key.shape}, "
-            f"x.shape={x.shape if x is not None else None}, "
-            f"cp_size={cp_size}, cp_rank={cp_rank}"
-        )
 
         # --- Step 1: Prepare single-head KV (squeeze singleton head dim) ---
         kv = key.squeeze(-2)  # [sq, b, 1, v_head_dim] -> [sq, b, v_head_dim]
-        logger.debug(
-            f"[rank {_rank}] CSA Layer {self.layer_number} Step 1 done: kv.shape={kv.shape}"
-        )
 
         # --- Step 2: Halo exchange for sliding window (CP only) ---
         if cp_size > 1:
             halo_size = self.window_size - 1 if cp_rank > 0 else 0
-            logger.debug(
-                f"[rank {_rank}] CSA Layer {self.layer_number} Step 2: "
-                f"before halo exchange, halo_size={halo_size}"
-            )
             kv = _exchange_halo(kv, self.window_size - 1, self.pg_collection.cp, name="kv")
-            logger.debug(
-                f"[rank {_rank}] CSA Layer {self.layer_number} Step 2 done: "
-                f"after halo exchange, kv.shape={kv.shape}"
-            )
         else:
             halo_size = 0
 
         # --- Step 3: Compression ---
-        logger.debug(
-            f"[rank {_rank}] CSA Layer {self.layer_number} Step 3: "
-            f"starting compression, compress_ratio={self.compress_ratio}"
-        )
         if self.compressor is not None and self.compress_ratio > 1:
             compressed_kv = self.compressor(x)
             if compressed_kv is not None:
@@ -777,20 +790,12 @@ class CompressedSparseAttention(MegatronModule):
             n_compressed = 0
 
         offset = sq + halo_size  # compressed indices start after halo + original positions
-        logger.debug(
-            f"[rank {_rank}] CSA Layer {self.layer_number} Step 3 done: "
-            f"kv_full.shape={kv_full.shape}, n_compressed={n_compressed}, offset={offset}"
-        )
 
         # --- Step 4: Window indices ---
         if halo_size > 0:
             window_idxs = get_window_topk_idxs_cp(self.window_size, b, sq, halo_size, query.device)
         else:
             window_idxs = get_window_topk_idxs(self.window_size, b, sq, query.device)
-        logger.debug(
-            f"[rank {_rank}] CSA Layer {self.layer_number} Step 4 done: "
-            f"window_idxs.shape={window_idxs.shape}"
-        )
 
         # --- Step 5: Compressed indices ---
         indexer_loss = None
@@ -826,19 +831,9 @@ class CompressedSparseAttention(MegatronModule):
                         b, -1, -1
                     )  # [b, sq, n_compressed]
 
-                    logger.debug(
-                        f"[rank {_rank}] CSA Layer {self.layer_number} Step 5: "
-                        f"causal_mask built, calling indexer.forward_before_topk"
-                    )
-
                     if self.training and torch.is_grad_enabled():
                         q_indexer, k_indexer, weights_indexer = self.indexer.forward_before_topk(
                             x_det, qr_det, packed_seq_params
-                        )
-                        logger.debug(
-                            f"[rank {_rank}] CSA Layer {self.layer_number} Step 5: "
-                            f"forward_before_topk done, q_indexer.shape={q_indexer.shape}, "
-                            f"k_indexer.shape={k_indexer.shape}"
                         )
                         indexer_loss_coeff = getattr(self.config, 'dsa_indexer_loss_coeff', 0.0)
                         # compressed_kv is [n, b, hn]; expand to [n, b, np, hn] for loss
@@ -848,10 +843,6 @@ class CompressedSparseAttention(MegatronModule):
                         # weights-scaling trick so the effective weights match
                         # the pre-scale-split behaviour.
                         weights_for_unfused = weights_indexer * self.indexer.softmax_scale
-                        logger.debug(
-                            f"[rank {_rank}] CSA Layer {self.layer_number} Step 5: "
-                            f"calling FusedDSAIndexerLoss"
-                        )
                         topk_indices_compressed, indexer_loss = FusedDSAIndexerLoss.apply(
                             q_indexer,
                             weights_for_unfused,
@@ -864,11 +855,6 @@ class CompressedSparseAttention(MegatronModule):
                             causal_mask,
                             getattr(self.config, "dsa_indexer_use_sparse_loss", True),
                             self.indexer.pg_collection,
-                        )
-                        logger.debug(
-                            f"[rank {_rank}] CSA Layer {self.layer_number} Step 5: "
-                            f"FusedDSAIndexerLoss done, "
-                            f"topk_indices_compressed.shape={topk_indices_compressed.shape}"
                         )
                         if indexer_loss_coeff > 0:
                             DSAIndexerLossLoggingHelper.save_loss_to_tracker(
@@ -883,8 +869,11 @@ class CompressedSparseAttention(MegatronModule):
 
                     n_valid_per_pos = global_positions // self.compress_ratio  # [sq, 1]
                     valid = topk_indices_compressed < n_valid_per_pos
+                    # compress_topk_idxs = torch.where(
+                    #     valid, topk_indices_compressed + offset, torch.tensor(-1, device="cuda")
+                    # )
                     compress_topk_idxs = torch.where(
-                        valid, topk_indices_compressed + offset, torch.tensor(-1, device=x.device)
+                        valid, topk_indices_compressed + offset, -1
                     )
                 else:
                     if cp_size > 1:
@@ -906,12 +895,6 @@ class CompressedSparseAttention(MegatronModule):
                 topk_idxs = window_idxs
 
             topk_idxs = topk_idxs.int()
-            logger.debug(
-                f"[rank {_rank}] CSA Layer {self.layer_number} Step 5 done: "
-                f"topk_idxs.shape={topk_idxs.shape}, "
-                f"topk_idxs.min()={topk_idxs.min().item()}, "
-                f"topk_idxs.max()={topk_idxs.max().item()}"
-            )
 
             # --- Step 6: Sparse attention ---
             nvtx_range_push("sparse_attn_kernel")
@@ -919,10 +902,6 @@ class CompressedSparseAttention(MegatronModule):
                 query, kv_full, self.attn_sink.float(), topk_idxs, self.softmax_scale
             )
             nvtx_range_pop("sparse_attn_kernel")
-            logger.debug(
-                f"[rank {_rank}] CSA Layer {self.layer_number} Step 6 done: "
-                f"output.shape={output.shape}"
-            )
 
         else:
             raise ValueError("Fused path is not supported for CompressedSparseAttention")

--- a/megatron/core/transformer/experimental_attention_variant/csa.py
+++ b/megatron/core/transformer/experimental_attention_variant/csa.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
 
 import copy
+import logging
 from dataclasses import dataclass
 from functools import lru_cache
 from typing import Optional, Tuple, Union
@@ -13,6 +14,11 @@ from megatron.core.models.common.embeddings import RotaryEmbedding, apply_rotary
 from megatron.core.packed_seq_params import PackedSeqParams
 from megatron.core.process_groups_config import ProcessGroupCollection
 from megatron.core.transformer.enums import AttnMaskType
+from megatron.core.transformer.experimental_attention_variant.csa_utils import (
+    _exchange_halo,
+    differentiable_all_gather,
+    get_window_topk_idxs_cp,
+)
 from megatron.core.transformer.experimental_attention_variant.dsa import (
     DSAIndexerLossAutoScaler,
     DSAIndexerLossLoggingHelper,
@@ -24,6 +30,8 @@ from megatron.core.transformer.module import MegatronModule
 from megatron.core.transformer.spec_utils import ModuleSpec, build_module
 from megatron.core.transformer.transformer_config import TransformerConfig
 from megatron.core.utils import nvtx_range_pop, nvtx_range_push
+
+logger = logging.getLogger(__name__)
 
 # ---------------------------------------------------------------------------
 # Helper functions for index computation
@@ -79,95 +87,6 @@ def get_compress_topk_idxs(
 
 
 # ---------------------------------------------------------------------------
-# Helper functions for Context Parallel (sliding window halo exchange)
-# ---------------------------------------------------------------------------
-
-
-def _exchange_kv_halo(
-    kv: torch.Tensor,
-    halo_size: int,
-    cp_group: torch.distributed.ProcessGroup,
-) -> torch.Tensor:
-    """P2P halo exchange for sliding window attention with context parallelism.
-
-    Each rank sends its last `halo_size` KV tokens to the next rank, and receives
-    `halo_size` tokens from the previous rank to prepend to its local KV.
-
-    Args:
-        kv: [local_seq, b, hn] local KV tensor.
-        halo_size: number of tokens to exchange (typically window_size - 1).
-        cp_group: context parallel process group.
-
-    Returns:
-        kv_with_halo: [halo_size + local_seq, b, hn] for rank > 0,
-                      [local_seq, b, hn] for rank 0 (no halo needed).
-    """
-    cp_rank = cp_group.rank()
-    cp_size = cp_group.size()
-
-    if cp_size == 1:
-        return kv
-
-    global_ranks = torch.distributed.get_process_group_ranks(cp_group)
-    prev_rank = global_ranks[(cp_rank - 1) % cp_size]
-    next_rank = global_ranks[(cp_rank + 1) % cp_size]
-
-    send_buf = kv[-halo_size:].contiguous()
-    recv_buf = torch.empty_like(send_buf)
-
-    ops = []
-    if cp_rank < cp_size - 1:
-        ops.append(torch.distributed.isend(send_buf, dst=next_rank, group=cp_group))
-    if cp_rank > 0:
-        ops.append(torch.distributed.irecv(recv_buf, src=prev_rank, group=cp_group))
-
-    for op in ops:
-        op.wait()
-
-    print(f"[CSA CP] _exchange_kv_halo done: rank={cp_rank}, "
-          f"send_to={next_rank if cp_rank < cp_size - 1 else 'None'}, "
-          f"recv_from={prev_rank if cp_rank > 0 else 'None'}, "
-          f"halo_size={halo_size}")
-
-    if cp_rank == 0:
-        return kv
-    else:
-        return torch.cat([recv_buf, kv], dim=0)
-
-
-@lru_cache(maxsize=8)
-def _get_window_topk_idxs_cp_cached(
-    window_size: int, local_seq_len: int, halo_size: int, device_str: str
-) -> torch.Tensor:
-    """Compute sliding-window indices with halo offset for CP (cached).
-
-    KV layout after halo exchange: [halo(halo_size) | local(local_seq_len)]
-    For local query position i, its position in kv_with_halo is i + halo_size.
-    Its window covers [i + halo_size - window_size + 1, i + halo_size].
-
-    Returns:
-        indices: [local_seq_len, window_size] int tensor, -1 for invalid positions.
-    """
-    base = torch.arange(local_seq_len, device=device_str).unsqueeze(1) + halo_size
-    offsets = torch.arange(window_size, device=device_str)
-    matrix = (base - window_size + 1).clamp(min=0) + offsets
-    matrix = torch.where(matrix > base, -1, matrix)
-    return matrix
-
-
-def get_window_topk_idxs_cp(
-    window_size: int,
-    batch_size: int,
-    local_seq_len: int,
-    halo_size: int,
-    device: torch.device,
-) -> torch.Tensor:
-    """Sliding-window indices with CP halo offset [batch, local_seq_len, window_size]."""
-    matrix = _get_window_topk_idxs_cp_cached(window_size, local_seq_len, halo_size, str(device))
-    return matrix.unsqueeze(0).expand(batch_size, -1, -1)
-
-
-# ---------------------------------------------------------------------------
 # Helper functions for RoPE
 # ---------------------------------------------------------------------------
 
@@ -192,11 +111,20 @@ def _apply_rope(
         total_seq_len = rotary_seq_len
     else:
         total_seq_len = rotary_seq_len * ratio
+
+    contiguous_split = getattr(config, 'cp_seq_split_mode', '2chunk') == 'contiguous'
+    # When CP is enabled, rotary_pos_emb_module.forward() will slice the emb internally,
+    # so we need to pass the full sequence length (local * cp_size).
+    if cp_group is not None and cp_group.size() > 1:
+        total_seq_len = total_seq_len * cp_group.size()
+
     mscale = 1.0
     rotary_pos_cos = None
     rotary_pos_sin = None
     if config.rope_type == "rope":
-        rotary_pos_emb = rotary_pos_emb_module(total_seq_len, packed_seq=False)
+        rotary_pos_emb = rotary_pos_emb_module(
+            total_seq_len, packed_seq=False, contiguous_split=contiguous_split
+        )
         mscale = 1.0
     else:
         if config.apply_rope_fusion:
@@ -208,17 +136,19 @@ def _apply_rope(
                 fused_mla_rope_inplace is not None
             ), "Fused MLA RoPE apply is not imported successfully"
         else:
-            rotary_pos_emb, mscale = rotary_pos_emb_module(total_seq_len, packed_seq=False)
+            rotary_pos_emb, mscale = rotary_pos_emb_module(
+                total_seq_len, packed_seq=False, contiguous_split=contiguous_split
+            )
             # DSv4 reference (DS-Inf) RoPE is pure rotation (norm-preserving). Yarn's
             # concentration factor (mscale) is NOT part of the DSv4 model contract --
             # the model relies on Q/KV RMS-norm + unit-magnitude rotation. Force 1.0.
             mscale = 1.0
     if rotary_pos_emb is not None and ratio > 1:
-        rotary_pos_emb = rotary_pos_emb[:total_seq_len:ratio][:rotary_seq_len]
+        rotary_pos_emb = rotary_pos_emb[::ratio][:rotary_seq_len]
     if rotary_pos_cos is not None and ratio > 1:
-        rotary_pos_cos = rotary_pos_cos[:total_seq_len:ratio][:rotary_seq_len]
+        rotary_pos_cos = rotary_pos_cos[::ratio][:rotary_seq_len]
     if rotary_pos_sin is not None and ratio > 1:
-        rotary_pos_sin = rotary_pos_sin[:total_seq_len:ratio][:rotary_seq_len]
+        rotary_pos_sin = rotary_pos_sin[::ratio][:rotary_seq_len]
 
     squeeze_head = x.dim() == 3
     if squeeze_head:
@@ -752,26 +682,114 @@ class CompressedSparseAttention(MegatronModule):
         cp_size = self.pg_collection.cp.size()
         cp_rank = self.pg_collection.cp.rank()
 
+        if torch.distributed.get_rank() == 0:
+            logger.debug(
+                f"\n[CSA CP DEBUG] Layer {self.layer_number} START: "
+                f"query.shape={query.shape}, key.shape={key.shape}, "
+                f"x.shape={x.shape if x is not None else None}"
+            )
+
         # --- Step 1: Prepare single-head KV (squeeze singleton head dim) ---
         kv = key.squeeze(-2)  # [sq, b, 1, v_head_dim] -> [sq, b, v_head_dim]
+        if torch.distributed.get_rank() == 0:
+            logger.debug(f"[CSA CP DEBUG] Layer {self.layer_number} Step 1: kv.shape={kv.shape}")
 
         # --- Step 2: Halo exchange for sliding window (CP only) ---
         if cp_size > 1:
             halo_size = self.window_size - 1 if cp_rank > 0 else 0
             if torch.distributed.get_rank() == 0:
-                print(f"[CSA CP] Layer {self.layer_number}: cp_size={cp_size}, cp_rank={cp_rank}, "
-                      f"halo_size={halo_size}, window_size={self.window_size}, "
-                      f"compress_ratio={self.compress_ratio}, kv.shape={kv.shape}")
-            kv = _exchange_kv_halo(kv, self.window_size - 1, self.pg_collection.cp)
+                logger.debug(
+                    f"[CSA CP] Layer {self.layer_number}: cp_size={cp_size}, cp_rank={cp_rank}, "
+                    f"halo_size={halo_size}, window_size={self.window_size}, "
+                    f"compress_ratio={self.compress_ratio}, kv.shape={kv.shape}"
+                )
+            kv = _exchange_halo(kv, self.window_size - 1, self.pg_collection.cp, name="kv")
             if torch.distributed.get_rank() == 0:
-                print(f"[CSA CP] Layer {self.layer_number}: after halo exchange, kv.shape={kv.shape}")
+                logger.debug(
+                    f"[CSA CP] Layer {self.layer_number}: after halo exchange, kv.shape={kv.shape}"
+                )
         else:
             halo_size = 0
 
         # --- Step 3: Compression ---
         if self.compressor is not None and self.compress_ratio > 1:
-            compressed_kv = self.compressor(x)  # [n_compressed, b, v_head_dim]
-            if compressed_kv is not None:
+            # CP: exchange hidden_states halo for compression boundary handling.
+            # For non-overlap (ratio=128, HCA): halo needed only if sq % ratio != 0.
+            # For overlap (ratio=4, CSA): halo needed for _overlap_transform cross-boundary.
+            x_for_compression = x
+            if cp_size > 1 and cp_rank > 0:
+                need_compression_halo = self.compressor.overlap or (sq % self.compress_ratio != 0)
+                if need_compression_halo:
+                    compression_halo_size = self.compress_ratio
+                    if torch.distributed.get_rank() == 0:
+                        logger.debug(
+                            f"[CSA CP] Layer {self.layer_number}: compression halo exchange, "
+                            f"halo_size={compression_halo_size}, overlap={self.compressor.overlap}"
+                        )
+                    x_for_compression = _exchange_halo(
+                        x, compression_halo_size, self.pg_collection.cp, name="hidden_states"
+                    )
+
+            compressed_kv = self.compressor(
+                x_for_compression
+            )  # [n_compressed_local, b, v_head_dim]
+            if compressed_kv is not None and cp_size > 1:
+                # Pad to uniform length (sq // ratio + 1) for all-gather
+                uniform_len = sq // self.compress_ratio + 1
+                n_local = compressed_kv.size(0)
+                if torch.distributed.get_rank() == 0:
+                    logger.debug(
+                        f"[CSA CP] Layer {self.layer_number}: compressed n_local={n_local}, "
+                        f"uniform_len={uniform_len}"
+                    )
+                if n_local < uniform_len:
+                    pad = torch.zeros(
+                        uniform_len - n_local,
+                        *compressed_kv.shape[1:],
+                        device=compressed_kv.device,
+                        dtype=compressed_kv.dtype,
+                    )
+                    compressed_kv_padded = torch.cat([compressed_kv, pad], dim=0)
+                else:
+                    compressed_kv_padded = compressed_kv[:uniform_len]
+
+                # All-gather padded compressed KV from all ranks (differentiable)
+                gathered_full = differentiable_all_gather(
+                    compressed_kv_padded, self.pg_collection.cp
+                )
+                # Split back into list for select-and-pad logic
+                gathered_list = list(torch.split(gathered_full, uniform_len, dim=0))
+
+                # Select-and-Pad: reorder valid tokens, move padding to tail
+                # Each rank has n_valid tokens followed by padding.
+                # Rank 0: n_valid = n_local (no halo, may be sq//ratio)
+                # Rank i>0 with halo: n_valid = n_local (may be sq//ratio + 1)
+                # Collect valid tokens in global order, pad at the end.
+                valid_tokens = []
+                for i in range(cp_size):
+                    chunk = gathered_list[i]
+                    # Determine how many valid tokens this rank produced
+                    if i == 0:
+                        n_valid_i = sq // self.compress_ratio
+                    else:
+                        # With halo: (compression_halo + sq) // ratio
+                        if self.compressor.overlap or (sq % self.compress_ratio != 0):
+                            n_valid_i = (self.compress_ratio + sq) // self.compress_ratio
+                        else:
+                            n_valid_i = sq // self.compress_ratio
+                    valid_tokens.append(chunk[:n_valid_i])
+                compressed_kv = torch.cat(
+                    valid_tokens, dim=0
+                )  # [n_compressed_global, b, v_head_dim]
+                if torch.distributed.get_rank() == 0:
+                    logger.debug(
+                        f"[CSA CP] Layer {self.layer_number}: after select-and-pad, "
+                        f"compressed_kv.shape={compressed_kv.shape}"
+                    )
+
+                kv_full = torch.cat([kv, compressed_kv], dim=0)
+                n_compressed = compressed_kv.size(0)
+            elif compressed_kv is not None:
                 kv_full = torch.cat([kv, compressed_kv], dim=0)
                 n_compressed = compressed_kv.size(0)
             else:
@@ -782,17 +800,22 @@ class CompressedSparseAttention(MegatronModule):
             n_compressed = 0
 
         offset = sq + halo_size  # compressed indices start after halo + original positions
+        if torch.distributed.get_rank() == 0:
+            logger.debug(
+                f"[CSA CP DEBUG] Layer {self.layer_number} Step 3 done: "
+                f"kv_full.shape={kv_full.shape}, n_compressed={n_compressed}, offset={offset}"
+            )
 
         # --- Step 4: Window indices ---
         if halo_size > 0:
-            window_idxs = get_window_topk_idxs_cp(
-                self.window_size, b, sq, halo_size, query.device
-            )
-            if torch.distributed.get_rank() == 0:
-                print(f"[CSA CP] Layer {self.layer_number}: using CP window indices, "
-                      f"window_idxs.shape={window_idxs.shape}, offset={offset}")
+            window_idxs = get_window_topk_idxs_cp(self.window_size, b, sq, halo_size, query.device)
         else:
             window_idxs = get_window_topk_idxs(self.window_size, b, sq, query.device)
+        if torch.distributed.get_rank() == 0:
+            logger.debug(
+                f"[CSA CP DEBUG] Layer {self.layer_number} Step 4: "
+                f"window_idxs.shape={window_idxs.shape}"
+            )
 
         # --- Step 5: Compressed indices ---
         indexer_loss = None
@@ -858,9 +881,18 @@ class CompressedSparseAttention(MegatronModule):
                         valid, topk_indices_compressed + offset, torch.tensor(-1, device=x.device)
                     )
                 else:
-                    compress_topk_idxs = get_compress_topk_idxs(
-                        self.compress_ratio, b, sq, offset, query.device
-                    )
+                    if cp_size > 1:
+                        # Use global seq len and slice current rank's rows
+                        global_seq_len = sq * cp_size
+                        all_idxs = get_compress_topk_idxs(
+                            self.compress_ratio, b, global_seq_len, offset, query.device
+                        )
+                        start = cp_rank * sq
+                        compress_topk_idxs = all_idxs[:, start : start + sq, :]
+                    else:
+                        compress_topk_idxs = get_compress_topk_idxs(
+                            self.compress_ratio, b, sq, offset, query.device
+                        )
 
                 topk_idxs = torch.cat([window_idxs, compress_topk_idxs], dim=-1)
                 nvtx_range_pop("compressed_indices")
@@ -868,6 +900,13 @@ class CompressedSparseAttention(MegatronModule):
                 topk_idxs = window_idxs
 
             topk_idxs = topk_idxs.int()
+            if torch.distributed.get_rank() == 0:
+                logger.debug(
+                    f"[CSA CP DEBUG] Layer {self.layer_number} Step 5: "
+                    f"topk_idxs.shape={topk_idxs.shape}, "
+                    f"topk_idxs.min()={topk_idxs.min().item()}, "
+                    f" topk_idxs.max()={topk_idxs.max().item()}"
+                )
 
             # --- Step 6: Sparse attention ---
             nvtx_range_push("sparse_attn_kernel")
@@ -875,6 +914,11 @@ class CompressedSparseAttention(MegatronModule):
                 query, kv_full, self.attn_sink.float(), topk_idxs, self.softmax_scale
             )
             nvtx_range_pop("sparse_attn_kernel")
+            if torch.distributed.get_rank() == 0:
+                logger.debug(
+                    f"[CSA CP DEBUG] Layer {self.layer_number} Step 6: "
+                    f"output.shape={output.shape}\n"
+                )
 
         else:
             raise ValueError("Fused path is not supported for CompressedSparseAttention")

--- a/megatron/core/transformer/experimental_attention_variant/csa.py
+++ b/megatron/core/transformer/experimental_attention_variant/csa.py
@@ -79,6 +79,95 @@ def get_compress_topk_idxs(
 
 
 # ---------------------------------------------------------------------------
+# Helper functions for Context Parallel (sliding window halo exchange)
+# ---------------------------------------------------------------------------
+
+
+def _exchange_kv_halo(
+    kv: torch.Tensor,
+    halo_size: int,
+    cp_group: torch.distributed.ProcessGroup,
+) -> torch.Tensor:
+    """P2P halo exchange for sliding window attention with context parallelism.
+
+    Each rank sends its last `halo_size` KV tokens to the next rank, and receives
+    `halo_size` tokens from the previous rank to prepend to its local KV.
+
+    Args:
+        kv: [local_seq, b, hn] local KV tensor.
+        halo_size: number of tokens to exchange (typically window_size - 1).
+        cp_group: context parallel process group.
+
+    Returns:
+        kv_with_halo: [halo_size + local_seq, b, hn] for rank > 0,
+                      [local_seq, b, hn] for rank 0 (no halo needed).
+    """
+    cp_rank = cp_group.rank()
+    cp_size = cp_group.size()
+
+    if cp_size == 1:
+        return kv
+
+    global_ranks = torch.distributed.get_process_group_ranks(cp_group)
+    prev_rank = global_ranks[(cp_rank - 1) % cp_size]
+    next_rank = global_ranks[(cp_rank + 1) % cp_size]
+
+    send_buf = kv[-halo_size:].contiguous()
+    recv_buf = torch.empty_like(send_buf)
+
+    ops = []
+    if cp_rank < cp_size - 1:
+        ops.append(torch.distributed.isend(send_buf, dst=next_rank, group=cp_group))
+    if cp_rank > 0:
+        ops.append(torch.distributed.irecv(recv_buf, src=prev_rank, group=cp_group))
+
+    for op in ops:
+        op.wait()
+
+    print(f"[CSA CP] _exchange_kv_halo done: rank={cp_rank}, "
+          f"send_to={next_rank if cp_rank < cp_size - 1 else 'None'}, "
+          f"recv_from={prev_rank if cp_rank > 0 else 'None'}, "
+          f"halo_size={halo_size}")
+
+    if cp_rank == 0:
+        return kv
+    else:
+        return torch.cat([recv_buf, kv], dim=0)
+
+
+@lru_cache(maxsize=8)
+def _get_window_topk_idxs_cp_cached(
+    window_size: int, local_seq_len: int, halo_size: int, device_str: str
+) -> torch.Tensor:
+    """Compute sliding-window indices with halo offset for CP (cached).
+
+    KV layout after halo exchange: [halo(halo_size) | local(local_seq_len)]
+    For local query position i, its position in kv_with_halo is i + halo_size.
+    Its window covers [i + halo_size - window_size + 1, i + halo_size].
+
+    Returns:
+        indices: [local_seq_len, window_size] int tensor, -1 for invalid positions.
+    """
+    base = torch.arange(local_seq_len, device=device_str).unsqueeze(1) + halo_size
+    offsets = torch.arange(window_size, device=device_str)
+    matrix = (base - window_size + 1).clamp(min=0) + offsets
+    matrix = torch.where(matrix > base, -1, matrix)
+    return matrix
+
+
+def get_window_topk_idxs_cp(
+    window_size: int,
+    batch_size: int,
+    local_seq_len: int,
+    halo_size: int,
+    device: torch.device,
+) -> torch.Tensor:
+    """Sliding-window indices with CP halo offset [batch, local_seq_len, window_size]."""
+    matrix = _get_window_topk_idxs_cp_cached(window_size, local_seq_len, halo_size, str(device))
+    return matrix.unsqueeze(0).expand(batch_size, -1, -1)
+
+
+# ---------------------------------------------------------------------------
 # Helper functions for RoPE
 # ---------------------------------------------------------------------------
 
@@ -660,10 +749,26 @@ class CompressedSparseAttention(MegatronModule):
 
         sq, b, np, hn = query.size()
 
+        cp_size = self.pg_collection.cp.size()
+        cp_rank = self.pg_collection.cp.rank()
+
         # --- Step 1: Prepare single-head KV (squeeze singleton head dim) ---
         kv = key.squeeze(-2)  # [sq, b, 1, v_head_dim] -> [sq, b, v_head_dim]
 
-        # --- Step 2: Compression ---
+        # --- Step 2: Halo exchange for sliding window (CP only) ---
+        if cp_size > 1:
+            halo_size = self.window_size - 1 if cp_rank > 0 else 0
+            if torch.distributed.get_rank() == 0:
+                print(f"[CSA CP] Layer {self.layer_number}: cp_size={cp_size}, cp_rank={cp_rank}, "
+                      f"halo_size={halo_size}, window_size={self.window_size}, "
+                      f"compress_ratio={self.compress_ratio}, kv.shape={kv.shape}")
+            kv = _exchange_kv_halo(kv, self.window_size - 1, self.pg_collection.cp)
+            if torch.distributed.get_rank() == 0:
+                print(f"[CSA CP] Layer {self.layer_number}: after halo exchange, kv.shape={kv.shape}")
+        else:
+            halo_size = 0
+
+        # --- Step 3: Compression ---
         if self.compressor is not None and self.compress_ratio > 1:
             compressed_kv = self.compressor(x)  # [n_compressed, b, v_head_dim]
             if compressed_kv is not None:
@@ -676,12 +781,20 @@ class CompressedSparseAttention(MegatronModule):
             kv_full = kv
             n_compressed = 0
 
-        offset = sq  # compressed indices start after original positions
+        offset = sq + halo_size  # compressed indices start after halo + original positions
 
-        # --- Step 3: Window indices ---
-        window_idxs = get_window_topk_idxs(self.window_size, b, sq, query.device)
+        # --- Step 4: Window indices ---
+        if halo_size > 0:
+            window_idxs = get_window_topk_idxs_cp(
+                self.window_size, b, sq, halo_size, query.device
+            )
+            if torch.distributed.get_rank() == 0:
+                print(f"[CSA CP] Layer {self.layer_number}: using CP window indices, "
+                      f"window_idxs.shape={window_idxs.shape}, offset={offset}")
+        else:
+            window_idxs = get_window_topk_idxs(self.window_size, b, sq, query.device)
 
-        # --- Step 4: Compressed indices ---
+        # --- Step 5: Compressed indices ---
         indexer_loss = None
 
         if self.force_unfused_dsa:
@@ -756,7 +869,7 @@ class CompressedSparseAttention(MegatronModule):
 
             topk_idxs = topk_idxs.int()
 
-            # --- Step 5: Sparse attention ---
+            # --- Step 6: Sparse attention ---
             nvtx_range_push("sparse_attn_kernel")
             output = unfused_compressed_sparse_attn(
                 query, kv_full, self.attn_sink.float(), topk_idxs, self.softmax_scale
@@ -766,7 +879,7 @@ class CompressedSparseAttention(MegatronModule):
         else:
             raise ValueError("Fused path is not supported for CompressedSparseAttention")
 
-        # --- Step 6: Attach indexer loss ---
+        # --- Step 7: Attach indexer loss ---
         if indexer_loss is not None and self.training and torch.is_grad_enabled():
             output = DSAIndexerLossAutoScaler.apply(output, indexer_loss)
 

--- a/megatron/core/transformer/experimental_attention_variant/csa.py
+++ b/megatron/core/transformer/experimental_attention_variant/csa.py
@@ -357,26 +357,56 @@ class Compressor(MegatronModule):
     def forward(self, x: torch.Tensor) -> Optional[torch.Tensor]:
         """Compress hidden states into shorter KV sequence.
 
+        When CP is active (cp_size > 1), this method internally handles:
+        1. Halo exchange (prepend boundary tokens from previous rank)
+        2. Local compression (discard halo group to avoid duplicates)
+        3. All-gather across CP ranks to produce the global compressed sequence
+
         Args:
-            x: [sq, b, hidden_size]
+            x: [sq, b, hidden_size] — local hidden states (without halo).
 
         Returns:
-            compressed_kv [sq // ratio, b, head_dim] or None if too short.
+            cp_size == 1: [sq // ratio, b, head_dim] or None if too short.
+            cp_size > 1:  [n_compressed_global, b, head_dim] or None if too short.
         """
         nvtx_range_push("compressor")
 
         sq, b, _ = x.size()
         ratio = self.compress_ratio
+        cp_group = self.pg_collection.cp
+        cp_size = cp_group.size()
+        cp_rank = cp_group.rank()
 
-        if sq < ratio:
+        # --- CP Step 1: Halo exchange for compression boundary ---
+        _rank = torch.distributed.get_rank()
+        has_halo = False
+        if cp_size > 1:
+            need_halo = self.overlap or (sq % ratio != 0)
+            if need_halo:
+                logger.debug(
+                    f"[rank {_rank}] Compressor(ratio={ratio}): "
+                    f"before halo exchange, x.shape={x.shape}"
+                )
+                x = _exchange_halo(x, ratio, cp_group)
+                logger.debug(
+                    f"[rank {_rank}] Compressor(ratio={ratio}): "
+                    f"after halo exchange, x.shape={x.shape}"
+                )
+                if cp_rank > 0:
+                    has_halo = True
+
+        sq_with_halo = x.size(0)
+
+        if sq_with_halo < ratio:
             nvtx_range_pop("compressor")
             return None
 
-        kv, _ = self.linear_wkv(x)  # [sq, b, coff * head_dim]
-        score, _ = self.linear_wgate(x)  # [sq, b, coff * head_dim]
+        # --- Core compression ---
+        kv, _ = self.linear_wkv(x)  # [sq_with_halo, b, coff * head_dim]
+        score, _ = self.linear_wgate(x)  # [sq_with_halo, b, coff * head_dim]
 
-        cutoff = (sq // ratio) * ratio
-        if cutoff < sq:
+        cutoff = (sq_with_halo // ratio) * ratio
+        if cutoff < sq_with_halo:
             kv = kv[:cutoff]
             score = score[:cutoff]
 
@@ -395,6 +425,12 @@ class Compressor(MegatronModule):
 
         kv = (kv * torch.softmax(score, dim=1)).sum(dim=1)  # [n_compressed, b, head_dim]
 
+        # Discard halo group: it only served as overlap context for group 1.
+        # The same tokens are already compressed by the previous rank.
+        if has_halo:
+            kv = kv[1:]
+            n_compressed = n_compressed - 1
+
         kv = self.norm(kv.to(x.dtype))
 
         kv = _apply_rope(
@@ -405,14 +441,26 @@ class Compressor(MegatronModule):
             self.config,
             n_compressed,
             ratio=ratio,
-            cp_group=self.pg_collection.cp,
+            cp_group=cp_group,
         )
 
         if self.rotate:
             kv = rotate_activation(kv)
 
+        # --- CP Step 2: All-gather to produce global compressed sequence ---
+        if cp_size > 1:
+            logger.debug(
+                f"[rank {_rank}] Compressor(ratio={ratio}): "
+                f"before all-gather, kv.shape={kv.shape}, expected_local={sq // ratio}"
+            )
+            kv = differentiable_all_gather(kv, cp_group)
+            logger.debug(
+                f"[rank {_rank}] Compressor(ratio={ratio}): "
+                f"after all-gather, kv.shape={kv.shape}"
+            )
+
         nvtx_range_pop("compressor")
-        return kv  # [n_compressed, b, head_dim]
+        return kv
 
 
 # ---------------------------------------------------------------------------
@@ -681,115 +729,44 @@ class CompressedSparseAttention(MegatronModule):
 
         cp_size = self.pg_collection.cp.size()
         cp_rank = self.pg_collection.cp.rank()
+        _rank = torch.distributed.get_rank()
 
-        if torch.distributed.get_rank() == 0:
-            logger.debug(
-                f"\n[CSA CP DEBUG] Layer {self.layer_number} START: "
-                f"query.shape={query.shape}, key.shape={key.shape}, "
-                f"x.shape={x.shape if x is not None else None}"
-            )
+        logger.debug(
+            f"[rank {_rank}] CSA Layer {self.layer_number} START: "
+            f"query.shape={query.shape}, key.shape={key.shape}, "
+            f"x.shape={x.shape if x is not None else None}, "
+            f"cp_size={cp_size}, cp_rank={cp_rank}"
+        )
 
         # --- Step 1: Prepare single-head KV (squeeze singleton head dim) ---
         kv = key.squeeze(-2)  # [sq, b, 1, v_head_dim] -> [sq, b, v_head_dim]
-        if torch.distributed.get_rank() == 0:
-            logger.debug(f"[CSA CP DEBUG] Layer {self.layer_number} Step 1: kv.shape={kv.shape}")
+        logger.debug(
+            f"[rank {_rank}] CSA Layer {self.layer_number} Step 1 done: kv.shape={kv.shape}"
+        )
 
         # --- Step 2: Halo exchange for sliding window (CP only) ---
         if cp_size > 1:
             halo_size = self.window_size - 1 if cp_rank > 0 else 0
-            if torch.distributed.get_rank() == 0:
-                logger.debug(
-                    f"[CSA CP] Layer {self.layer_number}: cp_size={cp_size}, cp_rank={cp_rank}, "
-                    f"halo_size={halo_size}, window_size={self.window_size}, "
-                    f"compress_ratio={self.compress_ratio}, kv.shape={kv.shape}"
-                )
+            logger.debug(
+                f"[rank {_rank}] CSA Layer {self.layer_number} Step 2: "
+                f"before halo exchange, halo_size={halo_size}"
+            )
             kv = _exchange_halo(kv, self.window_size - 1, self.pg_collection.cp, name="kv")
-            if torch.distributed.get_rank() == 0:
-                logger.debug(
-                    f"[CSA CP] Layer {self.layer_number}: after halo exchange, kv.shape={kv.shape}"
-                )
+            logger.debug(
+                f"[rank {_rank}] CSA Layer {self.layer_number} Step 2 done: "
+                f"after halo exchange, kv.shape={kv.shape}"
+            )
         else:
             halo_size = 0
 
         # --- Step 3: Compression ---
+        logger.debug(
+            f"[rank {_rank}] CSA Layer {self.layer_number} Step 3: "
+            f"starting compression, compress_ratio={self.compress_ratio}"
+        )
         if self.compressor is not None and self.compress_ratio > 1:
-            # CP: exchange hidden_states halo for compression boundary handling.
-            # For non-overlap (ratio=128, HCA): halo needed only if sq % ratio != 0.
-            # For overlap (ratio=4, CSA): halo needed for _overlap_transform cross-boundary.
-            x_for_compression = x
-            if cp_size > 1 and cp_rank > 0:
-                need_compression_halo = self.compressor.overlap or (sq % self.compress_ratio != 0)
-                if need_compression_halo:
-                    compression_halo_size = self.compress_ratio
-                    if torch.distributed.get_rank() == 0:
-                        logger.debug(
-                            f"[CSA CP] Layer {self.layer_number}: compression halo exchange, "
-                            f"halo_size={compression_halo_size}, overlap={self.compressor.overlap}"
-                        )
-                    x_for_compression = _exchange_halo(
-                        x, compression_halo_size, self.pg_collection.cp, name="hidden_states"
-                    )
-
-            compressed_kv = self.compressor(
-                x_for_compression
-            )  # [n_compressed_local, b, v_head_dim]
-            if compressed_kv is not None and cp_size > 1:
-                # Pad to uniform length (sq // ratio + 1) for all-gather
-                uniform_len = sq // self.compress_ratio + 1
-                n_local = compressed_kv.size(0)
-                if torch.distributed.get_rank() == 0:
-                    logger.debug(
-                        f"[CSA CP] Layer {self.layer_number}: compressed n_local={n_local}, "
-                        f"uniform_len={uniform_len}"
-                    )
-                if n_local < uniform_len:
-                    pad = torch.zeros(
-                        uniform_len - n_local,
-                        *compressed_kv.shape[1:],
-                        device=compressed_kv.device,
-                        dtype=compressed_kv.dtype,
-                    )
-                    compressed_kv_padded = torch.cat([compressed_kv, pad], dim=0)
-                else:
-                    compressed_kv_padded = compressed_kv[:uniform_len]
-
-                # All-gather padded compressed KV from all ranks (differentiable)
-                gathered_full = differentiable_all_gather(
-                    compressed_kv_padded, self.pg_collection.cp
-                )
-                # Split back into list for select-and-pad logic
-                gathered_list = list(torch.split(gathered_full, uniform_len, dim=0))
-
-                # Select-and-Pad: reorder valid tokens, move padding to tail
-                # Each rank has n_valid tokens followed by padding.
-                # Rank 0: n_valid = n_local (no halo, may be sq//ratio)
-                # Rank i>0 with halo: n_valid = n_local (may be sq//ratio + 1)
-                # Collect valid tokens in global order, pad at the end.
-                valid_tokens = []
-                for i in range(cp_size):
-                    chunk = gathered_list[i]
-                    # Determine how many valid tokens this rank produced
-                    if i == 0:
-                        n_valid_i = sq // self.compress_ratio
-                    else:
-                        # With halo: (compression_halo + sq) // ratio
-                        if self.compressor.overlap or (sq % self.compress_ratio != 0):
-                            n_valid_i = (self.compress_ratio + sq) // self.compress_ratio
-                        else:
-                            n_valid_i = sq // self.compress_ratio
-                    valid_tokens.append(chunk[:n_valid_i])
-                compressed_kv = torch.cat(
-                    valid_tokens, dim=0
-                )  # [n_compressed_global, b, v_head_dim]
-                if torch.distributed.get_rank() == 0:
-                    logger.debug(
-                        f"[CSA CP] Layer {self.layer_number}: after select-and-pad, "
-                        f"compressed_kv.shape={compressed_kv.shape}"
-                    )
-
-                kv_full = torch.cat([kv, compressed_kv], dim=0)
-                n_compressed = compressed_kv.size(0)
-            elif compressed_kv is not None:
+            compressed_kv = self.compressor(x)
+            if compressed_kv is not None:
                 kv_full = torch.cat([kv, compressed_kv], dim=0)
                 n_compressed = compressed_kv.size(0)
             else:
@@ -800,22 +777,20 @@ class CompressedSparseAttention(MegatronModule):
             n_compressed = 0
 
         offset = sq + halo_size  # compressed indices start after halo + original positions
-        if torch.distributed.get_rank() == 0:
-            logger.debug(
-                f"[CSA CP DEBUG] Layer {self.layer_number} Step 3 done: "
-                f"kv_full.shape={kv_full.shape}, n_compressed={n_compressed}, offset={offset}"
-            )
+        logger.debug(
+            f"[rank {_rank}] CSA Layer {self.layer_number} Step 3 done: "
+            f"kv_full.shape={kv_full.shape}, n_compressed={n_compressed}, offset={offset}"
+        )
 
         # --- Step 4: Window indices ---
         if halo_size > 0:
             window_idxs = get_window_topk_idxs_cp(self.window_size, b, sq, halo_size, query.device)
         else:
             window_idxs = get_window_topk_idxs(self.window_size, b, sq, query.device)
-        if torch.distributed.get_rank() == 0:
-            logger.debug(
-                f"[CSA CP DEBUG] Layer {self.layer_number} Step 4: "
-                f"window_idxs.shape={window_idxs.shape}"
-            )
+        logger.debug(
+            f"[rank {_rank}] CSA Layer {self.layer_number} Step 4 done: "
+            f"window_idxs.shape={window_idxs.shape}"
+        )
 
         # --- Step 5: Compressed indices ---
         indexer_loss = None
@@ -827,21 +802,43 @@ class CompressedSparseAttention(MegatronModule):
                     x_det = x.detach()
                     qr_det = qr.detach()
 
-                    causal_mask = (
-                        torch.arange(n_compressed, device=x.device).unsqueeze(0).expand(sq, -1)
-                    )
-                    positions = torch.arange(1, sq + 1, device=x.device).unsqueeze(1)
-                    causal_mask = (
-                        torch.where(
-                            causal_mask >= positions // self.compress_ratio, float("-inf"), 0.0
-                        )
-                        .unsqueeze(0)
-                        .expand(b, -1, -1)
+                    # Causal mask with global positions for CP
+                    # Compressed token j covers [j*ratio, (j+1)*ratio).
+                    # Query at global pos g attends to j iff (j+1)*ratio-1 <= g.
+                    compressed_indices = torch.arange(n_compressed, device=x.device).unsqueeze(
+                        0
+                    )  # [1, n_compressed]
+                    compressed_max_pos = (
+                        compressed_indices + 1
+                    ) * self.compress_ratio - 1  # [1, n_compressed]
+
+                    # Global query positions for current rank
+                    local_positions = torch.arange(1, sq + 1, device=x.device).unsqueeze(
+                        1
+                    )  # [sq, 1]
+                    global_positions = cp_rank * sq + local_positions  # [sq, 1]
+
+                    # Causal constraint: compressed_max_pos <= global_positions
+                    causal_mask = torch.where(
+                        compressed_max_pos > global_positions, float("-inf"), 0.0
+                    )  # [sq, n_compressed]
+                    causal_mask = causal_mask.unsqueeze(0).expand(
+                        b, -1, -1
                     )  # [b, sq, n_compressed]
+
+                    logger.debug(
+                        f"[rank {_rank}] CSA Layer {self.layer_number} Step 5: "
+                        f"causal_mask built, calling indexer.forward_before_topk"
+                    )
 
                     if self.training and torch.is_grad_enabled():
                         q_indexer, k_indexer, weights_indexer = self.indexer.forward_before_topk(
                             x_det, qr_det, packed_seq_params
+                        )
+                        logger.debug(
+                            f"[rank {_rank}] CSA Layer {self.layer_number} Step 5: "
+                            f"forward_before_topk done, q_indexer.shape={q_indexer.shape}, "
+                            f"k_indexer.shape={k_indexer.shape}"
                         )
                         indexer_loss_coeff = getattr(self.config, 'dsa_indexer_loss_coeff', 0.0)
                         # compressed_kv is [n, b, hn]; expand to [n, b, np, hn] for loss
@@ -851,6 +848,10 @@ class CompressedSparseAttention(MegatronModule):
                         # weights-scaling trick so the effective weights match
                         # the pre-scale-split behaviour.
                         weights_for_unfused = weights_indexer * self.indexer.softmax_scale
+                        logger.debug(
+                            f"[rank {_rank}] CSA Layer {self.layer_number} Step 5: "
+                            f"calling FusedDSAIndexerLoss"
+                        )
                         topk_indices_compressed, indexer_loss = FusedDSAIndexerLoss.apply(
                             q_indexer,
                             weights_for_unfused,
@@ -864,6 +865,11 @@ class CompressedSparseAttention(MegatronModule):
                             getattr(self.config, "dsa_indexer_use_sparse_loss", True),
                             self.indexer.pg_collection,
                         )
+                        logger.debug(
+                            f"[rank {_rank}] CSA Layer {self.layer_number} Step 5: "
+                            f"FusedDSAIndexerLoss done, "
+                            f"topk_indices_compressed.shape={topk_indices_compressed.shape}"
+                        )
                         if indexer_loss_coeff > 0:
                             DSAIndexerLossLoggingHelper.save_loss_to_tracker(
                                 loss=indexer_loss,
@@ -875,7 +881,7 @@ class CompressedSparseAttention(MegatronModule):
                             x_det, qr_det, mask=causal_mask, packed_seq_params=packed_seq_params
                         )
 
-                    n_valid_per_pos = positions // self.compress_ratio  # [sq, 1]
+                    n_valid_per_pos = global_positions // self.compress_ratio  # [sq, 1]
                     valid = topk_indices_compressed < n_valid_per_pos
                     compress_topk_idxs = torch.where(
                         valid, topk_indices_compressed + offset, torch.tensor(-1, device=x.device)
@@ -900,13 +906,12 @@ class CompressedSparseAttention(MegatronModule):
                 topk_idxs = window_idxs
 
             topk_idxs = topk_idxs.int()
-            if torch.distributed.get_rank() == 0:
-                logger.debug(
-                    f"[CSA CP DEBUG] Layer {self.layer_number} Step 5: "
-                    f"topk_idxs.shape={topk_idxs.shape}, "
-                    f"topk_idxs.min()={topk_idxs.min().item()}, "
-                    f" topk_idxs.max()={topk_idxs.max().item()}"
-                )
+            logger.debug(
+                f"[rank {_rank}] CSA Layer {self.layer_number} Step 5 done: "
+                f"topk_idxs.shape={topk_idxs.shape}, "
+                f"topk_idxs.min()={topk_idxs.min().item()}, "
+                f"topk_idxs.max()={topk_idxs.max().item()}"
+            )
 
             # --- Step 6: Sparse attention ---
             nvtx_range_push("sparse_attn_kernel")
@@ -914,11 +919,10 @@ class CompressedSparseAttention(MegatronModule):
                 query, kv_full, self.attn_sink.float(), topk_idxs, self.softmax_scale
             )
             nvtx_range_pop("sparse_attn_kernel")
-            if torch.distributed.get_rank() == 0:
-                logger.debug(
-                    f"[CSA CP DEBUG] Layer {self.layer_number} Step 6: "
-                    f"output.shape={output.shape}\n"
-                )
+            logger.debug(
+                f"[rank {_rank}] CSA Layer {self.layer_number} Step 6 done: "
+                f"output.shape={output.shape}"
+            )
 
         else:
             raise ValueError("Fused path is not supported for CompressedSparseAttention")

--- a/megatron/core/transformer/experimental_attention_variant/csa_utils.py
+++ b/megatron/core/transformer/experimental_attention_variant/csa_utils.py
@@ -1,0 +1,124 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+
+"""Utility functions for Context Parallel support in CompressedSparseAttention."""
+
+from functools import lru_cache
+
+import torch
+
+# ---------------------------------------------------------------------------
+# P2P halo exchange
+# ---------------------------------------------------------------------------
+
+
+def _exchange_halo(
+    tensor: torch.Tensor, halo_size: int, cp_group: torch.distributed.ProcessGroup, name: str = ""
+) -> torch.Tensor:
+    """P2P halo exchange for context parallelism.
+
+    Each rank sends its last `halo_size` tokens to the next rank, and receives
+    `halo_size` tokens from the previous rank to prepend.
+
+    Args:
+        tensor: [local_seq, ...] local tensor (KV or hidden_states).
+        halo_size: number of tokens to exchange.
+        cp_group: context parallel process group.
+        name: optional name for debug logging.
+
+    Returns:
+        tensor_with_halo: [halo_size + local_seq, ...] for rank > 0,
+                          [local_seq, ...] for rank 0 (no halo needed).
+    """
+    cp_rank = cp_group.rank()
+    cp_size = cp_group.size()
+
+    if cp_size == 1:
+        return tensor
+
+    global_ranks = torch.distributed.get_process_group_ranks(cp_group)
+    prev_rank = global_ranks[(cp_rank - 1) % cp_size]
+    next_rank = global_ranks[(cp_rank + 1) % cp_size]
+
+    send_buf = tensor[-halo_size:].contiguous()
+    recv_buf = torch.empty_like(send_buf)
+
+    ops = []
+    if cp_rank < cp_size - 1:
+        ops.append(torch.distributed.isend(send_buf, dst=next_rank, group=cp_group))
+    if cp_rank > 0:
+        ops.append(torch.distributed.irecv(recv_buf, src=prev_rank, group=cp_group))
+
+    for op in ops:
+        op.wait()
+
+    if cp_rank == 0:
+        return tensor
+    else:
+        return torch.cat([recv_buf, tensor], dim=0)
+
+
+# ---------------------------------------------------------------------------
+# Differentiable all-gather
+# ---------------------------------------------------------------------------
+
+
+class _AllGatherAlongFirstDim(torch.autograd.Function):
+    """Differentiable all-gather along dim 0 for context parallel compressed KV."""
+
+    @staticmethod
+    def forward(ctx, input_, cp_group):
+        """Forward pass: all-gather input along dim 0."""
+        ctx.cp_group = cp_group
+        ctx.cp_rank = cp_group.rank()
+        ctx.cp_size = cp_group.size()
+        ctx.input_size_0 = input_.size(0)
+
+        gathered = [torch.empty_like(input_) for _ in range(ctx.cp_size)]
+        torch.distributed.all_gather(gathered, input_.contiguous(), group=cp_group)
+        return torch.cat(gathered, dim=0)
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        """Backward pass: slice gradient back to current rank's portion."""
+        chunk_size = ctx.input_size_0
+        start = ctx.cp_rank * chunk_size
+        grad_input = grad_output[start : start + chunk_size].contiguous()
+        return grad_input, None
+
+
+def differentiable_all_gather(tensor, cp_group):
+    """All-gather along first dim with gradient support."""
+    return _AllGatherAlongFirstDim.apply(tensor, cp_group)
+
+
+# ---------------------------------------------------------------------------
+# CP-aware sliding window indices
+# ---------------------------------------------------------------------------
+
+
+@lru_cache(maxsize=8)
+def _get_window_topk_idxs_cp_cached(
+    window_size: int, local_seq_len: int, halo_size: int, device_str: str
+) -> torch.Tensor:
+    """Compute sliding-window indices with halo offset for CP (cached).
+
+    KV layout after halo exchange: [halo(halo_size) | local(local_seq_len)]
+    For local query position i, its position in kv_with_halo is i + halo_size.
+    Its window covers [i + halo_size - window_size + 1, i + halo_size].
+
+    Returns:
+        indices: [local_seq_len, window_size] int tensor, -1 for invalid positions.
+    """
+    base = torch.arange(local_seq_len, device=device_str).unsqueeze(1) + halo_size
+    offsets = torch.arange(window_size, device=device_str)
+    matrix = (base - window_size + 1).clamp(min=0) + offsets
+    matrix = torch.where(matrix > base, -1, matrix)
+    return matrix
+
+
+def get_window_topk_idxs_cp(
+    window_size: int, batch_size: int, local_seq_len: int, halo_size: int, device: torch.device
+) -> torch.Tensor:
+    """Sliding-window indices with CP halo offset [batch, local_seq_len, window_size]."""
+    matrix = _get_window_topk_idxs_cp_cached(window_size, local_seq_len, halo_size, str(device))
+    return matrix.unsqueeze(0).expand(batch_size, -1, -1)

--- a/megatron/core/transformer/experimental_attention_variant/csa_utils.py
+++ b/megatron/core/transformer/experimental_attention_variant/csa_utils.py
@@ -92,6 +92,61 @@ def differentiable_all_gather(tensor, cp_group):
 
 
 # ---------------------------------------------------------------------------
+# Async differentiable all-gather (for compute/communication overlap)
+# ---------------------------------------------------------------------------
+
+_ASYNC_AG_HANDLE = None
+
+
+class _AsyncAllGatherAlongFirstDim(torch.autograd.Function):
+    """Async differentiable all-gather: launches non-blocking all-gather in forward.
+
+    The caller must invoke async_differentiable_all_gather_wait() before
+    reading the returned output buffer.
+    """
+
+    @staticmethod
+    def forward(ctx, input_, cp_group):
+        global _ASYNC_AG_HANDLE
+        ctx.cp_group = cp_group
+        ctx.cp_rank = cp_group.rank()
+        ctx.cp_size = cp_group.size()
+        ctx.input_size_0 = input_.size(0)
+
+        output = torch.empty(
+            ctx.cp_size * input_.size(0), *input_.shape[1:],
+            dtype=input_.dtype, device=input_.device,
+        )
+        _ASYNC_AG_HANDLE = torch.distributed.all_gather_into_tensor(
+            output, input_.contiguous(), group=cp_group, async_op=True
+        )
+        return output
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        chunk_size = ctx.input_size_0
+        start = ctx.cp_rank * chunk_size
+        grad_input = grad_output[start : start + chunk_size].contiguous()
+        return grad_input, None
+
+
+def async_differentiable_all_gather_start(tensor, cp_group):
+    """Launch async all-gather. Returns output buffer (not yet valid).
+
+    Call async_differentiable_all_gather_wait() before reading the buffer.
+    """
+    return _AsyncAllGatherAlongFirstDim.apply(tensor, cp_group)
+
+
+def async_differentiable_all_gather_wait():
+    """Wait for the most recent async all-gather to complete."""
+    global _ASYNC_AG_HANDLE
+    if _ASYNC_AG_HANDLE is not None:
+        _ASYNC_AG_HANDLE.wait()
+        _ASYNC_AG_HANDLE = None
+
+
+# ---------------------------------------------------------------------------
 # CP-aware sliding window indices
 # ---------------------------------------------------------------------------
 

--- a/megatron/core/transformer/experimental_attention_variant/deepseek_v4_hybrid_attention.py
+++ b/megatron/core/transformer/experimental_attention_variant/deepseek_v4_hybrid_attention.py
@@ -314,11 +314,18 @@ class DSv4HybridAttention(Attention):
         else:
             cu_seqlens_kv = None
             rope_seqlen = seq_len
+        contiguous_split = getattr(self.config, 'cp_seq_split_mode', '2chunk') == 'contiguous'
+        # When CP is enabled, rope_seqlen needs to be the full sequence length
+        # so that the RoPE forward() can slice it correctly for this CP rank
+        if self.pg_collection.cp.size() > 1:
+            rope_seqlen = rope_seqlen * self.pg_collection.cp.size()
         mscale = 1.0
         rotary_pos_cos = None
         rotary_pos_sin = None
         if self.config.rope_type == "rope":
-            rotary_pos_emb = self.rotary_pos_emb(rope_seqlen, packed_seq=packed_seq)
+            rotary_pos_emb = self.rotary_pos_emb(
+                rope_seqlen, packed_seq=packed_seq, contiguous_split=contiguous_split
+            )
         else:
             if self.config.apply_rope_fusion:
                 rotary_pos_cos, rotary_pos_sin = self.rotary_pos_emb.get_cached_cos_sin(
@@ -330,7 +337,9 @@ class DSv4HybridAttention(Attention):
                     fused_mla_rope_inplace is not None
                 ), "Fused MLA RoPE apply is not imported successfully"
             else:
-                rotary_pos_emb, mscale = self.rotary_pos_emb(rope_seqlen, packed_seq=packed_seq)
+                rotary_pos_emb, mscale = self.rotary_pos_emb(
+                    rope_seqlen, packed_seq=packed_seq, contiguous_split=contiguous_split
+                )
                 # DSv4 reference (DS-Inf) RoPE is pure rotation (norm-preserving). Yarn's
                 # concentration factor (mscale) is NOT part of the DSv4 model contract --
                 # the model relies on Q/KV RMS-norm + unit-magnitude rotation. Force 1.0.
@@ -519,10 +528,20 @@ class DSv4HybridSelfAttention(DSv4HybridAttention):
         rotary_pos_cos = None
         rotary_pos_sin = None
         packed_seq = packed_seq_params is not None and packed_seq_params.qkv_format == 'thd'
+        contiguous_split = getattr(self.config, 'cp_seq_split_mode', '2chunk') == 'contiguous'
+        if torch.distributed.get_rank() == 0 and self.layer_number == 1:
+            print(f"[DSv4 Hybrid Attn] Layer {self.layer_number}: contiguous_split={contiguous_split}, "
+                  f"cp_seq_split_mode={getattr(self.config, 'cp_seq_split_mode', '2chunk')}")
         if self.config.rope_type == "rope":
-            rotary_pos_emb = self.rotary_pos_emb(rotary_seq_len, packed_seq=packed_seq)
+            rotary_pos_emb = self.rotary_pos_emb(
+                rotary_seq_len, packed_seq=packed_seq, contiguous_split=contiguous_split
+            )
         else:
             if self.config.apply_rope_fusion:
+                assert not contiguous_split, (
+                    "apply_rope_fusion is not supported with cp_seq_split_mode='contiguous'. "
+                    "Please set apply_rope_fusion=False."
+                )
                 rotary_pos_cos, rotary_pos_sin = self.rotary_pos_emb.get_cached_cos_sin(
                     rotary_seq_len, dtype=hidden_states.dtype, packed_seq=packed_seq
                 )
@@ -532,7 +551,9 @@ class DSv4HybridSelfAttention(DSv4HybridAttention):
                     fused_mla_rope_inplace is not None
                 ), "Fused MLA RoPE apply is not imported successfully"
             else:
-                rotary_pos_emb, mscale = self.rotary_pos_emb(rotary_seq_len, packed_seq=packed_seq)
+                rotary_pos_emb, mscale = self.rotary_pos_emb(
+                    rotary_seq_len, packed_seq=packed_seq, contiguous_split=contiguous_split
+                )
                 # DSv4 reference (DS-Inf) RoPE is pure rotation (norm-preserving). Yarn's
                 # concentration factor (mscale) is NOT part of the DSv4 model contract --
                 # the model relies on Q/KV RMS-norm + unit-magnitude rotation. Force 1.0.

--- a/megatron/core/transformer/experimental_attention_variant/deepseek_v4_hybrid_attention.py
+++ b/megatron/core/transformer/experimental_attention_variant/deepseek_v4_hybrid_attention.py
@@ -1,6 +1,6 @@
 # Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 
-
+import logging
 from dataclasses import dataclass
 from typing import NoReturn, Optional, Union
 
@@ -30,6 +30,7 @@ try:
 except Exception:
     fused_mla_rope_inplace = None
 
+logger = logging.getLogger(__name__)
 
 if HAVE_TE:
     from megatron.core.extensions.transformer_engine import TELinear, set_save_original_input
@@ -530,8 +531,13 @@ class DSv4HybridSelfAttention(DSv4HybridAttention):
         packed_seq = packed_seq_params is not None and packed_seq_params.qkv_format == 'thd'
         contiguous_split = getattr(self.config, 'cp_seq_split_mode', '2chunk') == 'contiguous'
         if torch.distributed.get_rank() == 0 and self.layer_number == 1:
-            print(f"[DSv4 Hybrid Attn] Layer {self.layer_number}: contiguous_split={contiguous_split}, "
-                  f"cp_seq_split_mode={getattr(self.config, 'cp_seq_split_mode', '2chunk')}")
+            cp_mode = getattr(self.config, 'cp_seq_split_mode', '2chunk')
+            logger.debug(
+                "[DSv4 Hybrid Attn] Layer %d: contiguous_split=%s, " "cp_seq_split_mode=%s",
+                self.layer_number,
+                contiguous_split,
+                cp_mode,
+            )
         if self.config.rope_type == "rope":
             rotary_pos_emb = self.rotary_pos_emb(
                 rotary_seq_len, packed_seq=packed_seq, contiguous_split=contiguous_split

--- a/megatron/core/transformer/experimental_attention_variant/fused_compressor_kernel.py
+++ b/megatron/core/transformer/experimental_attention_variant/fused_compressor_kernel.py
@@ -1,0 +1,386 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+
+"""Fused Triton kernel for CSA Compressor post-GEMM operations.
+
+Fuses: cutoff+reshape, add APE, overlap_transform, softmax+weighted_sum,
+       discard_halo, RMSNorm.
+
+Input:  kv, score from GEMM outputs [sq_with_halo, b, coff * head_dim]
+Output: normalized compressed KV [n_out, b, head_dim] ready for RoPE
+
+Uses torch.autograd.Function: forward runs Triton kernel, backward uses
+PyTorch ops for gradient computation.
+"""
+
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def _fused_compress_no_overlap_kernel(
+    kv_ptr,
+    score_ptr,
+    ape_ptr,
+    norm_weight_ptr,
+    out_ptr,
+    ratio: tl.constexpr,
+    head_dim: tl.constexpr,
+    n_groups,
+    has_halo: tl.constexpr,
+    eps,
+    stride_s,
+    stride_b,
+    out_stride_s,
+    out_stride_b,
+    BLOCK_D: tl.constexpr,
+    RATIO: tl.constexpr,
+):
+    """Fused compressor kernel for non-overlap mode (ratio=128).
+
+    Grid: (n_out, batch_size)
+    Each program handles one output compressed position for one batch element.
+    Processes BLOCK_D elements of head_dim at a time.
+    """
+    pid_out = tl.program_id(0)
+    pid_b = tl.program_id(1)
+
+    # Map output index to group index (skip halo group)
+    group_idx = pid_out + (1 if has_halo else 0)
+
+    # Offsets for head_dim
+    d_offs = tl.arange(0, BLOCK_D)
+    d_mask = d_offs < head_dim
+
+    # Accumulator for weighted sum
+    acc = tl.zeros([BLOCK_D], dtype=tl.float32)
+
+    # --- Softmax + weighted sum over ratio positions ---
+    # For each position in the group, compute score + APE, then softmax
+    # softmax is per-element along ratio dim
+
+    # First pass: find max score per element
+    max_scores = tl.full([BLOCK_D], value=float("-inf"), dtype=tl.float32)
+
+    for r in range(RATIO):
+        src_pos = group_idx * ratio + r
+        # Load score[src_pos, b, d] + ape[r, d]
+        score_offset = src_pos * stride_s + pid_b * stride_b + d_offs
+        ape_offset = r * head_dim + d_offs
+        s = tl.load(score_ptr + score_offset, mask=d_mask, other=0.0).to(tl.float32)
+        a = tl.load(ape_ptr + ape_offset, mask=d_mask, other=0.0).to(tl.float32)
+        s = s + a
+        max_scores = tl.maximum(max_scores, s)
+
+    # Second pass: compute exp sum
+    exp_sum = tl.zeros([BLOCK_D], dtype=tl.float32)
+    for r in range(RATIO):
+        src_pos = group_idx * ratio + r
+        score_offset = src_pos * stride_s + pid_b * stride_b + d_offs
+        ape_offset = r * head_dim + d_offs
+        s = tl.load(score_ptr + score_offset, mask=d_mask, other=0.0).to(tl.float32)
+        a = tl.load(ape_ptr + ape_offset, mask=d_mask, other=0.0).to(tl.float32)
+        s = s + a
+        exp_sum += tl.exp(s - max_scores)
+
+    # Third pass: weighted sum
+    for r in range(RATIO):
+        src_pos = group_idx * ratio + r
+        score_offset = src_pos * stride_s + pid_b * stride_b + d_offs
+        ape_offset = r * head_dim + d_offs
+        s = tl.load(score_ptr + score_offset, mask=d_mask, other=0.0).to(tl.float32)
+        a = tl.load(ape_ptr + ape_offset, mask=d_mask, other=0.0).to(tl.float32)
+        s = s + a
+        weight = tl.exp(s - max_scores) / exp_sum
+
+        kv_offset = src_pos * stride_s + pid_b * stride_b + d_offs
+        kv_val = tl.load(kv_ptr + kv_offset, mask=d_mask, other=0.0).to(tl.float32)
+        acc += weight * kv_val
+
+    # --- RMSNorm ---
+    var = tl.sum(acc * acc) / head_dim
+    rms = tl.rsqrt(var + eps)
+    norm_w = tl.load(norm_weight_ptr + d_offs, mask=d_mask, other=1.0).to(tl.float32)
+    out_val = acc * rms * norm_w
+
+    # Store
+    out_offset = pid_out * out_stride_s + pid_b * out_stride_b + d_offs
+    tl.store(out_ptr + out_offset, out_val.to(tl.bfloat16), mask=d_mask)
+
+
+@triton.jit
+def _fused_compress_overlap_kernel(
+    kv_ptr,
+    score_ptr,
+    ape_ptr,
+    norm_weight_ptr,
+    out_ptr,
+    ratio: tl.constexpr,
+    head_dim: tl.constexpr,
+    n_groups,
+    has_halo: tl.constexpr,
+    eps,
+    stride_s,
+    stride_b,
+    out_stride_s,
+    out_stride_b,
+    BLOCK_D: tl.constexpr,
+    RATIO: tl.constexpr,
+):
+    """Fused compressor kernel for overlap mode (ratio=4).
+
+    In overlap mode, coff=2, so kv/score have shape [sq, b, 2*head_dim].
+    The overlap transform creates a 2*ratio window:
+      - positions [0..ratio-1]: first half (dim_offset=0) of previous group
+      - positions [ratio..2*ratio-1]: second half (dim_offset=head_dim) of current group
+
+    APE mapping:
+      - position r < ratio: ape[r, :head_dim] (first half)
+      - position r >= ratio: ape[r-ratio, head_dim:] (second half)
+
+    Grid: (n_out, batch_size)
+    """
+    pid_out = tl.program_id(0)
+    pid_b = tl.program_id(1)
+
+    group_idx = pid_out + (1 if has_halo else 0)
+
+    d_offs = tl.arange(0, BLOCK_D)
+    d_mask = d_offs < head_dim
+
+    acc = tl.zeros([BLOCK_D], dtype=tl.float32)
+    max_scores = tl.full([BLOCK_D], value=float("-inf"), dtype=tl.float32)
+
+    start_pos = group_idx * ratio
+    coff_head_dim = 2 * head_dim  # coff=2 in overlap mode
+
+    # First pass: find max score
+    for r in range(2 * RATIO):
+        if r < ratio:
+            src_pos = (group_idx - 1) * ratio + r
+            dim_offset = 0
+            ape_offset = r * coff_head_dim + d_offs
+            valid = group_idx > 0
+        else:
+            src_pos = start_pos + (r - ratio)
+            dim_offset = head_dim
+            ape_offset = (r - ratio) * coff_head_dim + head_dim + d_offs
+            valid = True
+
+        if valid:
+            score_offset = src_pos * stride_s + pid_b * stride_b + dim_offset + d_offs
+            s = tl.load(score_ptr + score_offset, mask=d_mask, other=0.0).to(tl.float32)
+            a = tl.load(ape_ptr + ape_offset, mask=d_mask, other=0.0).to(tl.float32)
+            s = s + a
+            max_scores = tl.maximum(max_scores, s)
+
+    # Second pass: exp sum
+    exp_sum = tl.zeros([BLOCK_D], dtype=tl.float32)
+    for r in range(2 * RATIO):
+        if r < ratio:
+            src_pos = (group_idx - 1) * ratio + r
+            dim_offset = 0
+            ape_offset = r * coff_head_dim + d_offs
+            valid = group_idx > 0
+        else:
+            src_pos = start_pos + (r - ratio)
+            dim_offset = head_dim
+            ape_offset = (r - ratio) * coff_head_dim + head_dim + d_offs
+            valid = True
+
+        if valid:
+            score_offset = src_pos * stride_s + pid_b * stride_b + dim_offset + d_offs
+            s = tl.load(score_ptr + score_offset, mask=d_mask, other=0.0).to(tl.float32)
+            a = tl.load(ape_ptr + ape_offset, mask=d_mask, other=0.0).to(tl.float32)
+            s = s + a
+            exp_sum += tl.exp(s - max_scores)
+
+    # Third pass: weighted sum
+    for r in range(2 * RATIO):
+        if r < ratio:
+            src_pos = (group_idx - 1) * ratio + r
+            dim_offset = 0
+            ape_offset = r * coff_head_dim + d_offs
+            valid = group_idx > 0
+        else:
+            src_pos = start_pos + (r - ratio)
+            dim_offset = head_dim
+            ape_offset = (r - ratio) * coff_head_dim + head_dim + d_offs
+            valid = True
+
+        if valid:
+            score_offset = src_pos * stride_s + pid_b * stride_b + dim_offset + d_offs
+            s = tl.load(score_ptr + score_offset, mask=d_mask, other=0.0).to(tl.float32)
+            a = tl.load(ape_ptr + ape_offset, mask=d_mask, other=0.0).to(tl.float32)
+            s = s + a
+            weight = tl.exp(s - max_scores) / exp_sum
+
+            kv_offset = src_pos * stride_s + pid_b * stride_b + dim_offset + d_offs
+            kv_val = tl.load(kv_ptr + kv_offset, mask=d_mask, other=0.0).to(tl.float32)
+            acc += weight * kv_val
+
+    # --- RMSNorm ---
+    var = tl.sum(acc * acc) / head_dim
+    rms = tl.rsqrt(var + eps)
+    norm_w = tl.load(norm_weight_ptr + d_offs, mask=d_mask, other=1.0).to(tl.float32)
+    out_val = acc * rms * norm_w
+
+    out_offset = pid_out * out_stride_s + pid_b * out_stride_b + d_offs
+    tl.store(out_ptr + out_offset, out_val.to(tl.bfloat16), mask=d_mask)
+
+
+def _triton_forward(kv, score, ape, norm_weight, ratio, head_dim, has_halo, use_overlap, eps):
+    """Run the Triton kernel forward pass (no autograd)."""
+    sq_with_halo, b, _ = kv.shape
+    cutoff = (sq_with_halo // ratio) * ratio
+    n_groups = cutoff // ratio
+    n_out = n_groups - (1 if has_halo else 0)
+
+    out = torch.empty(n_out, b, head_dim, dtype=torch.bfloat16, device=kv.device)
+
+    stride_s = kv.stride(0)
+    stride_b = kv.stride(1)
+    out_stride_s = out.stride(0)
+    out_stride_b = out.stride(1)
+
+    BLOCK_D = triton.next_power_of_2(head_dim)
+
+    grid = (n_out, b)
+
+    if use_overlap:
+        _fused_compress_overlap_kernel[grid](
+            kv, score, ape, norm_weight, out,
+            ratio=ratio,
+            head_dim=head_dim,
+            n_groups=n_groups,
+            has_halo=has_halo,
+            eps=eps,
+            stride_s=stride_s,
+            stride_b=stride_b,
+            out_stride_s=out_stride_s,
+            out_stride_b=out_stride_b,
+            BLOCK_D=BLOCK_D,
+            RATIO=ratio,
+        )
+    else:
+        _fused_compress_no_overlap_kernel[grid](
+            kv, score, ape, norm_weight, out,
+            ratio=ratio,
+            head_dim=head_dim,
+            n_groups=n_groups,
+            has_halo=has_halo,
+            eps=eps,
+            stride_s=stride_s,
+            stride_b=stride_b,
+            out_stride_s=out_stride_s,
+            out_stride_b=out_stride_b,
+            BLOCK_D=BLOCK_D,
+            RATIO=ratio,
+        )
+
+    return out
+
+
+def _pytorch_forward(kv, score, ape, norm_weight, ratio, head_dim, has_halo, use_overlap, eps):
+    """PyTorch reference forward (differentiable, used for backward)."""
+    sq_with_halo, b, _ = kv.shape
+    cutoff = (sq_with_halo // ratio) * ratio
+    kv_cut = kv[:cutoff]
+    score_cut = score[:cutoff]
+    n_compressed = cutoff // ratio
+
+    coff = 2 if use_overlap else 1
+
+    kv_r = kv_cut.view(n_compressed, ratio, b, -1)
+    score_r = score_cut.view(n_compressed, ratio, b, -1)
+
+    score_r = score_r + ape.view(1, ratio, 1, -1)
+
+    if use_overlap:
+        d = head_dim
+        n_groups = n_compressed
+
+        new_kv = kv_r.new_full((n_groups, 2 * ratio, b, d), 0)
+        new_kv[:, ratio:] = kv_r[:, :, :, d:]
+        new_kv[1:, :ratio] = kv_r[:-1, :, :, :d]
+        kv_r = new_kv
+
+        new_score = score_r.new_full((n_groups, 2 * ratio, b, d), float("-inf"))
+        new_score[:, ratio:] = score_r[:, :, :, d:]
+        new_score[1:, :ratio] = score_r[:-1, :, :, :d]
+        score_r = new_score
+
+    kv_r = (kv_r * torch.softmax(score_r.float(), dim=1)).sum(dim=1)
+
+    if has_halo:
+        kv_r = kv_r[1:]
+
+    # RMSNorm
+    kv_f = kv_r.float()
+    var = (kv_f * kv_f).mean(dim=-1, keepdim=True)
+    kv_f = kv_f * torch.rsqrt(var + eps)
+    kv_f = kv_f * norm_weight.float()
+    return kv_f.to(torch.bfloat16)
+
+
+class FusedCompressorPostGEMM(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, kv, score, ape, norm_weight, ratio, head_dim, has_halo, use_overlap, eps):
+        ctx.save_for_backward(kv, score, ape, norm_weight)
+        ctx.ratio = ratio
+        ctx.head_dim = head_dim
+        ctx.has_halo = has_halo
+        ctx.use_overlap = use_overlap
+        ctx.eps = eps
+        return _triton_forward(kv, score, ape, norm_weight, ratio, head_dim, has_halo, use_overlap, eps)
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        kv, score, ape, norm_weight = ctx.saved_tensors
+        ratio = ctx.ratio
+        head_dim = ctx.head_dim
+        has_halo = ctx.has_halo
+        use_overlap = ctx.use_overlap
+        eps = ctx.eps
+
+        # Re-run PyTorch forward with autograd to get gradients
+        kv_d = kv.detach().requires_grad_(True)
+        score_d = score.detach().requires_grad_(True)
+        ape_d = ape.detach().requires_grad_(True)
+        norm_weight_d = norm_weight.detach().requires_grad_(True)
+
+        with torch.enable_grad():
+            out = _pytorch_forward(kv_d, score_d, ape_d, norm_weight_d, ratio, head_dim, has_halo, use_overlap, eps)
+            out.backward(grad_output)
+
+        return kv_d.grad, score_d.grad, ape_d.grad, norm_weight_d.grad, None, None, None, None, None
+
+
+def fused_compressor_post_gemm(
+    kv: torch.Tensor,
+    score: torch.Tensor,
+    ape: torch.Tensor,
+    norm_weight: torch.Tensor,
+    ratio: int,
+    head_dim: int,
+    has_halo: bool,
+    use_overlap: bool,
+    eps: float = 1e-6,
+) -> torch.Tensor:
+    """Fused compressor forward pass (post-GEMM operations).
+
+    Args:
+        kv: [sq_with_halo, b, coff * head_dim] from linear_wkv
+        score: [sq_with_halo, b, coff * head_dim] from linear_wgate
+        ape: [ratio, coff * head_dim] absolute position embedding (fp32)
+        norm_weight: [head_dim] RMSNorm weight
+        ratio: compression ratio (4 or 128)
+        head_dim: output head dimension
+        has_halo: whether to discard first group (halo)
+        use_overlap: whether overlap mode is active (ratio=4)
+        eps: RMSNorm epsilon
+
+    Returns:
+        [n_out, b, head_dim] normalized compressed KV (bf16)
+    """
+    return FusedCompressorPostGEMM.apply(kv, score, ape, norm_weight, ratio, head_dim, has_halo, use_overlap, eps)

--- a/megatron/core/transformer/experimental_attention_variant/test_fused_compressor.py
+++ b/megatron/core/transformer/experimental_attention_variant/test_fused_compressor.py
@@ -1,0 +1,183 @@
+"""Unit test for fused_compressor_kernel correctness."""
+
+import torch
+import torch.nn.functional as F
+
+import sys
+sys.path.insert(0, "/share/project/lixianduo/context_parallel/Megatron-LM-FL")
+
+from megatron.core.transformer.experimental_attention_variant.fused_compressor_kernel import (
+    fused_compressor_post_gemm,
+)
+
+
+def reference_compressor_post_gemm(kv, score, ape, norm_weight, ratio, head_dim, has_halo, use_overlap, eps):
+    """Reference implementation matching the original PyTorch code."""
+    sq_with_halo, b, _ = kv.shape
+    cutoff = (sq_with_halo // ratio) * ratio
+    kv = kv[:cutoff]
+    score = score[:cutoff]
+    n_compressed = cutoff // ratio
+
+    coff = 2 if use_overlap else 1
+
+    # Reshape: [n_compressed, ratio, b, coff * head_dim]
+    kv = kv.view(n_compressed, ratio, b, -1)
+    score = score.view(n_compressed, ratio, b, -1)
+
+    # APE: [ratio, coff * head_dim] -> [1, ratio, 1, coff * head_dim]
+    score = score + ape.view(1, ratio, 1, -1)
+
+    if use_overlap:
+        # _overlap_transform
+        d = head_dim
+        n_groups = n_compressed
+
+        # kv transform
+        new_kv = kv.new_full((n_groups, 2 * ratio, b, d), 0)
+        new_kv[:, ratio:] = kv[:, :, :, d:]
+        new_kv[1:, :ratio] = kv[:-1, :, :, :d]
+        kv = new_kv
+
+        # score transform
+        new_score = score.new_full((n_groups, 2 * ratio, b, d), float("-inf"))
+        new_score[:, ratio:] = score[:, :, :, d:]
+        new_score[1:, :ratio] = score[:-1, :, :, :d]
+        score = new_score
+
+    # softmax + weighted sum
+    kv = (kv * torch.softmax(score.float(), dim=1)).sum(dim=1)  # [n_compressed, b, head_dim]
+
+    # Discard halo
+    if has_halo:
+        kv = kv[1:]
+        n_compressed = n_compressed - 1
+
+    # RMSNorm
+    kv = kv.float()
+    var = (kv * kv).mean(dim=-1, keepdim=True)
+    kv = kv * torch.rsqrt(var + eps)
+    kv = kv * norm_weight.float()
+    kv = kv.to(torch.bfloat16)
+
+    return kv
+
+
+def test_no_overlap():
+    """Test non-overlap mode (ratio=128)."""
+    torch.manual_seed(42)
+    ratio = 128
+    head_dim = 128
+    coff = 1
+    sq_with_halo = 2048 + ratio  # with halo
+    b = 1
+
+    kv = torch.randn(sq_with_halo, b, coff * head_dim, dtype=torch.bfloat16, device="cuda")
+    score = torch.randn(sq_with_halo, b, coff * head_dim, dtype=torch.bfloat16, device="cuda")
+    ape = torch.randn(ratio, coff * head_dim, dtype=torch.float32, device="cuda")
+    norm_weight = torch.ones(head_dim, dtype=torch.float32, device="cuda")
+
+    ref = reference_compressor_post_gemm(kv, score, ape, norm_weight, ratio, head_dim, True, False, 1e-6)
+    out = fused_compressor_post_gemm(kv, score, ape, norm_weight, ratio, head_dim, True, False, 1e-6)
+
+    print(f"[no_overlap] ref shape: {ref.shape}, out shape: {out.shape}")
+    print(f"[no_overlap] max diff: {(ref.float() - out.float()).abs().max().item():.6f}")
+    print(f"[no_overlap] mean diff: {(ref.float() - out.float()).abs().mean().item():.6f}")
+
+    # Allow some tolerance for bf16 + triton
+    assert ref.shape == out.shape, f"Shape mismatch: {ref.shape} vs {out.shape}"
+    assert (ref.float() - out.float()).abs().max().item() < 0.05, "Too large difference!"
+    print("[no_overlap] PASSED\n")
+
+
+def test_overlap():
+    """Test overlap mode (ratio=4)."""
+    torch.manual_seed(42)
+    ratio = 4
+    head_dim = 128
+    coff = 2
+    sq_with_halo = 2048 + ratio  # with halo
+    b = 1
+
+    kv = torch.randn(sq_with_halo, b, coff * head_dim, dtype=torch.bfloat16, device="cuda")
+    score = torch.randn(sq_with_halo, b, coff * head_dim, dtype=torch.bfloat16, device="cuda")
+    ape = torch.randn(ratio, coff * head_dim, dtype=torch.float32, device="cuda")
+    norm_weight = torch.ones(head_dim, dtype=torch.float32, device="cuda")
+
+    ref = reference_compressor_post_gemm(kv, score, ape, norm_weight, ratio, head_dim, True, True, 1e-6)
+    out = fused_compressor_post_gemm(kv, score, ape, norm_weight, ratio, head_dim, True, True, 1e-6)
+
+    print(f"[overlap] ref shape: {ref.shape}, out shape: {out.shape}")
+    print(f"[overlap] max diff: {(ref.float() - out.float()).abs().max().item():.6f}")
+    print(f"[overlap] mean diff: {(ref.float() - out.float()).abs().mean().item():.6f}")
+
+    assert ref.shape == out.shape, f"Shape mismatch: {ref.shape} vs {out.shape}"
+    assert (ref.float() - out.float()).abs().max().item() < 0.05, "Too large difference!"
+    print("[overlap] PASSED\n")
+
+
+def test_no_halo():
+    """Test without halo (cp_size=1 scenario)."""
+    torch.manual_seed(42)
+    ratio = 128
+    head_dim = 128
+    coff = 1
+    sq = 2048
+    b = 1
+
+    kv = torch.randn(sq, b, coff * head_dim, dtype=torch.bfloat16, device="cuda")
+    score = torch.randn(sq, b, coff * head_dim, dtype=torch.bfloat16, device="cuda")
+    ape = torch.randn(ratio, coff * head_dim, dtype=torch.float32, device="cuda")
+    norm_weight = torch.ones(head_dim, dtype=torch.float32, device="cuda")
+
+    ref = reference_compressor_post_gemm(kv, score, ape, norm_weight, ratio, head_dim, False, False, 1e-6)
+    out = fused_compressor_post_gemm(kv, score, ape, norm_weight, ratio, head_dim, False, False, 1e-6)
+
+    print(f"[no_halo] ref shape: {ref.shape}, out shape: {out.shape}")
+    print(f"[no_halo] max diff: {(ref.float() - out.float()).abs().max().item():.6f}")
+    print(f"[no_halo] mean diff: {(ref.float() - out.float()).abs().mean().item():.6f}")
+
+    assert ref.shape == out.shape, f"Shape mismatch: {ref.shape} vs {out.shape}"
+    assert (ref.float() - out.float()).abs().max().item() < 0.05, "Too large difference!"
+    print("[no_halo] PASSED\n")
+
+
+def test_backward():
+    """Test that backward pass produces valid gradients."""
+    torch.manual_seed(42)
+    ratio = 4
+    head_dim = 128
+    coff = 2
+    sq_with_halo = 64 + ratio
+    b = 1
+
+    kv = torch.randn(sq_with_halo, b, coff * head_dim, dtype=torch.bfloat16, device="cuda", requires_grad=True)
+    score = torch.randn(sq_with_halo, b, coff * head_dim, dtype=torch.bfloat16, device="cuda", requires_grad=True)
+    ape = torch.randn(ratio, coff * head_dim, dtype=torch.float32, device="cuda", requires_grad=True)
+    norm_weight = torch.ones(head_dim, dtype=torch.float32, device="cuda", requires_grad=True)
+
+    out = fused_compressor_post_gemm(kv, score, ape, norm_weight, ratio, head_dim, True, True, 1e-6)
+    loss = out.float().sum()
+    loss.backward()
+
+    assert kv.grad is not None, "kv.grad is None"
+    assert score.grad is not None, "score.grad is None"
+    assert ape.grad is not None, "ape.grad is None"
+    assert norm_weight.grad is not None, "norm_weight.grad is None"
+
+    print(f"[backward] kv.grad norm: {kv.grad.float().norm().item():.6f}")
+    print(f"[backward] score.grad norm: {score.grad.float().norm().item():.6f}")
+    print(f"[backward] ape.grad norm: {ape.grad.float().norm().item():.6f}")
+    print(f"[backward] norm_weight.grad norm: {norm_weight.grad.float().norm().item():.6f}")
+
+    assert kv.grad.float().norm().item() > 0, "kv.grad is zero"
+    assert score.grad.float().norm().item() > 0, "score.grad is zero"
+    print("[backward] PASSED\n")
+
+
+if __name__ == "__main__":
+    test_no_overlap()
+    test_overlap()
+    test_no_halo()
+    test_backward()
+    print("All tests passed!")

--- a/megatron/core/transformer/transformer_config.py
+++ b/megatron/core/transformer/transformer_config.py
@@ -384,6 +384,12 @@ class TransformerConfig(ModelParallelConfig):
     """Whether to use dense mode for compressed sparse attention. If True, the CSA indexer will be
     disabled."""
 
+    enable_fused_compressor: bool = False
+    """Enable fused Triton kernel for CSA Compressor (fuse GEMM + post-GEMM ops)."""
+
+    enable_compressor_allgather_overlap: bool = False
+    """Overlap compressor all-gather with indexer weights projection."""
+
     ####################
     # linear attention
     ####################

--- a/megatron/core/utils.py
+++ b/megatron/core/utils.py
@@ -2048,6 +2048,38 @@ def get_batch_on_this_cp_rank(
     return batch
 
 
+def get_batch_on_this_cp_rank_contiguous(
+    batch: Dict[str, Any], cp_group: Optional[torch.distributed.ProcessGroup] = None
+):
+    """Slice batch input along sequence dimension with contiguous split.
+
+    Unlike get_batch_on_this_cp_rank which uses 2-chunk pattern for load balancing,
+    this uses simple contiguous split: rank_i gets [i*chunk_size, (i+1)*chunk_size).
+
+    Args:
+        batch (Dict[str, Any]): Input batch tensors.
+        cp_group (Optional[torch.distributed.ProcessGroup]): Context-parallel process group.
+    """
+    if cp_group is not None:
+        cp_size = get_pg_size(cp_group)
+        cp_rank = get_pg_rank(cp_group)
+    else:
+        cp_size = parallel_state.get_context_parallel_world_size()
+        cp_rank = parallel_state.get_context_parallel_rank()
+
+    if cp_size > 1:
+        for key, val in batch.items():
+            if val is not None:
+                seq_dim = 1 if key != 'attention_mask' else 2
+                seq_len = val.shape[seq_dim]
+                chunk_size = seq_len // cp_size
+                start = cp_rank * chunk_size
+                val = val.narrow(seq_dim, start, chunk_size)
+                batch[key] = val
+
+    return batch
+
+
 def get_thd_batch_on_this_cp_rank(
     batch: Dict[str, Any],
     cu_seqlens: torch.Tensor,

--- a/tests/unit_tests/transformer/test_sliding_window_cp.py
+++ b/tests/unit_tests/transformer/test_sliding_window_cp.py
@@ -1,0 +1,208 @@
+"""
+Unit test for sliding window attention + context parallel (contiguous split).
+
+Verifies that:
+1. _exchange_kv_halo correctly exchanges boundary tokens between ranks
+2. get_window_topk_idxs_cp generates correct indices with halo offset
+3. The full CP sliding window path produces the same output as the non-CP baseline
+
+Usage:
+    torchrun --nproc_per_node=2 test_sliding_window_cp.py
+"""
+
+import os
+import torch
+import torch.distributed as dist
+
+
+def setup():
+    dist.init_process_group("nccl")
+    rank = dist.get_rank()
+    torch.cuda.set_device(rank)
+
+
+def teardown():
+    dist.destroy_process_group()
+
+
+def test_exchange_kv_halo():
+    """Test that halo exchange correctly transfers boundary tokens."""
+    rank = dist.get_rank()
+    world_size = dist.get_world_size()
+    device = torch.cuda.current_device()
+
+    local_seq_len = 2048
+    batch_size = 2
+    head_dim = 128
+    halo_size = 127  # window_size - 1
+
+    # Each rank has KV with values = rank * 1000 + position
+    kv = torch.arange(local_seq_len, device=device, dtype=torch.float32)
+    kv = kv.unsqueeze(1).unsqueeze(2).expand(-1, batch_size, head_dim).clone()
+    kv += rank * 10000  # make values distinguishable per rank
+
+    from megatron.core.transformer.experimental_attention_variant.csa_utils import _exchange_halo
+
+    cp_group = dist.group.WORLD
+    kv_with_halo = _exchange_halo(kv, halo_size, cp_group)
+
+    if rank == 0:
+        # rank 0 should not have halo (no predecessor)
+        assert (
+            kv_with_halo.shape[0] == local_seq_len
+        ), f"rank 0 should have no halo, got shape {kv_with_halo.shape[0]}"
+        assert torch.equal(kv_with_halo, kv)
+        print(f"[rank {rank}] halo exchange: PASS (no halo)")
+    else:
+        # rank > 0 should have halo prepended
+        assert (
+            kv_with_halo.shape[0] == halo_size + local_seq_len
+        ), f"rank {rank} expected {halo_size + local_seq_len}, got {kv_with_halo.shape[0]}"
+        # The halo should be the last halo_size tokens from the previous rank
+        expected_halo_start = (rank - 1) * 10000 + (local_seq_len - halo_size)
+        actual_halo_start = kv_with_halo[0, 0, 0].item()
+        assert (
+            abs(actual_halo_start - expected_halo_start) < 1e-5
+        ), f"rank {rank} halo start mismatch: expected {expected_halo_start}, got {actual_halo_start}"
+        # Local part should be unchanged
+        assert torch.equal(kv_with_halo[halo_size:], kv)
+        print(f"[rank {rank}] halo exchange: PASS")
+
+
+def test_window_indices_cp():
+    """Test that CP-aware window indices are correct."""
+    rank = dist.get_rank()
+    device = torch.cuda.current_device()
+
+    from megatron.core.transformer.experimental_attention_variant.csa import get_window_topk_idxs
+    from megatron.core.transformer.experimental_attention_variant.csa_utils import (
+        get_window_topk_idxs_cp,
+    )
+
+    window_size = 128
+    local_seq_len = 2048
+    batch_size = 1
+
+    # rank 0: halo_size = 0 (same as original)
+    if rank == 0:
+        idxs_orig = get_window_topk_idxs(window_size, batch_size, local_seq_len, device)
+        idxs_cp = get_window_topk_idxs_cp(window_size, batch_size, local_seq_len, 0, device)
+        assert torch.equal(idxs_orig, idxs_cp), "rank 0 CP indices should match original"
+        print(f"[rank {rank}] window indices: PASS (matches original)")
+
+    # rank 1: halo_size = window_size - 1
+    if rank == 1:
+        halo_size = window_size - 1
+        idxs_cp = get_window_topk_idxs_cp(window_size, batch_size, local_seq_len, halo_size, device)
+
+        # For query position 0 on rank 1 (global position = local_seq_len):
+        # Its position in kv_with_halo is 0 + halo_size = 127
+        # Its window should be [127 - 127, ..., 127] = [0, 1, ..., 127]
+        expected_first_row = torch.arange(window_size, device=device)
+        actual_first_row = idxs_cp[0, 0, :]
+        assert torch.equal(actual_first_row, expected_first_row), (
+            f"rank 1 first query window mismatch:\n"
+            f"  expected: {expected_first_row[:5]}...{expected_first_row[-5:]}\n"
+            f"  actual:   {actual_first_row[:5]}...{actual_first_row[-5:]}"
+        )
+
+        # For query position 1 on rank 1:
+        # Its position in kv_with_halo is 1 + halo_size = 128
+        # Its window should be [1, 2, ..., 128]
+        expected_second_row = torch.arange(1, window_size + 1, device=device)
+        actual_second_row = idxs_cp[0, 1, :]
+        assert torch.equal(
+            actual_second_row, expected_second_row
+        ), f"rank 1 second query window mismatch"
+
+        # No -1 values should exist (halo provides full history)
+        assert (idxs_cp >= 0).all(), "rank 1 should have no -1 padding with full halo"
+        print(f"[rank {rank}] window indices: PASS")
+
+
+def test_full_sliding_window_cp():
+    """End-to-end test: CP output should match non-CP baseline."""
+    rank = dist.get_rank()
+    world_size = dist.get_world_size()
+    device = torch.cuda.current_device()
+
+    from megatron.core.transformer.experimental_attention_variant.csa import (
+        get_window_topk_idxs,
+        unfused_compressed_sparse_attn,
+    )
+    from megatron.core.transformer.experimental_attention_variant.csa_utils import (
+        _exchange_halo,
+        get_window_topk_idxs_cp,
+    )
+
+    torch.manual_seed(42)
+
+    seq_len = 4096
+    local_seq_len = seq_len // world_size
+    batch_size = 1
+    num_heads = 16
+    head_dim = 128
+    window_size = 128
+
+    # Generate full-sequence Q and KV on all ranks (for baseline comparison)
+    query_full = torch.randn(seq_len, batch_size, num_heads, head_dim, device=device)
+    kv_full = torch.randn(seq_len, batch_size, head_dim, device=device)
+    attn_sink = torch.zeros(num_heads, device=device)
+    softmax_scale = head_dim**-0.5
+
+    # --- Baseline: non-CP (full sequence) ---
+    window_idxs_full = get_window_topk_idxs(window_size, batch_size, seq_len, device).int()
+    output_baseline = unfused_compressed_sparse_attn(
+        query_full, kv_full, attn_sink, window_idxs_full, softmax_scale
+    )
+
+    # --- CP path: each rank processes its local chunk ---
+    start = rank * local_seq_len
+    end = start + local_seq_len
+
+    query_local = query_full[start:end].contiguous()
+    kv_local = kv_full[start:end].contiguous()
+
+    # Halo exchange
+    cp_group = dist.group.WORLD
+    halo_size = window_size - 1 if rank > 0 else 0
+    kv_with_halo = _exchange_halo(kv_local, window_size - 1, cp_group)
+
+    # CP-aware window indices
+    window_idxs_cp = get_window_topk_idxs_cp(
+        window_size, batch_size, local_seq_len, halo_size, device
+    ).int()
+
+    # Sparse attention on local chunk with halo
+    output_cp_local = unfused_compressed_sparse_attn(
+        query_local, kv_with_halo, attn_sink, window_idxs_cp, softmax_scale
+    )
+
+    # Compare with baseline slice
+    output_baseline_local = output_baseline[start:end]
+
+    max_diff = (output_cp_local - output_baseline_local).abs().max().item()
+    mean_diff = (output_cp_local - output_baseline_local).abs().mean().item()
+
+    passed = max_diff < 1e-4
+    status = "PASS" if passed else "FAIL"
+    print(
+        f"[rank {rank}] full sliding window CP: {status} "
+        f"(max_diff={max_diff:.2e}, mean_diff={mean_diff:.2e})"
+    )
+    assert passed, f"rank {rank} output mismatch: max_diff={max_diff}"
+
+
+if __name__ == "__main__":
+    setup()
+    try:
+        test_exchange_kv_halo()
+        dist.barrier()
+        test_window_indices_cp()
+        dist.barrier()
+        test_full_sliding_window_cp()
+        dist.barrier()
+        if dist.get_rank() == 0:
+            print("\n=== All tests PASSED ===")
+    finally:
+        teardown()


### PR DESCRIPTION
# Context Parallel (CP) support for sparse attention mechanisms in deepseek-v4

## Part I: Functional Support

### 1. Sliding Window Attention + CP

- (1) switching to a contiguous sequence split mode so that each rank holds a consecutive chunk of the global sequence, 
- (2) a P2P halo exchange that prepends boundary tokens from the previous rank,
- (3) an offset-aware index computation that correctly addresses into the halo-augmented KV buffer. Additionally, RoPE is adapted to encode global positions rather than local ones.

### 2. HCA (Hybrid Compressed Attention) + CP

- (1) halo exchange for compression boundary handling when groups span ranks, 
- (2) deduplication logic that discards the halo group to avoid double-counting tokens already compressed by the previous 
- (3) a differentiable all-gather that assembles the global compressed KV while preserving gradient flow,
- (4) dense compressed indexing where each query attends to all compressed tokens with global causal masking.

### 3. CSA (Compressed Sparse Attention) + CP

- (1) handling the overlapping compression groups at rank boundaries through halo exchange and halo group deduplication (same as HCA but with overlap), 
- (2) computing a global causal mask based on which global positions each compressed token covers,
- (3) assembling the final KV buffer that combines halo-augmented local KV and global compressed KV with correct index offsets for the sparse attention kernel.

## Part II: Performance Optimization

### 1. Fused Triton Kernel for Compressor

- (1) The compressor's post-GEMM pipeline consists of multiple small operations (cutoff, reshape, APE addition, overlap transform, softmax, weighted sum, halo discard, RMSNorm) that individually have high kernel launch overhead and excessive memory traffic. 
- (2) Fuse all of these into a single Triton kernel with two variants (non-overlap for ratio=128, overlap for ratio=4). To maintain training correctness, the forward pass uses the Triton kernel for speed while the backward pass uses standard PyTorch ops for gradient computation.

### 2. Async All-Gather / Compute Overlap

- (1) After local compression, each rank must all-gather compressed KV from all other ranks before the indexer can compute top-k scores. 
- (2) Launch a non-blocking all-gather and overlap it with the weights projection GEMM. This hides a significant portion of the communication latency behind useful computation.

### 3. Compressor Refactoring for Pipeline

- (1) To enable the async overlap pattern, the Compressor's forward method is refactored into a two-stage pipeline: `compress_local()` handles everything up to and including RoPE (halo exchange, GEMM, pooling, halo discard, normalization), and `forward()` optionally launches the all-gather synchronously or asynchronously. 
- (2) This separation gives the caller fine-grained control over when the all-gather is issued and when it is waited on, enabling the compute/communication overlap described above.