### PR TITLE
[train]: fix bug of engram, remove wrong sequence_parallel flag of engram sub-modules.

### DIFF
--- a/megatron/core/transformer/engram.py
+++ b/megatron/core/transformer/engram.py
@@ -660,7 +660,6 @@ class ShortConv(nn.Module):
         norm_eps: float = 1e-5,
         hc_mult: int = 4,
         activation: bool = True,
-        sequence_parallel: bool = False,
     ):
         super().__init__()
         self.hc_mult = hc_mult
@@ -683,9 +682,6 @@ class ShortConv(nn.Module):
 
         if self.activation:
             self.act_fn = nn.SiLU()
-        # Set sequence_parallel to enable grad is correctly reduce across tensor_parallel_group.
-        for param in self.parameters():
-            param.sequence_parallel = sequence_parallel
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         """
@@ -753,7 +749,6 @@ class EngramModule(nn.Module):
             kernel_size=config.engram_kernel_size,
             dilation=config.max_ngram_size,
             hc_mult=self.hc_mult,
-            sequence_parallel=self.config.sequence_parallel,
         )
         engram_hidden_size = (
             config.max_ngram_size - 1
@@ -779,9 +774,6 @@ class EngramModule(nn.Module):
                 for _ in range(self.hc_mult)
             ]
         )
-        for module in [self.value_proj] + list(self.key_projs) + list(self.norm1) + list(self.norm2):
-            for param in module.parameters():
-                param.sequence_parallel = self.config.sequence_parallel
 
     def forward(self, hidden_states, hash_input_ids):
         """
@@ -835,8 +827,6 @@ class EngramModule(nn.Module):
         # Pre-compute scaling factor for efficiency
         scale = 1.0 / math.sqrt(self.config.hidden_size)
         gates = []
-        tp_rank = parallel_state.get_tensor_model_parallel_rank()
-        print(f"[TP rank {tp_rank}]: engram.norm1 = {self.norm1}, engram.norm2 = {self.norm2}")
         for hc_idx in range(self.hc_mult):
             key = self.key_projs[hc_idx](embeddings)
             # [L/tp_size, B, HIDDEN_SIZE]


### PR DESCRIPTION
# Description
Remove wrong sequence_parallel flag, because sequence has been all-gathered when entering engram module.

It is mistakenly pushed in pr https://github.com/flagos-ai/Megatron-LM-FL/pull/54(https://github.com/flagos-ai/Megatron-LM-FL/pull/54), this pr is used to remove it.

The sequence_parallel flag has been handled in pr https://github.com/flagos-ai/Megatron-LM-FL/pull/56.

## Type of change

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Infra/Build change (changes to CI/CD workflows or build scripts)
- [ ] Code refactoring
- [ ] Documentation change
- [ ✅] Bug fix
- [ ] Breaking change

## Changes

- Content 1
- Content 2
- Content 3
- Content 4

## Checklist

- [ ] I have read and followed the contributing guidelines
- [ ] The functionality is complete
- [ ] I have commented my code, particularly in coverage report uploading steps
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added/updated tests that prove my feature works
- [ ] New and existing unit tests pass locally
