### PR TITLE
[CICD] guard checkpoint energy monitoring and stabilize unit test CI

### DIFF
--- a/.github/workflows/unit_tests_common.yml
+++ b/.github/workflows/unit_tests_common.yml
@@ -118,6 +118,10 @@ jobs:
           # Ensure curl is available (required by coverage upload action)
           command -v curl || (apt-get update -qq && apt-get install -y --no-install-recommends curl 2>/dev/null)
 
+          # Keep all dependency installs on a protobuf version supported by wandb.
+          printf 'protobuf<7\n' > /tmp/megatron-unit-test-constraints.txt
+          export PIP_CONSTRAINT=/tmp/megatron-unit-test-constraints.txt
+
           # Install dependence package
           pip install torch boto3 mock pytest-mock coverage pytest-asyncio anyio wandb openai httpx nltk msgpack --no-cache-dir
           if [ "$PLATFORM" = "metax" ]; then
@@ -143,6 +147,7 @@ jobs:
           
           # Build
           pip install -e . --no-deps --no-build-isolation --no-cache-dir
+          python -c 'import google.protobuf, wandb; print("protobuf:", google.protobuf.__version__, "wandb:", wandb.__version__)'
         timeout-minutes: 30
 
       - name: Run unit tests - ${{ matrix.test_group.name }}

--- a/megatron/training/training.py
+++ b/megatron/training/training.py
@@ -2479,7 +2479,8 @@ def save_checkpoint_and_time(
 
     # Stop timer to get accurate train interval time and exclude checkpointing duration
     timers('interval-time').stop()
-    energy_monitor.pause()
+    if args.log_energy:
+        energy_monitor.pause()
 
     # Extra barrier is added to make sure all ranks report the max time.
     timer_key = 'save-checkpoint-non-persistent' if non_persistent_ckpt else 'save-checkpoint'
@@ -2537,7 +2538,8 @@ def save_checkpoint_and_time(
         )
 
     # Recover timing
-    energy_monitor.resume()
+    if args.log_energy:
+        energy_monitor.resume()
     timers('interval-time', log_level=0).start(barrier=True)
 
 

--- a/tests/unit_tests/test_training.py
+++ b/tests/unit_tests/test_training.py
@@ -889,6 +889,7 @@ def test_save_checkpoint_and_time_covers_persistent_progress_and_cleanup(monkeyp
         overlap_param_gather=True,
         fp8=True,
         log_progress=True,
+        log_energy=True,
         async_save=False,
     )
 
@@ -976,6 +977,7 @@ def test_save_checkpoint_and_time_non_persistent_skips_progress(monkeypatch):
         overlap_param_gather=False,
         fp8=False,
         log_progress=True,
+        log_energy=False,
         async_save=True,
     )
 
@@ -2742,3 +2744,509 @@ class TestSaveGrads:
             assert torch.equal(
                 loaded["model_chunk0"]["layer.bias"], state_dict["model_chunk0"]["layer.bias"]
             )
