### PR TITLE
Migrate XME blocking patches into ME-FL overrides

### DIFF
--- a/megatron/core/dist_checkpointing/strategies/filesystem_async.py
+++ b/megatron/core/dist_checkpointing/strategies/filesystem_async.py
@@ -49,6 +49,7 @@ except ImportError:
 _results_queue = None
 
 # FlagScale Begin
+from megatron.plugin.decorators import overridable
 from megatron.plugin.platform import get_platform
 
 cur_platform = get_platform()
@@ -117,6 +118,7 @@ class FileSystemWriterAsync(FileSystemWriter):
         self.results_queue: Optional[mp.Queue] = None
         self.separation_hint = separation_hint
 
+    @overridable  # FlagScale Add
     def prepare_write_data(self, plan: SavePlan, planner: SavePlanner) -> None:
         """
         First stage of async saving. Copy data to CPU and plan the local saving.
@@ -230,6 +232,7 @@ class FileSystemWriterAsync(FileSystemWriter):
         )
 
     @staticmethod
+    @overridable  # FlagScale Add
     def preload_tensors(write_buckets: List[WriteBucket], non_blocking=True) -> List[WriteBucket]:
         """
         Preloads tensors in `state_dict` to host memory via CPU memory.
@@ -366,6 +369,7 @@ class FileSystemWriterAsync(FileSystemWriter):
         logger.debug(f"{w_end}, rank: {rank}, write(sync,threads): {w_end - w_start}")
 
     @staticmethod