+
+def test_setup_model_and_optimizer_ckpt_convert_format(monkeypatch):
+    calls = []
+    args = SimpleNamespace(
+        skip_train=False,
+        perform_rl_step=False,
+        no_load_optim=False,
+        use_mup=False,
+        use_gloo_process_groups=False,
+        dump_param_to_param_group_map=False,
+        moe_use_upcycling=False,
+        load=None,
+        pretrained_checkpoint=None,
+        ckpt_convert_format="torch_dist",
+        ckpt_format="torch",
+        ckpt_convert_save="/tmp/converted",
+        save="/tmp/original",
+        fp16=False,
+        bf16=False,
+        use_torch_fsdp2=False,
+        iteration=0,
+        num_floating_point_operations_so_far=0,
+    )
+
+    class FakeTimerObj:
+        def start(self, barrier=False):
+            pass
+
+        def stop(self, barrier=False):
+            pass
+
+        def active_time(self):
+            return 1.5
+
+    class FakeTimers:
+        def __call__(self, name, log_level=None):
+            return FakeTimerObj()
+
+        def log(self, names):
+            pass
+
+    model = [SimpleNamespace()]
+    optimizer, scheduler = "optimizer", "scheduler"
+    optimizer_config = SimpleNamespace(optimizer="adam", timers=None)
+
+    monkeypatch.setattr(training, "get_args", lambda: args)
+    monkeypatch.setattr(training, "get_timers", lambda: FakeTimers())
+    monkeypatch.setattr(training, "get_one_logger", lambda: None)
+    monkeypatch.setattr(training, "get_model", lambda *a, **kw: model)
+    monkeypatch.setattr(training, "unwrap_model", lambda m: m)
+    monkeypatch.setattr(training, "get_megatron_optimizer_config", lambda a: (optimizer_config, {}))
+    monkeypatch.setattr(
+        training,
+        "get_megatron_optimizer",
+        lambda c, m, **kw: calls.append("build-optimizer") or optimizer,
+    )
+    monkeypatch.setattr(training, "get_optimizer_param_scheduler", lambda o: scheduler)
+    monkeypatch.setattr(
+        training, "update_use_dist_ckpt", lambda a: calls.append("update-dist-ckpt")
+    )
+    monkeypatch.setattr(
+        training,
+        "save_checkpoint",
+        lambda it, m, o, s, f, **kw: calls.append(("save", it, f is not None)),
+    )
+    monkeypatch.setattr(training, "print_rank_0", lambda msg: calls.append(("print", msg)))
+    monkeypatch.setattr(training.torch.distributed, "barrier", lambda **kw: calls.append("barrier"))
+
+    with pytest.raises(SystemExit) as exc_info:
+        training.setup_model_and_optimizer(lambda: None, training.ModelType.encoder_or_decoder)
+
+    assert exc_info.value.code is None
+    assert "update-dist-ckpt" in calls
+    assert ("save", 0, True) in calls
+    assert calls[-1] == "barrier"
+    assert any("converted checkpoint" in str(c) for c in calls)
+
+
+def test_setup_model_and_optimizer_moe_upcycling(monkeypatch):
+    calls = []
+    args = SimpleNamespace(
+        skip_train=False,
+        perform_rl_step=False,
+        no_load_optim=False,
+        use_mup=False,
+        use_gloo_process_groups=False,
+        dump_param_to_param_group_map=False,
+        moe_use_upcycling=True,
+        num_experts=8,
+        expert_model_parallel_size=2,
+        ffn_hidden_size=4096,
+        moe_upcycling_granularity=2,
+        load=None,
+        pretrained_checkpoint=None,
+        ckpt_convert_format=None,
+        save="/tmp/upcycled",
+        fp16=True,
+        bf16=False,
+        use_torch_fsdp2=False,
+        ckpt_format="torch",
+        iteration=0,
+        num_floating_point_operations_so_far=0,
+    )
+
+    class FakeOptimizer:
+        def reload_model_params(self):
+            calls.append("reload-model-params")
+
+    class FakeTimerObj:
+        def start(self, barrier=False):
+            pass
+
+        def stop(self, barrier=False):
+            pass
+
+        def active_time(self):
+            return 1.5
+
+    class FakeTimers:
+        def __call__(self, name, log_level=None):
+            return FakeTimerObj()
+
+        def log(self, names):
+            pass
+
+    model = [SimpleNamespace()]
+    dense_model = [SimpleNamespace()]
+    optimizer = FakeOptimizer()
+    scheduler = "scheduler"
+    optimizer_config = SimpleNamespace(optimizer="adam", timers=None)
+
+    # first call returns model, second returns dense_model
+    model_calls = [model, dense_model]
+    call_idx = [0]
+
+    def fake_get_model(*a, **kw):
+        result = model_calls[call_idx[0]]
+        call_idx[0] += 1
+        return result
+
+    monkeypatch.setattr(training, "get_args", lambda: args)
+    monkeypatch.setattr(training, "get_timers", lambda: FakeTimers())
+    monkeypatch.setattr(training, "get_one_logger", lambda: None)
+    monkeypatch.setattr(training, "get_model", fake_get_model)
+    monkeypatch.setattr(training, "unwrap_model", lambda m: m)
+    monkeypatch.setattr(
+        training,
+        "get_megatron_optimizer_config",
+        lambda a: (optimizer_config, {}),
+    )
+    monkeypatch.setattr(
+        training,
+        "get_megatron_optimizer",
+        lambda c, m, **kw: calls.append("build-optimizer") or optimizer,
+    )
+    monkeypatch.setattr(training, "get_optimizer_param_scheduler", lambda o: scheduler)
+    monkeypatch.setattr(
+        training,
+        "checkpoint_exists",
+        lambda path: calls.append(("checkpoint-exists", path)) or False,
+    )
+    monkeypatch.setattr(
+        training.torch.distributed,
+        "barrier",
+        lambda **kw: calls.append("barrier"),
+    )
+    monkeypatch.setattr(
+        training,
+        "save_checkpoint",
+        lambda it, m, o, s, f, **kw: calls.append(("save", it)),
+    )
+    monkeypatch.setattr(
+        training, "print_rank_0", lambda msg: calls.append(("print", msg))
+    )
+    monkeypatch.setattr(
+        training,
+        "load_checkpoint",
+        lambda m, o, s, **kw: calls.append("load-checkpoint") or (0, 0.0),
+    )
+    monkeypatch.setattr(
+        training.upcycling_utils,
+        "load_and_upcycle_model",
+        lambda lc, uw, dm, **kw: calls.append("upcycle") or (None, 999.0),
+    )
+
+    training.setup_model_and_optimizer(
+        lambda: None, training.ModelType.encoder_or_decoder
+    )
+
+    assert "barrier" in calls
+    assert ("checkpoint-exists", "/tmp/upcycled") in calls
+    assert "build-optimizer" in calls
+    assert "upcycle" in calls
+    assert ("save", 1) in calls
+    assert "reload-model-params" in calls
+    assert any("Upcycled checkpoint" in str(c) for c in calls)
+
+    assert args.iteration == 0
+    assert args.num_floating_point_operations_so_far == 0
+    assert args.num_experts == 8
+    assert args.expert_model_parallel_size == 2
+    assert args.ffn_hidden_size == 4096
+
+
+def test_train_step_save_dgrads_and_wgrads_paths(monkeypatch):
+    calls = []
+    args = SimpleNamespace(
+        seq_length=1024,
+        decoder_seq_length=None,
+        micro_batch_size=4,
+        global_batch_size=32,
+        data_parallel_size=1,
+        save="/tmp/grads",
+        save_dgrads_interval=1,
+        save_wgrads_interval=1,
+        reuse_grad_buf_for_mxfp8_param_ag=False,
+        overlap_param_gather=False,
+        empty_unused_memory_level=0,
+        vision_pretraining=False,
+        vision_pretraining_type="",
+        barrier_with_L1_time=False,
+        log_num_zeros_in_grad=False,
+        qk_clip=False,
+        log_max_attention_logit=False,
+    )
+    data_iterator = iter([None])
+
+    class FakeOptimizer:
+        def zero_grad(self):
+            pass
+
+        def step(self):
+            calls.append("optimizer-step")
+            return True, torch.tensor(1.0), torch.tensor(0)
+
+    optimizer = FakeOptimizer()
+    opt_param_scheduler = SimpleNamespace(
+        step=lambda *, increment: calls.append(("scheduler-step", increment))
+    )
+
+    model = [SimpleNamespace()]
+    model[0].force_all_reduce = False
+    model[0].zero_grad_buffer = lambda: None
+
+    class FakeParam:
+        main_grad = None
+
+    def fake_named_parameters():
+        p = FakeParam()
+        p.main_grad = torch.ones(4, 4)
+        yield ("layer.weight", p)
+
+    monkeypatch.setattr(training, "unwrap_model",
+                        lambda m: SimpleNamespace(named_parameters=fake_named_parameters))
+
+    loop_counter = [0]
+
+    class FakeRerunMachine:
+        def should_run_forward_backward(self, di):
+            loop_counter[0] += 1
+            if loop_counter[0] == 1:
+                return True
+            return False
+
+        def should_checkpoint_and_exit(self):
+            return False, False, None
+
+    class FakeTimer:
+        def start(self, barrier=False):
+            pass
+
+        def stop(self, barrier=False):
+            pass
+
+    class FakeTimers:
+        def __call__(self, name, log_level=None):
+            return FakeTimer()
+
+    monkeypatch.setattr(training, "get_args", lambda: args)
+    monkeypatch.setattr(training, "get_timers", lambda: FakeTimers())
+    monkeypatch.setattr(training, "get_num_microbatches", lambda: 1)
+    monkeypatch.setattr(training, "get_rerun_state_machine", lambda: FakeRerunMachine())
+    monkeypatch.setattr(training, "has_nvidia_modelopt", False)
+    monkeypatch.setattr(training, "clip_qk", lambda m, **kw: 0.0)
+    monkeypatch.setattr(training, "reduce_max_stat_across_model_parallel_group", lambda v: v)
+    monkeypatch.setattr(training, "logical_and_across_model_parallel_group", lambda v: v)
+    monkeypatch.setattr(training, "enable_dgrad_logging",
+                        lambda m, s: calls.append("enable-dgrad"))
+    monkeypatch.setattr(training, "disable_dgrad_logging",
+                        lambda: calls.append("disable-dgrad"))
+    monkeypatch.setattr(training, "save_dgrads",
+                        lambda it: calls.append(("save-dgrads", it)))
+    monkeypatch.setattr(training, "save_grads",
+                        lambda save_dir, sd, it, label: calls.append(("save-grads", label, it)))
+    monkeypatch.setattr(training.mpu, "is_pipeline_last_stage", lambda **kw: False)
+
+
+    def fake_forward_backward(**kw):
+        calls.append("fbw")
+        return [{"lm_loss": torch.tensor(1.0)}]
+
+    training.train_step(
+        forward_step_func=lambda *a, **kw: None,
+        data_iterator=data_iterator,
+        model=model,
+        optimizer=optimizer,
+        opt_param_scheduler=opt_param_scheduler,
+        config=SimpleNamespace(timers=None),
+        forward_backward_func=fake_forward_backward,
+        iteration=0,
+    )
+
+    # The dgrad path runs inside the forward-backward loop.
+    assert "enable-dgrad" in calls
+    assert "fbw" in calls
+    assert "disable-dgrad" in calls
+    assert ("save-dgrads", 1) in calls
+    # The wgrad path runs after the forward-backward loop.
+    assert ("save-grads", "wgrads", 1) in calls
+    assert ("scheduler-step", 4) in calls
+
+
+# ============================================================================
+# Coverage test for GRPO, world size, and memory metrics in training_log.
+# ============================================================================
+def test_training_log_grpo_and_auxiliary_writer_paths(monkeypatch):
+    """Cover previously untested writer and scalar paths in training_log.
+
+    The existing skipped/nan/memory test uses writer=None, so it does not
+    exercise the writer branch. This test supplies writers and enables the
+    corresponding logging options.
+
+    Covered paths include:
+      - skipped-train-samples > 0 writer and wandb logging
+      - log_world_size_to_tensorboard=True
+      - perform_rl_step=True GRPO collection iteration
+      - log_memory_to_tensorboard=True memory metrics
+      - log_loss_scale_to_tensorboard=True
+      - log_max_attention_logit=True
+      - RL sequence-packing metrics
+      - grad norm logging
+    """
+    calls = []
+    real_tensor = torch.tensor
+
+    def cpu_tensor(*items, **kwargs):
+        kwargs.pop("device", None)
+        return real_tensor(*items, **kwargs)
+
+    class FakeWriter:
+        def add_scalar(self, name, value, iteration):
+            calls.append(("scalar", name, value, iteration))
+
+    class FakeWandb:
+        def log(self, payload, iteration=None):
+            calls.append(("wandb", tuple(sorted(payload)), iteration))
+
+    class FakeTimer:
+        def elapsed(self, barrier=False, reset=True):
+            return 4.0
+
+    class FakeTimers:
+        def __call__(self, name, log_level=None):
+            return FakeTimer()
+
+        def write(self, *items, **kwargs):
+            pass
+
+        def log(self, names, normalizer=None, reset=True):
+            pass
+
+    class FakeMemStats:
+        def __getitem__(self, key):
+            return 1024
+
+    args = SimpleNamespace(
+        timing_log_level=1,
+        perform_rl_step=True,
+        rl_use_sequence_packing=True,
+        grpo_iterations=1,
+        grpo_samples_per_iteration=128,
+        global_batch_size=32,
+        micro_batch_size=2,
+        data_parallel_size=2,
+        world_size=8,
+        seq_length=8,
+        tensorboard_log_interval=10,                   # Log on iteration 10.
+        consumed_train_samples=16,
+        skipped_train_samples=10,
+        log_loss_scale_to_tensorboard=True,
+        log_world_size_to_tensorboard=True,
+        log_memory_to_tensorboard=True,
+        log_max_attention_logit=True,
+        num_experts=None,                              # Keep MoE logging disabled.
+        moe_router_load_balancing_type="",
+        moe_z_loss_coeff=None,
+        num_layers=3,
+        moe_per_layer_logging=False,
+        moe_layer_freq=[1, 0, 1],
+        mtp_num_layers=1,
+        dsa_indexer_loss_coeff=0.2,
+        log_interval=2,
+        train_iters=12,
+        log_throughput=True,
+        log_timers_to_tensorboard=False,
+        log_energy=True,
+        record_memory_history=False,
+        memory_snapshot_path="unused",
+        log_memory_interval=2,
+    )
+
+    # Both the availability flag and RL utility module must be mocked.
+    class FakeRlUtils:
+        @staticmethod
+        def get_sequence_packing_tensorboard_metrics(args):
+            calls.append("rl-packing-metrics")
+            return {"packed_bins": 5}
+
+        @staticmethod
+        def get_sequence_packing_log_info(args):
+            return " packed bins: 5 |"
+
+    monkeypatch.setattr(training.torch, "tensor", cpu_tensor)
+    monkeypatch.setattr(training, "get_args", lambda: args)
+    monkeypatch.setattr(training, "get_timers", lambda: FakeTimers())
+    monkeypatch.setattr(training, "get_tensorboard_writer", lambda: FakeWriter())
+    monkeypatch.setattr(training, "get_wandb_writer", lambda: FakeWandb())
+    monkeypatch.setattr(training, "get_one_logger", lambda: None)
+    monkeypatch.setattr(training, "get_energy_monitor",
+                        lambda: SimpleNamespace(lap=lambda: 40.0))
+    monkeypatch.setattr(training, "get_num_microbatches", lambda: 2)
+    monkeypatch.setattr(training, "reduce_max_stat_across_model_parallel_group",
+                        lambda value: value)
+    monkeypatch.setattr(training.one_logger_utils, "track_app_tag",
+                        lambda *items: None)
+    monkeypatch.setattr(training.one_logger_utils, "track_e2e_metrics",
+                        lambda *items: None)
+    monkeypatch.setattr(training, "num_floating_point_operations",
+                        lambda args, batch_size: 8e12)
+    monkeypatch.setattr(training, "print_rank_last", lambda message: None)
+    monkeypatch.setattr(training, "is_hybrid_model", lambda args: False)
+    monkeypatch.setattr(training, "track_moe_metrics", lambda **kwargs: None)
+    monkeypatch.setattr(training.MTPLossLoggingHelper, "track_mtp_metrics",
+                        lambda *items: None)
+    monkeypatch.setattr(training.DSAIndexerLossLoggingHelper,
+                        "track_indexer_metrics", lambda **kwargs: None)
+    monkeypatch.setattr(training.torch.distributed, "get_rank", lambda: 0)
+    monkeypatch.setattr(training, "report_theoretical_memory",
+                        lambda *items, **kwargs: None)
+    monkeypatch.setattr(training, "report_memory", lambda message: calls.append(("memory", message)))
+    monkeypatch.setattr(training, "get_loaded_iteration", lambda: 0)
+    # Enable the mocked RL logging path.
+    monkeypatch.setattr(training, "has_rl_utils", True)
+    monkeypatch.setattr(training, "rl_utils", FakeRlUtils())
+    # Return deterministic CUDA memory statistics.
+    monkeypatch.setattr(training.torch.cuda, "memory_stats", lambda: FakeMemStats())
+
+    training_log(
+        {"lm loss": torch.tensor([2.0])},
+        total_loss_dict={},
+        learning_rate=0.0001,
+        iteration=10,
+        loss_scale=64.0,
+        report_memory_flag=True,
+        skipped_iter=0,
+        grad_norm=torch.tensor(1.0),
+        params_norm=None,
+        num_zeros_in_grad=None,
+        max_attention_logit=0.5,
+    )
+
+    # Verify the expected TensorBoard scalars.
+    scalar_names = {
+        item[1]
+        for item in calls
+        if isinstance(item, tuple) and len(item) == 4 and item[0] == "scalar"
+    }
+    assert "skipped-train-samples" in scalar_names
+    assert "grpo_collection_iteration" in scalar_names
+    assert "world-size" in scalar_names
+    assert "mem-reserved-bytes" in scalar_names
+    assert "mem-allocated-bytes" in scalar_names
+    assert "mem-max-allocated-bytes" in scalar_names
+    assert "loss-scale" in scalar_names
+    assert "max_attention_logit" in scalar_names
+    assert "grad-norm" in scalar_names
+    assert "batch-size" in scalar_names
+
+    # Verify that wandb receives metrics too.
+    assert any(item[0] == "wandb" for item in calls)
+
+    # Verify the calculated GRPO collection iteration.
+    # iteration=10, grpo_iterations=1, grpo_samples_per_iteration=128, global_batch_size=32
+    # grpo_collection_iteration = 10 // (1 * (128//32)) = 10 // 4 = 2
+    grpo_calls = [
+        item
+        for item in calls
+        if isinstance(item, tuple)
+        and len(item) == 4
+        and item[0] == "scalar"
+        and item[1] == "grpo_collection_iteration"
+    ]
+    assert grpo_calls[0][2] == 2
+
+    # Verify that the sequence-packing helper was called.
+    assert "rl-packing-metrics" in calls

--- a/tests/unit_tests/test_training.py
+++ b/tests/unit_tests/test_training.py
@@ -3145,6 +3145,7 @@ def test_training_log_grpo_and_auxiliary_writer_paths(monkeypatch):
         moe_layer_freq=[1, 0, 1],
         mtp_num_layers=1,
         dsa_indexer_loss_coeff=0.2,
+        csa_compress_ratios=None,
         log_interval=2,
         train_iters=12,
         log_throughput=True,


### PR DESCRIPTION
# Description

Fix a CUDA functional test segmentation fault caused by checkpoint code accessing an uninitialized NVML energy-monitor handle when `log_energy` is disabled. Also stabilize the unit test environment and correct recently added training tests to match the actual production behavior.

## Type of change

- [ ] New feature (non-breaking change which adds functionality)
- [x] Infra/Build change (changes to CI/CD workflows or build scripts)
- [ ] Code refactoring
- [x] Bug fix
- [ ] Documentation change
- [ ] Breaking change

## Root cause

When `log_energy=False`, `EnergyMonitor.setup()` is not called and its NVML device handle remains uninitialized. However, the checkpoint path still called `energy_monitor.pause()` and `energy_monitor.resume()` unconditionally.

At the end of training, this passed an invalid handle to `nvmlDeviceGetTotalEnergyConsumption`, causing all ranks to terminate with SIGSEGV.