+    @overridable  # FlagScale Add
     @_disable_gc()
     def write_preloaded_data(
         transform_list: List[_StorageWriterTransforms],

--- a/megatron/core/tensor_parallel/random.py
+++ b/megatron/core/tensor_parallel/random.py
@@ -23,6 +23,7 @@ from megatron.core.parallel_state import (
     get_tensor_model_parallel_rank,
 )
 from megatron.core.utils import is_te_min_version, safely_set_viewless_tensor_data
+from megatron.plugin.decorators import overridable  # FlagScale Add
 
 # ---------------------------------------------------------------------------
 # C++ extension: zero-copy storage sharing for CheckpointWithoutOutput
@@ -220,6 +221,7 @@ def get_data_parallel_rng_tracker_name():
     return _DATA_PARALLEL_RNG_TRACKER_NAME
 
 
+@overridable  # FlagScale Add
 class CudaRNGStatesTracker:
     """Tracker for the cuda RNG states.
 

--- a/megatron/core/transformer/moe/fused_a2a.py
+++ b/megatron/core/transformer/moe/fused_a2a.py
@@ -5,6 +5,10 @@
 
 from megatron.core.utils import internal_api
 
+########## FlagScale Begin ##########
+from megatron.plugin.decorators import overridable
+########## FlagScale End ##########
+
 try:
     from deep_ep import Buffer
     from deep_ep.utils import EventHandle, EventOverlap
@@ -30,6 +34,7 @@ def get_hidden_bytes(x: torch.Tensor) -> int:
     return x.size(1) * max(x.element_size(), 2)
 
 
+@overridable  # FlagScale Add
 def get_buffer(group: torch.distributed.ProcessGroup, hidden_bytes: int):
     """Get or create a buffer for all-to-all communication.
 
@@ -66,6 +71,7 @@ def get_buffer(group: torch.distributed.ProcessGroup, hidden_bytes: int):
     return _buffer
 
 
+@overridable  # FlagScale Add
 class FusedDispatch(torch.autograd.Function):
     """Fused dispatch operation for MoE routing combining computation and communication."""
 
@@ -160,6 +166,7 @@ class FusedDispatch(torch.autograd.Function):
         return grad_x, None, grad_token_probs, None, None, None, None
 
 
+@overridable  # FlagScale Add
 class FusedCombine(torch.autograd.Function):
     """Fused combine operation for MoE output combining computation and communication."""
 
@@ -209,6 +216,7 @@ class FusedCombine(torch.autograd.Function):
 
 if HAVE_DEEP_EP:
 
+    @overridable  # FlagScale Add
     def fused_dispatch(
         x,
         token_indices,
@@ -241,6 +249,7 @@ if HAVE_DEEP_EP:
             allocate_on_comm_stream,
         )
 
+    @overridable  # FlagScale Add
     def fused_combine(x, group, handle, async_finish=False, allocate_on_comm_stream=False):
         """Perform fused combine operation if deep_ep is available.
 

--- a/megatron/core/transformer/multi_token_prediction.py
+++ b/megatron/core/transformer/multi_token_prediction.py
@@ -39,6 +39,7 @@ from megatron.core.utils import (
 )
 
 ########## FlagScale Begin ##########
+from megatron.plugin.decorators import overridable
 from megatron.plugin.platform import get_platform
 
 cur_platform = get_platform()
@@ -376,6 +377,7 @@ class MTPLossLoggingHelper:
         tracker["reduce_group"] = None
         tracker["avg_group"] = None
 
+    @overridable  # FlagScale Add
     def reduce_loss_in_tracker():
         """Collect and reduce the mtp losses across ranks."""
         tracker = MTPLossLoggingHelper.tracker

--- a/megatron/plugin/decorators.py
+++ b/megatron/plugin/decorators.py
@@ -60,17 +60,33 @@ _original_impl_cache: set[Callable] = set()
 
 
 def _get_preferred_vendor() -> Optional[str]:
-    """Get the preferred vendor from MG_FL_PREFER environment variable.
+    """Get the preferred override vendor.
+
+    ``MG_FL_PREFER`` remains the explicit override selector. When it is unset,
+    follow the selected ME-FL platform so XPU-only patches activate with the
+    same runtime trigger as XME.
 
     Returns:
-        The vendor name string (lowercased), or None if not set.
+        Optional[str]: The vendor name string (lowercased) from MG_FL_PREFER,
+        or inferred from the selected platform (e.g. 'kunlunxin'), or None.
     """
     vendor = os.environ.get("MG_FL_PREFER")
     if vendor is not None:
         vendor = vendor.strip().lower()
         if vendor == "":
             return None
-    return vendor
+        return vendor
+
+    try:
+        from megatron.plugin.platform import platform_manager
+
+        platform = platform_manager.cur_platform
+        if platform is not None:
+            return platform.device_name()
+    except Exception as e:
+        logger.debug(f"Failed to infer override vendor from platform: {e}")
+
+    return None
 
 
 def register_override_method(method_key: str, implementation: Callable,
@@ -166,9 +182,14 @@ def get_override_method(method_key: str) -> Optional[Callable]:
         preferred = _get_preferred_vendor()
 
         # 1. Preferred vendor
-        if preferred is not None and preferred in vendor_map:
-            logger.debug(f"Using vendor '{preferred}' for {method_key}")
-            return vendor_map[preferred]
+        if preferred is not None:
+            if preferred in vendor_map:
+                logger.debug(f"Using vendor '{preferred}' for {method_key}")
+                return vendor_map[preferred]
+            if method_key in _lazy_registry and preferred in _lazy_registry[method_key]:
+                lazy_impl = _resolve_lazy_impl(method_key)
+                if lazy_impl is not None:
+                    return lazy_impl
 
         # 2. Default vendor
         if _DEFAULT_VENDOR in vendor_map:

--- a/megatron/plugin/kunlunxin/__init__.py
+++ b/megatron/plugin/kunlunxin/__init__.py
@@ -1,0 +1,1 @@
+"""KunLunXin vendor plugin implementations."""

--- a/megatron/plugin/kunlunxin/dist_checkpointing/__init__.py
+++ b/megatron/plugin/kunlunxin/dist_checkpointing/__init__.py
@@ -1,0 +1,1 @@
+"""KunLunXin dist checkpointing plugin implementations."""

--- a/megatron/plugin/kunlunxin/dist_checkpointing/strategies/__init__.py
+++ b/megatron/plugin/kunlunxin/dist_checkpointing/strategies/__init__.py
@@ -1,0 +1,1 @@
+"""KunLunXin dist checkpointing strategy plugins."""

--- a/megatron/plugin/kunlunxin/dist_checkpointing/strategies/filesystem_async.py
+++ b/megatron/plugin/kunlunxin/dist_checkpointing/strategies/filesystem_async.py
@@ -1,0 +1,218 @@
+"""KunLunXin plugin implementations for filesystem async checkpointing."""
+
+import importlib.util
+import inspect
+import logging
+import os
+import warnings
+from time import time
+from typing import List, Tuple, Union
+
+import torch
+from torch.distributed.checkpoint.filesystem import DEFAULT_SUFFIX, _StoragePrefix, _write_item
+from torch.distributed.checkpoint.planner import SavePlan, SavePlanner, WriteItemType
+from megatron.core.dist_checkpointing.strategies.filesystem_async import (
+    FileSystemWriterAsync,
+    WriteBucket,
+    _process_memory,
+    _split_by_separation_hint,
+    _split_by_size_and_type,
+    get_write_results_queue,
+    logger,
+)
+
+
+def _bridge_available() -> bool:
+    """Check if megatron.bridge is available."""
+    return importlib.util.find_spec("megatron.bridge") is not None
+
+
+def prepare_write_data(self, plan: SavePlan, planner: SavePlanner) -> None:
+    """Prepare async checkpoint write buckets for KunLunXin bridge path.
+
+    Args:
+        plan: Save plan from PyTorch distributed planner.
+        planner: Save planner for resolving bytes and tensor data.
+    """
+    if not _bridge_available():
+        return FileSystemWriterAsync.prepare_write_data.__wrapped__(self, plan, planner)
+
+    storage_plan: _StoragePrefix = plan.storage_data
+    start = time()
+    logger.debug(f"thread_count: {self.thread_count}, time: {start}")
+    if self.separation_hint:
+        assert self.thread_count > 1, "thread_count must be at least 2 if separation_hint is provided"
+    bins = self.thread_count // 2 if self.separation_hint is not None else self.thread_count
+    item_buckets = _split_by_size_and_type(bins, plan.items)
+    logger.debug(f"bucket_prep, time: {time() - start}")
+
+    start = time()
+    file_count = 0
+
+    def gen_file(prefix=""):
+        """Generate a unique checkpoint file name with optional prefix."""
+        nonlocal file_count
+        file_name = f"{prefix}{storage_plan.prefix}{file_count}{DEFAULT_SUFFIX}"
+        file_count += 1
+        return file_name
+
+    def _clone_or_dequantize_if_needed(ten: torch.Tensor):
+        """Detach and dequantize GPU tensors if needed."""
+        ten = ten.detach()
+        if ten.device.type != "cpu" and ten.device.type == "cuda" and "dequantize" in type(ten).__dict__:
+            ten = ten.dequantize()
+        return ten
+
+    self.write_buckets = []
+    for group_name, group_buckets in _split_by_separation_hint(
+        item_buckets, self.separation_hint
+    ).items():
+        for bucket in group_buckets:
+            bytes_data = [
+                (item, planner.resolve_data(item))
+                for item in bucket
+                if item.type == WriteItemType.BYTE_IO
+            ]
+            tensor_data = [
+                (item, _clone_or_dequantize_if_needed(planner.resolve_data(item)))
+                for item in bucket
+                if item.type != WriteItemType.BYTE_IO
+            ]
+            if len(bytes_data) > 0 or len(tensor_data) > 0:
+                file_name = gen_file(prefix=group_name)
+                self.write_buckets.append(
+                    (
+                        os.path.join(self.checkpoint_dir, file_name),
+                        file_name,
+                        (bytes_data, tensor_data),
+                    )
+                )
+
+    if len(self.write_buckets) > 0:
+        assert len(self.write_buckets) <= self.thread_count, (
+            len(self.write_buckets),
+            self.thread_count,
+        )
+        self.results_queue = get_write_results_queue()
+    else:
+        self.results_queue = None
+    end = time()
+    logger.debug(f"D2H and push, time: {end - start}")
+
+
+def preload_tensors_kunlunxin(
+    write_buckets: List[WriteBucket], non_blocking=True
+) -> List[WriteBucket]:
+    """Preload tensors with blocking D2H copies for KunLunXin.
+
+    Args:
+        write_buckets: List of write buckets to preload.
+        non_blocking: Whether to use non-blocking D2H (forced to False).
+
+    Returns:
+        List of write buckets with tensors moved to CPU.
+    """
+    if _bridge_available():
+        return write_buckets
+
+    if non_blocking:
+        warnings.warn(
+            "D2H might fail when `non_blocking` is True, force it to be False for KunLunXin."
+        )
+    return FileSystemWriterAsync.preload_tensors.__wrapped__(write_buckets, non_blocking=False)
+
+
+def write_preloaded_data(
+    transform_list,
+    local_proc_idx: int,
+    write_bucket: WriteBucket,
+    results_queue,
+    count_queue,
+    use_fsync: bool,
+    **kwargs,
+) -> Union[Tuple[int, Exception], None]:
+    """Write preloaded checkpoint data for KunLunXin bridge path.
+
+    Args:
+        transform_list: Storage writer transforms.
+        local_proc_idx: Index of the worker performing writing.
+        write_bucket: Data to write to storage.
+        results_queue: Queue to return write results (may be None for main worker).
+        count_queue: Queue to signal task completion (may be None).
+        use_fsync: If True, call os.fsync at end of saving.
+
+    Returns:
+        Tuple of (proc_idx, results) or (proc_idx, exception), or None.
+    """
+    if not _bridge_available():
+        return FileSystemWriterAsync.write_preloaded_data.__wrapped__(
+            transform_list,
+            local_proc_idx,
+            write_bucket,
+            results_queue,
+            count_queue,
+            use_fsync,
+            **kwargs,
+        )
+
+    logger = logging.getLogger(__name__)
+    logger.debug(f"{local_proc_idx} started")
+    mem_before = _process_memory()
+    use_msc = kwargs.get("use_msc", False)
+
+    local_results = []
+    try:
+        file_name, storage_key, (bytes_data, tensor_data) = write_bucket
+        extra_kwargs = {}
+        if "serialization_format" in inspect.signature(_write_item).parameters:
+            from torch.distributed.checkpoint.filesystem import SerializationFormat
+
+            extra_kwargs["serialization_format"] = SerializationFormat.TORCH_SAVE
+        if use_msc:
+            import multistorageclient as msc
+
+            open_file = msc.open
+        else:
+            open_file = open
+        with open_file(file_name, "wb") as stream:
+            for write_item, data in bytes_data:
+                local_results.append(
+                    _write_item(
+                        *transform_list, stream, data, write_item, storage_key, **extra_kwargs
+                    )
+                )
+
+            for write_item, tensor in tensor_data:
+                assert tensor.is_cpu
+                if tensor.dtype != torch.bfloat16:
+                    tensor = tensor.bfloat16()
+                if tensor.untyped_storage().size() != tensor.numel() * tensor.itemsize:
+                    tensor = tensor.clone()
+                local_results.append(
+                    _write_item(
+                        *transform_list, stream, tensor, write_item, storage_key, **extra_kwargs
+                    )
+                )
+
+            if use_fsync:
+                if use_msc:
+                    stream.fsync()
+                else:
+                    os.fsync(stream.fileno())
+        local_output = (local_proc_idx, local_results)
+    except Exception as e:
+        logger.debug(f"{local_proc_idx} failed")
+        local_output = (local_proc_idx, e)
+    if results_queue is not None:
+        results_queue.put(local_output)
+    if count_queue is not None:
+        count_queue.get()
+        count_queue.task_done()
+
+    mem_after = _process_memory()
+    logger.debug(
+        f"{local_proc_idx} consumed: {mem_after - mem_before},"
+        f" before: {mem_before}, after: {mem_after}"
+    )
+    return local_output
+

--- a/megatron/plugin/kunlunxin/tensor_parallel/random.py
+++ b/megatron/plugin/kunlunxin/tensor_parallel/random.py
@@ -1,0 +1,86 @@
+"""KunLunXin RNG tracker override matching XME v0.17 behavior."""
+
+import contextlib
+import logging
+import os
+
+import torch
+
+from megatron.core.tensor_parallel.random import (
+    CudaRNGStatesTracker as _CoreCudaRNGStatesTracker,
+    _MODEL_PARALLEL_RNG_TRACKER_NAME,
+)
+
+
+def _gpu_aligned_rng_enabled() -> bool:
+    """Check whether GPU-aligned RNG initialization is enabled via env var."""
+    value = os.getenv("TORCH_NN_INIT_IS_GPU_ALIGNED", "0")
+    return value.upper() in ("1", "TRUE", "YES", "Y")
+
+
+class CudaRNGStatesTrackerKunlunxin(_CoreCudaRNGStatesTracker):
+    """Cuda RNG tracker using XMLIR mock RNG state when XME enables it."""
+
+    def add(self, name, seed):
+        """Track the rng state using XMLIR mock RNG when GPU-aligned.
+
+        Args:
+            name: Unique name for the rng state.
+            seed: Integer seed for the rng state.
+        """
+        if not _gpu_aligned_rng_enabled():
+            return super().add(name, seed)
+
+        from torch_xmlir.symbrewrite.plugins.torch.mock_torch_init import (
+            MockRNGStateFinal,
+            get_global_mock_rng_state_final,
+            set_global_mock_rng_state_final,
+        )
+
+        self._is_initialized = True
+        if seed in self.seeds_:
+            raise Exception('seed {} already exists'.format(seed))
+        self.seeds_.add(seed)
+        if name in self.states_:
+            raise Exception('cuda rng state {} already exists'.format(name))
+
+        orig_rng_state = get_global_mock_rng_state_final()
+        new_state = MockRNGStateFinal()
+        set_global_mock_rng_state_final(new_state)
+
+        torch.cuda.manual_seed(seed)
+        self.states_[name] = get_global_mock_rng_state_final()
+
+        set_global_mock_rng_state_final(orig_rng_state)
+
+    @contextlib.contextmanager
+    def fork(self, name=_MODEL_PARALLEL_RNG_TRACKER_NAME):
+        """Fork the cuda rng state using XMLIR mock RNG when GPU-aligned.
+
+        Args:
+            name: Name of the previously added rng state to fork.
+        """
+        if not _gpu_aligned_rng_enabled():
+            with super().fork(name):
+                yield
+            return
+
+        from torch_xmlir.symbrewrite.plugins.torch.mock_torch_init import (
+            get_global_mock_rng_state_final,
+            set_global_mock_rng_state_final,
+        )
+
+        if name not in self.states_:
+            raise Exception('cuda rng state {} is not added'.format(name))
+        orig_rng_state = get_global_mock_rng_state_final()
+        set_global_mock_rng_state_final(self.states_[name])
+        cpu_rng_state = torch.get_rng_state()
+        try:
+            yield
+        finally:
+            if not torch.all(cpu_rng_state == torch.get_rng_state()).item():
+                logging.getLogger(__name__).warning(
+                    'CPU RNG state changed within GPU RNG context'
+                )
+            self.states_[name] = get_global_mock_rng_state_final()
+            set_global_mock_rng_state_final(orig_rng_state)

--- a/megatron/plugin/kunlunxin/transformer/__init__.py
+++ b/megatron/plugin/kunlunxin/transformer/__init__.py
@@ -1,0 +1,1 @@
+"""KunLunXin transformer plugin implementations."""

--- a/megatron/plugin/kunlunxin/transformer/moe/__init__.py
+++ b/megatron/plugin/kunlunxin/transformer/moe/__init__.py
@@ -1,0 +1,1 @@
+"""KunLunXin MoE plugin implementations."""

--- a/megatron/plugin/kunlunxin/transformer/moe/fused_a2a.py
+++ b/megatron/plugin/kunlunxin/transformer/moe/fused_a2a.py
@@ -1,0 +1,117 @@
+"""KunLunXin plugin implementations for megatron.core.transformer.moe.fused_a2a."""
+
+import torch
+
+from megatron.core.transformer.moe.fused_a2a import (
+    FusedCombine as _CoreFusedCombine,
+    FusedDispatch as _CoreFusedDispatch,
+)
+from megatron.plugin.platform import get_platform
+
+try:
+    from deep_ep import BufferV2
+except ImportError:
+    BufferV2 = None
+
+_buffer_v2 = None
+cur_platform = get_platform()
+
+
+def get_buffer(group: torch.distributed.ProcessGroup, hidden_bytes: int):
+    """Get or create a KunLunXin DeepEP BufferV2 communication buffer.
+
+    Args:
+        group: Distributed process group for communication.
+        hidden_bytes: Hidden size in bytes (unused, BufferV2 uses 0).
+    """
+    if BufferV2 is None:
+        return None
+
+    global _buffer_v2
+    if _buffer_v2 is None or _buffer_v2.group != group:
+        _buffer_v2 = BufferV2(group, 0, 0)
+    return _buffer_v2
+
+
+class FusedDispatchKunlunxin(_CoreFusedDispatch):
+    """KunLunXin fused dispatch with stream synchronization guards."""
+
+    @staticmethod
+    def forward(*args, **kwargs):
+        """Forward pass of fused dispatch."""
+        cur_platform.synchronize()
+        ret = _CoreFusedDispatch.forward(*args, **kwargs)
+        cur_platform.synchronize()
+        return ret
+
+    @staticmethod
+    def backward(*args, **kwargs):
+        """Backward pass of fused dispatch."""
+        cur_platform.synchronize()
+        ret = _CoreFusedDispatch.backward(*args, **kwargs)
+        cur_platform.synchronize()
+        return ret
+
+
+def fused_dispatch(
+    x,
+    token_indices,
+    token_probs,
+    num_experts,
+    group,
+    async_finish=False,
+    allocate_on_comm_stream=False,
+):
+    """Perform fused dispatch operation with KunLunXin synchronization guards.
+
+    Args:
+        x: Input tensor.
+        token_indices: Token routing indices.
+        token_probs: Token routing probabilities.
+        num_experts: Number of experts.
+        group: Distributed process group.
+        async_finish: Whether to finish asynchronously.
+        allocate_on_comm_stream: Whether to allocate on comm stream.
+    """
+    return FusedDispatchKunlunxin.apply(
+        x.contiguous(),
+        token_indices,
+        token_probs,
+        num_experts,
+        group,
+        async_finish,
+        allocate_on_comm_stream,
+    )
+
+
+class FusedCombineKunlunxin(_CoreFusedCombine):
+    """KunLunXin fused combine with stream synchronization guards."""
+
+    @staticmethod
+    def forward(*args, **kwargs):
+        """Forward pass of fused combine."""
+        cur_platform.synchronize()
+        ret = _CoreFusedCombine.forward(*args, **kwargs)
+        cur_platform.synchronize()
+        return ret
+
+    @staticmethod
+    def backward(*args, **kwargs):
+        """Backward pass of fused combine."""
+        cur_platform.synchronize()
+        ret = _CoreFusedCombine.backward(*args, **kwargs)
+        cur_platform.synchronize()
+        return ret
+
+
+def fused_combine(x, group, handle, async_finish=False, allocate_on_comm_stream=False):
+    """Perform fused combine operation with KunLunXin synchronization guards.
+
+    Args:
+        x: Input tensor.
+        group: Distributed process group.
+        handle: Dispatch handle from fused_dispatch.
+        async_finish: Whether to finish asynchronously.
+        allocate_on_comm_stream: Whether to allocate on comm stream.
+    """
+    return FusedCombineKunlunxin.apply(x, group, handle, async_finish, allocate_on_comm_stream)

--- a/megatron/plugin/kunlunxin/transformer/multi_token_prediction.py
+++ b/megatron/plugin/kunlunxin/transformer/multi_token_prediction.py
@@ -1,0 +1,23 @@
+"""KunLunXin plugin implementations for multi-token prediction."""
+
+import torch
+
+from megatron.core.transformer.multi_token_prediction import MTPLossLoggingHelper
+
+
+def reduce_loss_in_tracker():
+    """Collect and reduce the MTP losses across ranks for KunLunXin."""
+    tracker = MTPLossLoggingHelper.tracker
+    if "values" not in tracker:
+        return
+
+    values = tracker["values"]
+    if tracker.get("reduce_group") is not None:
+        torch.distributed.all_reduce(values, group=tracker.get("reduce_group"))
+
+    if tracker.get("avg_group") is not None:
+        torch.distributed.all_reduce(
+            values, group=tracker["avg_group"], op=torch.distributed.ReduceOp.SUM
+        )
+        group_size = torch.distributed.get_world_size(group=tracker["avg_group"])
+        values.div_(group_size)

--- a/megatron/plugin/override_registry.py
+++ b/megatron/plugin/override_registry.py
@@ -19,3 +19,69 @@ register(
     target="megatron.core.optimizer.clip_grads.get_grad_norm_fp32",
     impl="megatron.plugin.optimizer.clip_grads.get_grad_norm_fp32",
 )
+
+# =============================================================================
+# Transformer - multi_token_prediction
+# =============================================================================
+register(
+    target="megatron.core.transformer.multi_token_prediction.reduce_loss_in_tracker",
+    impl="megatron.plugin.kunlunxin.transformer.multi_token_prediction.reduce_loss_in_tracker",
+    vendor="kunlunxin",
+)
+
+# =============================================================================
+# Transformer - moe.fused_a2a
+# =============================================================================
+register(
+    target="megatron.core.transformer.moe.fused_a2a.get_buffer",
+    impl="megatron.plugin.kunlunxin.transformer.moe.fused_a2a.get_buffer",
+    vendor="kunlunxin",
+)
+register(
+    target="megatron.core.transformer.moe.fused_a2a.FusedDispatch",
+    impl="megatron.plugin.kunlunxin.transformer.moe.fused_a2a.FusedDispatchKunlunxin",
+    vendor="kunlunxin",
+)
+register(
+    target="megatron.core.transformer.moe.fused_a2a.FusedCombine",
+    impl="megatron.plugin.kunlunxin.transformer.moe.fused_a2a.FusedCombineKunlunxin",
+    vendor="kunlunxin",
+)
+register(
+    target="megatron.core.transformer.moe.fused_a2a.fused_dispatch",
+    impl="megatron.plugin.kunlunxin.transformer.moe.fused_a2a.fused_dispatch",
+    vendor="kunlunxin",
+)
+register(
+    target="megatron.core.transformer.moe.fused_a2a.fused_combine",
+    impl="megatron.plugin.kunlunxin.transformer.moe.fused_a2a.fused_combine",
+    vendor="kunlunxin",
+)
+
+# =============================================================================
+# Tensor parallel - random
+# =============================================================================
+register(
+    target="megatron.core.tensor_parallel.random.CudaRNGStatesTracker",
+    impl="megatron.plugin.kunlunxin.tensor_parallel.random.CudaRNGStatesTrackerKunlunxin",
+    vendor="kunlunxin",
+)
+
+# =============================================================================
+# Dist checkpointing - filesystem_async
+# =============================================================================
+register(
+    target="megatron.core.dist_checkpointing.strategies.filesystem_async.FileSystemWriterAsync.prepare_write_data",
+    impl="megatron.plugin.kunlunxin.dist_checkpointing.strategies.filesystem_async.prepare_write_data",
+    vendor="kunlunxin",
+)
+register(
+    target="megatron.core.dist_checkpointing.strategies.filesystem_async.preload_tensors",
+    impl="megatron.plugin.kunlunxin.dist_checkpointing.strategies.filesystem_async.preload_tensors_kunlunxin",
+    vendor="kunlunxin",
+)
+register(
+    target="megatron.core.dist_checkpointing.strategies.filesystem_async.write_preloaded_data",
+    impl="megatron.plugin.kunlunxin.dist_checkpointing.strategies.filesystem_async.write_preloaded_data",
+    vendor="kunlunxin",
+)

--- a/megatron/plugin/tests/test_override_manager.py
+++ b/megatron/plugin/tests/test_override_manager.py
@@ -254,12 +254,38 @@ class TestGetPreferredVendor(unittest.TestCase):
 
     def setUp(self):
         os.environ.pop("MG_FL_PREFER", None)
+        # Mock platform to prevent platform inference from leaking into tests
+        from megatron.plugin.platform import platform_manager
+
+        self._original_platform = platform_manager.cur_platform
+        platform_manager.cur_platform = None
 
     def tearDown(self):
         os.environ.pop("MG_FL_PREFER", None)
+        from megatron.plugin.platform import platform_manager
+
+        platform_manager.cur_platform = self._original_platform
 
     def test_unset(self):
         self.assertIsNone(_get_preferred_vendor())
+
+    def test_unset_uses_selected_kunlunxin_platform(self):
+        """Platform inference returns kunlunxin when that platform is selected."""
+        from megatron.plugin.platform import platform_manager
+
+        class KunlunxinPlatform:
+            """Stub platform returning kunlunxin device name."""
+
+            def device_name(self):
+                """Return the kunlunxin device name."""
+                return "kunlunxin"
+
+        original_platform = platform_manager.cur_platform
+        platform_manager.cur_platform = KunlunxinPlatform()
+        try:
+            self.assertEqual(_get_preferred_vendor(), "kunlunxin")
+        finally:
+            platform_manager.cur_platform = original_platform
 
     def test_empty(self):
         os.environ["MG_FL_PREFER"] = ""

--- a/tests/unit_tests/dist_checkpointing/test_async_utils_shutdown.py
+++ b/tests/unit_tests/dist_checkpointing/test_async_utils_shutdown.py
@@ -8,13 +8,15 @@ described in issue #3775).
 """
 
 from unittest import mock
-
-import pytest
-import torch
+import importlib
 
 from megatron.core.dist_checkpointing.strategies.async_utils import (
     PersistentAsyncCaller,
     TemporalAsyncCaller,
+)
+from megatron.plugin.decorators import get_override_method
+from megatron.plugin.kunlunxin.dist_checkpointing.strategies.filesystem_async import (
+    preload_tensors_kunlunxin,
 )
 
 
@@ -36,6 +38,35 @@ class TestPersistentAsyncCallerShutdown:
         with mock.patch("torch.distributed.is_initialized", return_value=False):
             # Must not raise
             caller.__del__()
+
+
+class TestFileSystemAsyncKunlunxin:
+    """Verify KunLunXin filesystem async checkpoint overrides."""
+
+    def test_filesystem_async_routes_to_kunlunxin_vendor(self, monkeypatch):
+        """KunLunXin vendor must own all migrated filesystem async patch points."""
+        monkeypatch.setenv("MG_FL_PREFER", "kunlunxin")
+        registry = importlib.import_module("megatron.plugin.override_registry")
+        importlib.reload(registry)
+        expected_module = "megatron.plugin.kunlunxin.dist_checkpointing.strategies.filesystem_async"
+        for key in (
+            "FileSystemWriterAsync.prepare_write_data",
+            "filesystem_async.preload_tensors",
+            "filesystem_async.write_preloaded_data",
+        ):
+            impl = get_override_method(key)
+            assert impl.__module__ == expected_module
+
+    def test_preload_tensors_skips_d2h_when_bridge_exists(self):
+        """Bridge mode must keep XME behavior and skip D2H staging."""
+        tensor = mock.Mock()
+        buckets = [("file", "key", ([], [("item", tensor)]))]
+
+        with mock.patch("importlib.util.find_spec", return_value=object()):
+            result = preload_tensors_kunlunxin(buckets, non_blocking=True)
+
+        assert result is buckets
+        tensor.to.assert_not_called()
 
 
 class TestTemporalAsyncCallerShutdown:


### PR DESCRIPTION
- Add ME-FL override hooks and registry entries for MTP loss reduction, DeepEP A2A, and async checkpointing
- Add KunLunXin plugin implementations for M13, DeepEP BufferV2/sync guards, and M11 filesystem async checkpointing
- Stage checkpoint tensors before persistent worker queue serialization to avoid XPU tensor sharing failures
- Add default passthrough plugins and route tests for default/KunLunXin override selection

Validation:
- PYTHONPATH=. pytest tests/unit_tests/dist_checkpointing/test_async_utils_shutdown.py -q
- PYTHONPATH=. python -m compileall ...
- Real XPU async checkpoint smoke with MG_FL_PREFER=kunlunxin

# Description

PR Description

## Type of change

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Infra/Build change (changes to CI/CD workflows or build scripts)
- [ ] Code refactoring
- [ ] Documentation change
- [ ] Bug fix
- [ ] Breaking change

## Changes

- Content 1
- Content 2
- Content 3
- Content 4

## Checklist

- [ ] I have read and followed the contributing guidelines
- [ ] The functionality is complete
- [ ] I have commented my code, particularly in coverage report uploading steps
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added/updated tests that prove my feature works
- [ ] New and existing unit tests pass locally