The unit test workflow also allowed protobuf 7.x to be installed, which is incompatible with the current wandb package and caused pytest collection failures.

## Changes

- **Energy monitor guard**: Call `energy_monitor.pause()` and `resume()` during checkpointing only when `args.log_energy` is enabled
- **Behavior preservation**: Keep existing energy monitoring behavior unchanged when energy logging is enabled
- **Dependency stability**: Apply a `protobuf<7` pip constraint across all unit test dependency installation commands
- **Early environment validation**: Verify protobuf and wandb imports during CI environment setup
- **Checkpoint conversion test**: Correctly assert the expected `SystemExit` behavior
- **MoE upcycling test**: Verify checkpoint saving at iteration 1 and the subsequent runtime-state reset
- **Gradient logging test**: Fix the `save_grads` patch target and complete the required `train_step` mocks
- **RL logging test**: Complete sequence-packing mocks and safely filter recorded scalar calls

## Validation

- CUDA functional training completes without the NVML segmentation fault
- Checkpoint and exit handling completes successfully with `log_energy=False`
- CUDA unit test suite passes
- Protobuf and wandb compatibility is validated during CI setup
- Existing energy logging behavior remains covered when `log_energy=True`

## Checklist

- [x] I have read and followed the contributing guidelines
- [x] The functionality is complete
- [x] I have commented my code, particularly in CI workflow setup steps
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added/updated tests that cover the changed behavior
- [x] New and existing CUDA CI tests pass