### PR TITLE
Add Fused dsa kernel for sm90.

### DIFF
--- a/megatron/core/transformer/experimental_attention_variant/csa.py
+++ b/megatron/core/transformer/experimental_attention_variant/csa.py
@@ -20,16 +20,61 @@ from megatron.core.transformer.experimental_attention_variant.dsa import (
     fused_qk_topk_naive,
     rotate_activation,
 )
-from megatron.core.transformer.experimental_attention_variant.dsa_kernels import (
-    build_flat_topk_idxs,
-    dsa_sparse_attn,
-    fused_indexer_sparse_attn,
-    indexer_topk,
-)
 from megatron.core.transformer.module import MegatronModule
 from megatron.core.transformer.spec_utils import ModuleSpec, build_module
 from megatron.core.transformer.transformer_config import TransformerConfig
 from megatron.core.utils import nvtx_range_pop, nvtx_range_push
+
+##### FlagScale Begin #####
+# ---------------------------------------------------------------------------
+# Backend dispatch: SM90 (Triton) vs SM100+ (FlashMLA + cuDNN)
+#
+# Each kernel file exposes the same high-level API so the dispatch here is
+# a simple import switch — no adapters or wrappers needed.
+# ---------------------------------------------------------------------------
+
+_dsa_sparse_attn = None
+_fused_indexer_sparse_attn = None
+_indexer_topk = None
+_build_flat_topk_idxs_fn = None
+
+
+def _ensure_dsa_kernels():
+    """Lazily resolve the correct kernel backend based on GPU SM version.
+
+    SM90 (Hopper): Triton-based kernels from megatron.plugin.dsa_kernel.
+    SM100+ (Blackwell): FlashMLA + cuDNN kernels from dsa_kernels.py.
+    """
+    global _dsa_sparse_attn, _fused_indexer_sparse_attn, _indexer_topk, _build_flat_topk_idxs_fn
+    if _dsa_sparse_attn is not None:
+        return
+
+    sm = torch.cuda.get_device_capability()
+    if sm[0] >= 10:
+        # SM100+: use the cuDNN/FlashMLA implementations.
+        from megatron.core.transformer.experimental_attention_variant.dsa_kernels import (
+            build_flat_topk_idxs,
+            dsa_sparse_attn,
+            fused_indexer_sparse_attn,
+            indexer_topk,
+        )
+        _dsa_sparse_attn = dsa_sparse_attn
+        _fused_indexer_sparse_attn = fused_indexer_sparse_attn
+        _indexer_topk = indexer_topk
+        _build_flat_topk_idxs_fn = build_flat_topk_idxs
+    else:
+        # SM90: use the Triton plugin implementations.
+        from megatron.plugin.dsa_kernel.triton_dsa_kernels import (
+            build_flat_topk_idxs as _triton_build_flat_topk_idxs,
+            dsa_sparse_attn_sbhd as _triton_dsa_sparse_attn_sbhd,
+            fused_indexer_sparse_attn as _triton_fused,
+            indexer_topk as _triton_topk,
+        )
+        _dsa_sparse_attn = _triton_dsa_sparse_attn_sbhd
+        _fused_indexer_sparse_attn = _triton_fused
+        _indexer_topk = _triton_topk
+        _build_flat_topk_idxs_fn = _triton_build_flat_topk_idxs
+##### FlagScale End #####
 
 # ---------------------------------------------------------------------------
 # Helper functions for index computation
@@ -613,6 +658,10 @@ class CompressedSparseAttention(MegatronModule):
         self.softmax_scale = softmax_scale
 
         self.apply_dsa_kernel_fusion = config.apply_dsa_kernel_fusion
+        ##### FlagScale Begin #####
+        if self.apply_dsa_kernel_fusion:
+            _ensure_dsa_kernels()
+        ##### FlagScale End #####
 
         # Learnable attention sink per head
         self.attn_sink = nn.Parameter(torch.zeros(self.n_local_heads, dtype=torch.float32))
@@ -787,17 +836,17 @@ class CompressedSparseAttention(MegatronModule):
             compress_topk_idxs = get_compress_topk_idxs(
                 self.compress_ratio, b, sq, offset, query.device
             )
-            flat_idxs, _ = build_flat_topk_idxs(
+            flat_idxs, _ = _build_flat_topk_idxs_fn(                ##### FlagScale Begin #####
                 window_idxs, compress_topk_idxs, batch_size=b, seqlen_kv=kv_full.shape[0]
             )
         else:
-            flat_idxs, _ = build_flat_topk_idxs(
+            flat_idxs, _ = _build_flat_topk_idxs_fn(                ##### FlagScale Begin #####
                 window_idxs, batch_size=b, seqlen_kv=kv_full.shape[0]
             )
         nvtx_range_pop("compressed_indices")
 
         nvtx_range_push("sparse_attn_kernel")
-        output = dsa_sparse_attn(
+        output = _dsa_sparse_attn(                                  ##### FlagScale Begin #####
             query, kv_full, self.attn_sink.float(), flat_idxs, self.softmax_scale
         )
         nvtx_range_pop("sparse_attn_kernel")
@@ -823,7 +872,7 @@ class CompressedSparseAttention(MegatronModule):
         q_indexer, k_indexer, weights_indexer = self.indexer.forward_before_topk(
             x_det, qr_det, packed_seq_params
         )
-        topk_indices_cmp, _ = indexer_topk(
+        topk_indices_cmp, _ = _indexer_topk(        ##### FlagScale Begin #####
             q_indexer,
             k_indexer,
             weights_indexer,
@@ -832,13 +881,13 @@ class CompressedSparseAttention(MegatronModule):
             indexer_softmax_scale=self.indexer.softmax_scale,
         )
         compress_topk_idxs = torch.where(topk_indices_cmp >= 0, topk_indices_cmp + offset, -1)
-        flat_idxs, flat_tlen = build_flat_topk_idxs(
+        flat_idxs, flat_tlen = _build_flat_topk_idxs_fn(            ##### FlagScale Begin #####
             window_idxs, compress_topk_idxs, batch_size=b, seqlen_kv=kv_full.shape[0], compact=True
         )
         nvtx_range_pop("compressed_indices")
 
         nvtx_range_push("sparse_attn_kernel")
-        output = dsa_sparse_attn(
+        output = _dsa_sparse_attn(          ##### FlagScale Begin #####
             query,
             kv_full,
             self.attn_sink.float(),
@@ -875,7 +924,7 @@ class CompressedSparseAttention(MegatronModule):
         indexer_loss_coeff = self.config.dsa_indexer_loss_coeff or 0.0
 
         nvtx_range_push("sparse_attn_kernel")
-        output, indexer_loss = fused_indexer_sparse_attn(
+        output, indexer_loss = _fused_indexer_sparse_attn(          ##### FlagScale Begin #####
             query,
             kv_full,
             self.attn_sink.float(),

--- a/megatron/core/transformer/transformer_config.py
+++ b/megatron/core/transformer/transformer_config.py
@@ -399,9 +399,12 @@ class TransformerConfig(ModelParallelConfig):
     disabled."""
 
     apply_dsa_kernel_fusion: bool = False
-    """If True, use fused DSA sparse-attention kernels (FlashMLA forward + cuDNN DSA backward,
-    indexer scoring, and top-K selection). Requires ``flash_mla`` and ``nvidia-cudnn-frontend``
-    with CuTe-DSL support. When False, falls back to unfused PyTorch implementations."""
+    ##### FlagScale Begin #####
+    """If True, use fused DSA sparse-attention kernels. On SM100+ (Blackwell), uses FlashMLA
+    forward + cuDNN DSA backward (requires ``flash_mla`` and ``nvidia-cudnn-frontend``).
+    On SM90 (Hopper), uses Triton-based fused kernels (requires ``triton>=3.0``).
+    When False, falls back to unfused PyTorch implementations."""
+    ##### FlagScale End #####
 
     ####################
     # linear attention
@@ -1323,38 +1326,53 @@ class TransformerConfig(ModelParallelConfig):
                     torch.cuda.is_available()
                 ), "apply_dsa_kernel_fusion requires a CUDA device, but none is available."
                 sm = torch.cuda.get_device_capability()
-                assert sm[0] >= 10, (
-                    f"apply_dsa_kernel_fusion requires SM100+ (Blackwell or later), "
+                ##### FlagScale Begin #####
+                assert sm[0] >= 9, (
+                    f"apply_dsa_kernel_fusion requires SM90+ (Hopper or later), "
                     f"but current device has compute capability {sm[0]}.{sm[1]}."
                 )
 
-                _flash_mla_available = True
-                try:
-                    from flash_mla import flash_mla_sparse_fwd  # noqa: F401
-                except ImportError:
-                    _flash_mla_available = False
+                if sm[0] >= 10:
+                    # SM100+ (Blackwell): require FlashMLA + cuDNN DSA
+                    _flash_mla_available = True
+                    try:
+                        from flash_mla import flash_mla_sparse_fwd  # noqa: F401
+                    except ImportError:
+                        _flash_mla_available = False
 
-                _cudnn_dsa_available = True
-                try:
-                    from cudnn import DSA  # noqa: F401
-                except ImportError:
-                    _cudnn_dsa_available = False
+                    _cudnn_dsa_available = True
+                    try:
+                        from cudnn import DSA  # noqa: F401
+                    except ImportError:
+                        _cudnn_dsa_available = False
 
-                if not _flash_mla_available or not _cudnn_dsa_available:
-                    missing = []
-                    if not _flash_mla_available:
-                        missing.append(
-                            "flash_mla (install from "
-                            "https://github.com/deepseek-ai/FlashMLA/tree/nv_dev)"
+                    if not _flash_mla_available or not _cudnn_dsa_available:
+                        missing = []
+                        if not _flash_mla_available:
+                            missing.append(
+                                "flash_mla (install from "
+                                "https://github.com/deepseek-ai/FlashMLA/tree/nv_dev)"
+                            )
+                        if not _cudnn_dsa_available:
+                            missing.append("cudnn-frontend DSA (nvidia-cudnn-frontend[cutedsl])")
+                        raise ValueError(
+                            f"apply_dsa_kernel_fusion on SM100+ requires fused DSA kernels, "
+                            f"but the following packages are not available: "
+                            f"{', '.join(missing)}. "
+                            f"Install them or pass --no-dsa-kernel-fusion to use the unfused "
+                            f"PyTorch fallback."
                         )
-                    if not _cudnn_dsa_available:
-                        missing.append("cudnn-frontend DSA (nvidia-cudnn-frontend[cutedsl])")
-                    raise ValueError(
-                        f"apply_dsa_kernel_fusion requires fused DSA kernels, but the "
-                        f"following packages are not available: {', '.join(missing)}. "
-                        f"Install them or pass --no-dsa-kernel-fusion to use the unfused "
-                        f"PyTorch fallback."
-                    )
+                else:
+                    # SM90 (Hopper): require Triton-based fused kernels
+                    try:
+                        import triton  # noqa: F401
+                    except ImportError as e:
+                        raise ImportError(
+                            "apply_dsa_kernel_fusion on SM90 requires Triton for the "
+                            "fused sparse-attention kernels. Install triton>=3.0 or "
+                            "pass --no-dsa-kernel-fusion to use the unfused PyTorch fallback."
+                        ) from e
+                ##### FlagScale End #####
 
         if self.fp8:
             # cannot support first last layer bf16 with delayed scaling

--- a/megatron/plugin/dsa_kernel/legacy/__init__.py
+++ b/megatron/plugin/dsa_kernel/legacy/__init__.py
@@ -1,0 +1,7 @@
+# Copyright (c) 2026, FlagOS Contributors. All rights reserved.
+
+"""Legacy PyTorch BMM implementations for DSA sparse attention.
+
+Provides fallback forward/backward for non-HP scenarios (decoding, testing).
+Training always uses the HP WGMMA kernel in ``triton_sparse_attn.py``.
+"""

--- a/megatron/plugin/dsa_kernel/legacy/pytorch_sparse_attn.py
+++ b/megatron/plugin/dsa_kernel/legacy/pytorch_sparse_attn.py
@@ -1,0 +1,362 @@
+# Copyright (c) 2026, FlagOS Contributors. All rights reserved.
+
+"""
+Legacy PyTorch BMM sparse attention implementations.
+
+These implementations use cuBLAS batched GEMM (torch.bmm) for score computation.
+They are retained for:
+  1. Low-load / decoding scenarios (small TopK, short sequences)
+  2. Numerical reference testing against Triton kernels
+  3. Fallback when Triton compilation is unavailable
+
+Enable via environment variable: DSA_USE_LEGACY=1
+
+For training (seq>=2048, TopK>=256), use the pure Triton implementations
+in the parent package (triton_sparse_attn.py).
+"""
+
+from __future__ import annotations
+
+from typing import Optional, Tuple
+
+import torch
+from torch import Tensor
+
+
+# ---------------------------------------------------------------------------
+# Forward: PyTorch BMM sparse attention
+# ---------------------------------------------------------------------------
+
+
+def pytorch_sparse_attn_fwd(
+    q: Tensor,
+    kv: Tensor,
+    topk_idxs: Tensor,
+    softmax_scale: float,
+    d_v: int = 512,
+    attn_sink: Optional[Tensor] = None,
+    indexer_topk: int = 0,
+) -> Tuple[Tensor, Tensor, Optional[Tensor]]:
+    """PyTorch-native sparse attention forward using gather + batched matmul.
+
+    Uses cuBLAS batched GEMM for score computation instead of the Triton kernel's
+    per-position tiled loop. Computes attention scores in f32 for numerical
+    precision (aligned with unfused reference and backward recomputation),
+    while keeping the output weighted-sum in bf16 for performance.
+
+    Best suited for small TopK (<=256) and short sequences where cuBLAS
+    kernel launch overhead is amortized.
+
+    Args:
+        q: Query tensor ``(total_S_q, H, D)`` bf16.
+        kv: KV tensor ``(total_S_kv, D_full)`` bf16.
+        topk_idxs: ``(total_S_q, H, TopK)`` int32.
+        softmax_scale: attention scale factor.
+        d_v: value dimension.
+        attn_sink: ``(H,)`` f32 — per-head bias-only sink.
+        indexer_topk: if > 0, compute separate LSE for first positions.
+
+    Returns:
+        out: ``(total_S_q, H, d_v)`` bf16.
+        lse: ``(total_S_q, H)`` f32.
+        lse_indexer: ``(total_S_q, H)`` f32 if indexer_topk > 0, else None.
+    """
+    total_Sq, H, D = q.shape
+    TopK = topk_idxs.shape[-1]
+    d_kv = kv.shape[-1] if kv.dim() > 1 else D
+
+    # Detect shared indices (MLA mode): stride=0 on head dim means all heads
+    # share the same TopK indices. Gather once, broadcast to all heads.
+    shared_indices = (topk_idxs.stride(1) == 0)
+
+    if shared_indices:
+        # Gather KV once with shape (total_Sq, TopK, d_kv), then use einsum for scores.
+        # This avoids materializing (total_Sq, H, TopK, d_kv) which is H times larger.
+        idxs_1h = topk_idxs[:, 0, :]  # (total_Sq, TopK) — single head slice
+        valid_mask_1h = idxs_1h >= 0   # (total_Sq, TopK)
+        safe_idxs_1h = idxs_1h.clamp(min=0).long()
+        flat_idxs = safe_idxs_1h.reshape(-1)  # (total_Sq * TopK)
+        kv_gathered_1h = kv[flat_idxs].reshape(total_Sq, TopK, d_kv)  # bf16, (S, T, D)
+
+        # Scores via BMM in f32: Q(S,H,D) @ K(S,D,T) -> (S,H,T)
+        k_1h_f = kv_gathered_1h[:, :, :D].float()  # (S, T, D) f32
+        scores = torch.bmm(q.float(), k_1h_f.transpose(1, 2)) * softmax_scale  # (S, H, T) f32
+        del k_1h_f
+        valid_mask = valid_mask_1h.unsqueeze(1).expand(-1, H, -1)
+        scores = scores.masked_fill(~valid_mask, float("-inf"))
+
+        # LSE with optional sink
+        if attn_sink is not None:
+            sink_expanded = attn_sink.unsqueeze(0).unsqueeze(-1).expand(total_Sq, -1, -1)
+            scores_with_sink = torch.cat([scores, sink_expanded], dim=-1)
+            lse = torch.logsumexp(scores_with_sink, dim=-1)
+        else:
+            lse = torch.logsumexp(scores, dim=-1)
+
+        # Attention weights (f32)
+        P = torch.exp(scores - lse.unsqueeze(-1))
+        P = P.masked_fill(~valid_mask, 0.0)
+
+        # Output via BMM in bf16: P(S,H,T) @ V(S,T,Dv) -> (S,H,Dv)
+        v_1h = kv_gathered_1h[:, :, :d_v]  # (S, T, Dv) bf16
+        out = torch.bmm(P.to(torch.bfloat16), v_1h)  # (S, H, Dv) bf16
+
+        # Indexer LSE
+        lse_indexer = None
+        if indexer_topk > 0:
+            if indexer_topk >= TopK:
+                lse_indexer = lse.clone()
+            else:
+                idx_scores = scores[:, :, :indexer_topk]
+                lse_indexer = torch.logsumexp(idx_scores, dim=-1)
+
+        return out.to(torch.bfloat16), lse, lse_indexer
+
+    else:
+        # General path: per-head gather
+        valid_mask = topk_idxs >= 0  # (total_Sq, H, TopK)
+        safe_idxs = topk_idxs.clamp(min=0).long()
+        flat_idxs = safe_idxs.reshape(-1)  # (total_Sq * H * TopK)
+        kv_gathered = kv[flat_idxs].reshape(total_Sq, H, TopK, d_kv)  # bf16
+
+        # Compute scores in f32 via bmm for precision.
+        q_r = q.float().reshape(total_Sq * H, 1, D)  # (SH, 1, D) f32
+        k_r = kv_gathered[:, :, :, :D].float().reshape(total_Sq * H, TopK, D).transpose(1, 2)
+        scores = torch.bmm(q_r, k_r).squeeze(1).reshape(total_Sq, H, TopK) * softmax_scale
+        del q_r, k_r
+        scores = scores.masked_fill(~valid_mask, float("-inf"))
+
+        # LSE with optional sink
+        if attn_sink is not None:
+            sink_expanded = attn_sink.unsqueeze(0).unsqueeze(-1).expand(total_Sq, -1, -1)
+            scores_with_sink = torch.cat([scores, sink_expanded], dim=-1)
+            lse = torch.logsumexp(scores_with_sink, dim=-1)
+        else:
+            lse = torch.logsumexp(scores, dim=-1)
+
+        # Attention weights (f32 for precision)
+        P = torch.exp(scores - lse.unsqueeze(-1))
+        P = P.masked_fill(~valid_mask, 0.0)
+
+        # Output via bmm in bf16
+        P_bf16 = P.to(torch.bfloat16).reshape(total_Sq * H, 1, TopK)
+        v_r = kv_gathered[:, :, :, :d_v].reshape(total_Sq * H, TopK, d_v)
+        out = torch.bmm(P_bf16, v_r).squeeze(1).reshape(total_Sq, H, d_v)
+
+        # Indexer LSE
+        lse_indexer = None
+        if indexer_topk > 0:
+            if indexer_topk >= TopK:
+                lse_indexer = lse.clone()
+            else:
+                idx_scores = scores[:, :, :indexer_topk]
+                lse_indexer = torch.logsumexp(idx_scores, dim=-1)
+
+        return out.to(torch.bfloat16), lse, lse_indexer
+
+
+# ---------------------------------------------------------------------------
+# Backward: PyTorch BMM sparse attention (f32 score recomputation)
+# ---------------------------------------------------------------------------
+
+
+def pytorch_sparse_attn_bwd(
+    grad_out: Tensor,   # (total_Sq, H, d_v) bf16
+    query: Tensor,      # (total_Sq, H, D) bf16
+    kv: Tensor,         # (total_Skv, D_full) bf16
+    topk_idxs: Tensor,  # (total_Sq, H, TopK) int32, shared (stride(1)==0)
+    out: Tensor,        # (total_Sq, H, d_v) bf16
+    lse: Tensor,        # (total_Sq, H) f32
+    attn_sink: Optional[Tensor],  # (H,) f32 or None
+    softmax_scale: float,
+    d_v: int,
+) -> Tuple[Tensor, Tensor, Optional[Tensor]]:
+    """BMM-based backward for shared-index sparse attention (f32 path).
+
+    Recomputes scores via cuBLAS BMM (f32 inputs, same accumulation as
+    the PyTorch BMM forward) so that exp(scores - lse) is numerically consistent.
+
+    Returns:
+        (dq, dkv, d_sink) where dq is (total_Sq, H, D) and dkv is (total_Skv, D_full).
+    """
+    total_Sq, H, D = query.shape
+    total_Skv = kv.shape[0]
+    D_full = kv.shape[-1] if kv.dim() > 1 else D
+    TopK = topk_idxs.shape[-1]
+
+    # Shared indices: use head 0
+    idxs_shared = topk_idxs[:, 0, :]  # (total_Sq, TopK)
+    valid_shared = idxs_shared >= 0    # (total_Sq, TopK)
+    safe_shared = idxs_shared.clamp(min=0).long()
+
+    # Gather KV
+    flat_idxs = safe_shared.reshape(-1)
+    kv_gathered = kv[flat_idxs].reshape(total_Sq, TopK, D_full).float()
+
+    kv_is_shared = (D == d_v == D_full)
+
+    # Di = sum(dO * O) per (query, head)
+    Di = (grad_out.float() * out.float()).sum(dim=-1)  # (total_Sq, H)
+
+    # Recompute scores (f32 × f32 → f32)
+    q_f32 = query.float()
+    scores = torch.bmm(q_f32, kv_gathered[:, :, :D].transpose(1, 2)) * softmax_scale
+
+    # P = exp(scores - lse) * valid_mask
+    valid_exp = valid_shared.unsqueeze(1).expand(-1, H, -1)
+    P = torch.exp(scores - lse.unsqueeze(-1))
+    del scores
+    P.masked_fill_(~valid_exp, 0.0)
+
+    # dov = dO @ V^T (f32)
+    dO_f32 = grad_out.float()
+    dov = torch.bmm(dO_f32, kv_gathered[:, :, :d_v].transpose(1, 2))
+
+    # dS = P * (dov - Di) * scale
+    dS = P * (dov - Di.unsqueeze(-1)) * softmax_scale
+    del dov
+
+    # dQ = dS @ K (f32)
+    dq = torch.bmm(dS, kv_gathered[:, :, :D])
+
+    # dKV: dK = dS^T @ Q, dV = P^T @ dO
+    dkv_gathered = torch.bmm(dS.transpose(1, 2), q_f32)  # (S, TopK, D) f32
+    del dS
+    if kv_is_shared:
+        torch.baddbmm(dkv_gathered, P.transpose(1, 2), dO_f32, out=dkv_gathered)
+    else:
+        dv = torch.bmm(P.transpose(1, 2), dO_f32)
+        dkv_tmp = torch.zeros(
+            total_Sq, TopK, D_full, dtype=torch.float32, device=query.device
+        )
+        dkv_tmp[:, :, :D] = dkv_gathered
+        dkv_tmp[:, :, :d_v] += dv
+        dkv_gathered = dkv_tmp
+    del P, q_f32, dO_f32
+
+    # Scatter dkv_gathered back to full KV positions
+    dkv_gathered.masked_fill_(~valid_shared.unsqueeze(-1), 0.0)
+    dkv = torch.zeros(total_Skv, D_full, dtype=torch.float32, device=query.device)
+    dkv.scatter_add_(
+        0,
+        flat_idxs.unsqueeze(-1).expand(-1, D_full),
+        dkv_gathered.reshape(-1, D_full),
+    )
+
+    dq_out = dq.to(query.dtype)
+    dkv_out = dkv.to(kv.dtype)
+
+    # d_sink
+    d_sink = None
+    if attn_sink is not None:
+        p_sink = torch.exp(attn_sink.unsqueeze(0) - lse)  # (total_Sq, H)
+        ds_sink = -p_sink * Di
+        d_sink = ds_sink.sum(0)  # (H,)
+
+    return dq_out, dkv_out, d_sink
+
+
+# ---------------------------------------------------------------------------
+# Backward: PyTorch BMM for FusedIndexerSparseAttn (baseline f32 path)
+# ---------------------------------------------------------------------------
+
+
+def pytorch_fused_bwd(
+    grad_output: Tensor,  # (sq, b, np * d_v) or flat
+    q_flat: Tensor,       # (total_Sq, np, d) bf16
+    kv_flat: Tensor,      # (skv * b, d_kv) bf16
+    global_idxs: Tensor,  # (total_Sq, 1, TopK) int32
+    out_flat: Tensor,     # (total_Sq, np, d_v) bf16
+    lse: Tensor,          # (total_Sq, np) f32
+    attn_sink: Optional[Tensor],  # (np,) f32 or None
+    softmax_scale: float,
+    total_Sq: int,
+    np_: int,
+    d: int,
+    d_v: int,
+    d_kv: int,
+    skv_b: int,
+) -> Tuple[Tensor, Tensor, Optional[Tensor]]:
+    """PyTorch BMM backward for FusedIndexerSparseAttn (baseline f32 path).
+
+    Fast for small configs (small TopK, short sequences). Uses full f32
+    for all intermediate computations.
+
+    Returns:
+        (dq, dkv, d_sink) where shapes match the flat layout.
+    """
+    TopK = global_idxs.shape[-1]
+
+    dO_flat = grad_output.reshape(total_Sq, np_, d_v).float()
+    out_f = out_flat.float()
+    q_f = q_flat.float()
+
+    # Di = sum(dO * O) per (query, head)
+    Di = (dO_flat * out_f).sum(dim=-1)  # (total_Sq, np)
+
+    # Shared indices: (total_Sq, 1, TopK) -> squeeze to (total_Sq, TopK)
+    idxs_shared = global_idxs.squeeze(1)  # (total_Sq, TopK)
+    valid_shared = idxs_shared >= 0       # (total_Sq, TopK)
+    safe_shared = idxs_shared.clamp(min=0).long()
+
+    # Gather KV once: (total_Sq * TopK) -> (total_Sq, TopK, d_kv)
+    flat_idxs = safe_shared.reshape(-1)
+    kv_gathered = kv_flat[flat_idxs].reshape(total_Sq, TopK, d_kv)
+
+    kv_is_shared = (d == d_v == d_kv)
+
+    # Upcast kv_gathered to f32 for the full backward.
+    kv_f = kv_gathered.float()
+    del kv_gathered
+
+    # Loop-free backward via batched BMM.
+    scores = torch.bmm(q_f, kv_f[:, :, :d].transpose(1, 2)) * softmax_scale
+    valid_exp = valid_shared.unsqueeze(1).expand(-1, np_, -1)
+    P = torch.exp(scores - lse.unsqueeze(-1))
+    del scores
+    P.masked_fill_(~valid_exp, 0.0)
+
+    dov = torch.bmm(dO_flat, kv_f[:, :, :d_v].transpose(1, 2))
+    dS = P * (dov - Di.unsqueeze(-1)) * softmax_scale
+    del dov
+
+    dq = torch.bmm(dS, kv_f[:, :, :d])
+
+    dkv_gathered = torch.bmm(dS.transpose(1, 2), q_f)  # dk: (S, T, d)
+    del dS
+    if kv_is_shared:
+        torch.baddbmm(dkv_gathered, P.transpose(1, 2), dO_flat, out=dkv_gathered)
+    else:
+        dv = torch.bmm(P.transpose(1, 2), dO_flat)
+        dkv_tmp = torch.zeros(total_Sq, TopK, d_kv, dtype=torch.float32, device=q_flat.device)
+        dkv_tmp[:, :, :d] = dkv_gathered
+        dkv_tmp[:, :, :d_v] += dv
+        dkv_gathered = dkv_tmp
+    del P, kv_f
+
+    dkv_gathered.masked_fill_(~valid_shared.unsqueeze(-1), 0.0)
+    dkv = torch.zeros(skv_b, d_kv, dtype=torch.float32, device=q_flat.device)
+    dkv.scatter_add_(
+        0,
+        flat_idxs.unsqueeze(-1).expand(-1, d_kv),
+        dkv_gathered.reshape(-1, d_kv),
+    )
+
+    dq_out = dq.to(q_flat.dtype)
+    dkv_out = dkv.to(kv_flat.dtype)
+
+    # d_sink
+    d_sink = None
+    if attn_sink is not None:
+        p_sink = torch.exp(attn_sink.unsqueeze(0) - lse)  # (total_Sq, np)
+        ds_sink = -p_sink * Di
+        d_sink = ds_sink.sum(0)  # (np,)
+
+    return dq_out, dkv_out, d_sink
+
+
+__all__ = [
+    "pytorch_sparse_attn_fwd",
+    "pytorch_sparse_attn_bwd",
+    "pytorch_fused_bwd",
+]

--- a/megatron/plugin/dsa_kernel/triton_dsa_kernels.py
+++ b/megatron/plugin/dsa_kernel/triton_dsa_kernels.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
+# Copyright (c) 2026, FlagOS Contributors. All rights reserved.
 
 """
 Triton-based DSA kernel wrappers — drop-in replacement for ``dsa_kernels.py``.

--- a/megatron/plugin/dsa_kernel/triton_dsa_kernels.py
+++ b/megatron/plugin/dsa_kernel/triton_dsa_kernels.py
@@ -226,8 +226,8 @@ class _DSASparseAttnFunc(torch.autograd.Function):
     """
 
     # Mirror the forward dispatch thresholds from triton_sparse_attn.py
-    _PYTORCH_FWD_TOPK_THRESHOLD = 512
-    _PYTORCH_FWD_MAX_GATHER_ELEMENTS = 2 * 1024 * 1024
+    _PYTORCH_FWD_TOPK_THRESHOLD = 256
+    _PYTORCH_FWD_MAX_GATHER_ELEMENTS = 1 * 1024 * 1024
 
     @staticmethod
     def forward(
@@ -249,19 +249,33 @@ class _DSASparseAttnFunc(torch.autograd.Function):
         # BMM to keep the score recomputation numerically consistent with LSE.
         TopK = topk_idxs.shape[-1]
         total_Sq, H = topk_idxs.shape[0], topk_idxs.shape[1]
+        D = query.shape[-1]
         shared = (topk_idxs.stride(1) == 0)
         gather_elements = total_Sq * TopK if shared else total_Sq * H * TopK
+
+        # Check if head-parallel WGMMA kernel was used (shared + aligned dims)
+        hp_eligible = (
+            shared and H >= 16 and (H % 16 == 0)
+            and (D % 16 == 0) and (d_v % 16 == 0)
+        )
+
         ctx.used_pytorch_fwd = (
-            TopK <= _DSASparseAttnFunc._PYTORCH_FWD_TOPK_THRESHOLD
+            not hp_eligible
+            and TopK <= _DSASparseAttnFunc._PYTORCH_FWD_TOPK_THRESHOLD
             and gather_elements <= _DSASparseAttnFunc._PYTORCH_FWD_MAX_GATHER_ELEMENTS
         )
+        # When HP kernel was used, backward must recompute scores with f16 inputs
+        # (matching tl.dot f16×f16→f32) instead of f32 inputs.
+        ctx.used_hp_fwd = hp_eligible
         ctx.shared_indices = shared
 
         logger.debug(
             "_DSASparseAttnFunc.forward: total_Sq=%d, H=%d, TopK=%d, shared=%s, "
             "fwd_path=%s",
             total_Sq, H, TopK, shared,
-            "pytorch_bmm" if ctx.used_pytorch_fwd else "triton",
+            "hp_wgmma" if hp_eligible else (
+                "pytorch_bmm" if ctx.used_pytorch_fwd else "triton"
+            ),
         )
 
         if attn_sink is not None:
@@ -281,19 +295,30 @@ class _DSASparseAttnFunc(torch.autograd.Function):
             attn_sink = None
 
         logger.debug(
-            "_DSASparseAttnFunc.backward: used_pytorch_fwd=%s, shared_indices=%s, "
-            "bwd_path=%s",
-            ctx.used_pytorch_fwd, ctx.shared_indices,
-            "bmm" if (ctx.used_pytorch_fwd and ctx.shared_indices) else "triton",
+            "_DSASparseAttnFunc.backward: used_pytorch_fwd=%s, used_hp_fwd=%s, "
+            "shared_indices=%s, bwd_path=%s",
+            ctx.used_pytorch_fwd, ctx.used_hp_fwd, ctx.shared_indices,
+            "bmm_f16" if ctx.used_hp_fwd else (
+                "bmm_f32" if (ctx.used_pytorch_fwd and ctx.shared_indices) else "triton"
+            ),
         )
 
-        if ctx.used_pytorch_fwd and ctx.shared_indices:
+        if ctx.used_hp_fwd:
+            # --- BMM backward with f16 score recomputation ---
+            # HP forward used tl.dot(Q_f16, K_f16^T) → f32 accumulator.
+            # cuBLAS BMM with f16 inputs also does f16×f16→f32 accumulation,
+            # so exp(scores_bwd - lse_fwd) is numerically consistent.
+            dq, dkv, d_sink = _DSASparseAttnFunc._bmm_backward(
+                grad_out, query, kv, topk_idxs, out, lse, attn_sink,
+                ctx.softmax_scale, ctx.d_v, score_dtype=torch.float16,
+            )
+        elif ctx.used_pytorch_fwd and ctx.shared_indices:
             # --- BMM backward: matches the PyTorch BMM forward path ---
-            # Recomputes scores via cuBLAS BMM (same accumulation as forward)
+            # Recomputes scores via cuBLAS BMM (f32 inputs, same accumulation as forward)
             # so that exp(scores - lse) is numerically consistent.
             dq, dkv, d_sink = _DSASparseAttnFunc._bmm_backward(
                 grad_out, query, kv, topk_idxs, out, lse, attn_sink,
-                ctx.softmax_scale, ctx.d_v,
+                ctx.softmax_scale, ctx.d_v, score_dtype=torch.float32,
             )
         else:
             # --- Triton backward: forward also used Triton kernel ---
@@ -317,11 +342,17 @@ class _DSASparseAttnFunc(torch.autograd.Function):
         attn_sink: Optional[Tensor],  # (H,) f32 or None
         softmax_scale: float,
         d_v: int,
+        score_dtype: torch.dtype = torch.float32,
     ) -> Tuple[Tensor, Tensor, Optional[Tensor]]:
         """BMM-based backward for shared-index sparse attention.
 
         Adapted from FusedIndexerSparseAttnFunc.backward (optimized path).
         Uses cuBLAS BMM for score recomputation to match the forward's LSE.
+
+        Args:
+            score_dtype: dtype for score recomputation inputs.
+                - torch.float32: matches PyTorch BMM forward (f32 × f32 → f32).
+                - torch.float16: matches HP WGMMA forward (f16 × f16 → f32 acc).
         """
         total_Sq, H, D = query.shape
         total_Skv = kv.shape[0]
@@ -333,7 +364,7 @@ class _DSASparseAttnFunc(torch.autograd.Function):
         valid_shared = idxs_shared >= 0    # (total_Sq, TopK)
         safe_shared = idxs_shared.clamp(min=0).long()
 
-        # Gather KV once in bf16 (cuBLAS bf16 BMM does f32 internal accumulation)
+        # Gather KV once in bf16
         flat_idxs = safe_shared.reshape(-1)  # (total_Sq * TopK)
         kv_gathered = kv[flat_idxs].reshape(total_Sq, TopK, D_full)  # bf16
 
@@ -342,14 +373,15 @@ class _DSASparseAttnFunc(torch.autograd.Function):
         # Di = sum(dO * O) per (query, head)
         Di = (grad_out.float() * out.float()).sum(dim=-1)  # (total_Sq, H)
 
-        # Recompute scores via f32 BMM — must match _pytorch_sparse_attn_fwd
-        # which uses torch.bmm(q.float(), k.float().T) * scale.
-        # Using f32 inputs ensures identical accumulation and thus exp(s - lse) ≈ 1
-        # at the correct positions (no bf16 truncation mismatch).
+        # Recompute scores via BMM — must match the forward's dot-product precision.
+        # score_dtype=f32: matches PyTorch BMM fwd (torch.bmm(q.float(), k.float().T))
+        # score_dtype=f16: matches HP WGMMA fwd (tl.dot(Q_f16, K_f16^T) → f32 acc)
+        q_score = query.to(score_dtype)  # (S, H, D)
+        k_score = kv_gathered[:, :, :D].to(score_dtype)  # (S, TopK, D)
         scores = torch.bmm(
-            query.float(),  # (S, H, D) f32
-            kv_gathered[:, :, :D].float().transpose(1, 2)  # (S, D, TopK) f32
-        ) * softmax_scale  # f32
+            q_score, k_score.transpose(1, 2)
+        ).float() * softmax_scale  # always f32 output
+        del q_score, k_score
 
         # P = exp(scores - lse) * valid_mask
         P = fused_exp_mask(scores, lse, valid_shared, H)

--- a/megatron/plugin/dsa_kernel/triton_dsa_kernels.py
+++ b/megatron/plugin/dsa_kernel/triton_dsa_kernels.py
@@ -1,0 +1,900 @@
+# Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
+
+"""
+Triton-based DSA kernel wrappers — drop-in replacement for ``dsa_kernels.py``.
+
+Provides the same public API as ``dsa_kernels.py`` but uses Triton kernels
+instead of cuDNN DSA namespace and FlashMLA. No external CUDA kernel
+dependencies required.
+
+Public API (identical to ``dsa_kernels.py``):
+
+* ``build_flat_topk_idxs`` / ``local_to_global_flat`` — index helpers.
+* ``dsa_sparse_attn`` — differentiable sparse attention (Path A / Path C step 2).
+* ``indexer_topk`` — indexer scoring + top-K selection (Path C inference).
+* ``fused_indexer_sparse_attn`` — fused indexer loss + sparse attention (Path B training).
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Optional, Tuple
+
+import torch
+from torch import Tensor
+
+from megatron.plugin.dsa_kernel.triton_sparse_attn import (
+    triton_sparse_attn_forward,
+    triton_sparse_attn_backward,
+)
+from megatron.plugin.dsa_kernel.triton_sparse_attn_bwd import (
+    fused_mask_scatter_add,
+    fused_exp_mask,
+    should_use_triton_bwd,
+)
+from megatron.plugin.dsa_kernel.triton_indexer_kernels import (
+    sparse_indexer_score_recompute,
+    sparse_attn_score_recompute,
+    dense_indexer_score_recompute,
+    dense_attn_score_recompute,
+    indexer_topk_selection,
+    fused_sparse_indexer_loss_and_backward,
+    fused_dense_indexer_loss_and_backward,
+)
+
+
+# ---------------------------------------------------------------------------
+# Profiling utilities (enabled via DSA_PROFILE=1 env var)
+# ---------------------------------------------------------------------------
+
+_DSA_PROFILE = os.environ.get("DSA_PROFILE", "0") == "1"
+
+
+class _CudaProfiler:
+    """Lightweight CUDA event profiler for forward pass breakdown."""
+
+    def __init__(self, enabled: bool = False):
+        self.enabled = enabled
+        self._events = []  # list of (name, start_event, end_event)
+        self._current_start = None
+        self._current_name = None
+
+    def start(self, name: str):
+        if not self.enabled:
+            return
+        start = torch.cuda.Event(enable_timing=True)
+        start.record()
+        self._current_start = start
+        self._current_name = name
+
+    def stop(self):
+        if not self.enabled or self._current_start is None:
+            return
+        end = torch.cuda.Event(enable_timing=True)
+        end.record()
+        self._events.append((self._current_name, self._current_start, end))
+        self._current_start = None
+        self._current_name = None
+
+    def report(self, prefix: str = ""):
+        if not self.enabled or not self._events:
+            return
+        torch.cuda.synchronize()
+        total = 0.0
+        parts = []
+        for name, start, end in self._events:
+            elapsed = start.elapsed_time(end)
+            total += elapsed
+            parts.append(f"    {name}: {elapsed:.3f} ms")
+        print(f"{prefix}FusedIndexerSparseAttn forward breakdown (total={total:.3f} ms):")
+        for p in parts:
+            print(p)
+        self._events.clear()
+
+
+# ---------------------------------------------------------------------------
+# Index helpers (pure PyTorch, no kernel dependency)
+# ---------------------------------------------------------------------------
+
+
+def local_to_global_flat(local_idxs: Tensor, batch_size: int, seqlen_kv: int) -> Tensor:
+    """Convert local per-batch indices to global flat indices.
+
+    ``local_idxs`` is ``(batch, seq_q, topk)`` with values in ``[0, seqlen_kv)``.
+    Returns ``(batch * seq_q, topk)`` with global flat values suitable for
+    indexing into a ``(total_kv,)``-shaped flat KV buffer.
+
+    Invalid positions (value ``-1``) remain ``-1``.
+    """
+    B, S_q, TopK = local_idxs.shape
+    device = local_idxs.device
+
+    # Batch offsets: batch_i contributes offset batch_i * seqlen_kv
+    batch_offsets = (
+        torch.arange(B, device=device, dtype=local_idxs.dtype) * seqlen_kv
+    )  # (B,)
+    batch_offsets = batch_offsets.view(B, 1, 1)  # (B, 1, 1)
+
+    global_idxs = local_idxs.clone()
+    valid = global_idxs >= 0
+    global_idxs = torch.where(valid, global_idxs + batch_offsets, global_idxs)
+
+    return global_idxs.reshape(B * S_q, TopK)
+
+
+def build_flat_topk_idxs(
+    window_idxs: Tensor,
+    compress_idxs: Optional[Tensor] = None,
+) -> Tensor:
+    """Concatenate window and compressed top-K indices into flat form.
+
+    Args:
+        window_idxs: ``(B, S_q, win_topk)`` int32, sliding-window indices.
+        compress_idxs: ``(B, S_q, cmp_topk)`` int32, optional compressed indices.
+
+    Returns:
+        flat_idxs: ``(B * S_q, total_topk)`` int32.
+    """
+    if compress_idxs is not None:
+        combined = torch.cat([compress_idxs, window_idxs], dim=-1)  # (B, S_q, total_topk)
+    else:
+        combined = window_idxs
+    B, S_q, TopK = combined.shape
+    return combined.reshape(B * S_q, TopK)
+
+
+# ---------------------------------------------------------------------------
+# Helper: SBHD <-> BSHD conversions (matches dsa_kernels.py layout conventions)
+# ---------------------------------------------------------------------------
+
+
+def _sbhd_to_bshd_indexer_inputs(
+    q_indexer: Tensor,  # (sq, b, idx_nh, idx_hd)
+    k_indexer: Tensor,  # (sk, b, idx_hd)
+    weights: Tensor,    # (sq, b, idx_nh)
+    indexer_softmax_scale: float,
+) -> Tuple[Tensor, Tensor, Tensor, Tensor]:
+    """Transpose indexer inputs from SBHD to BSHD layout.
+
+    Note: .contiguous() is omitted — downstream consumers (einsum, topk,
+    elementwise ops) all handle strided tensors correctly.
+    """
+    q_bshd = q_indexer.permute(1, 0, 2, 3)   # (b, sq, nh, hd)
+    k_bsd = k_indexer.permute(1, 0, 2)       # (b, sk, hd)
+    w_bsh = weights.permute(1, 0, 2)         # (b, sq, nh)
+    # Scale weights
+    w_bsh_scaled = w_bsh * indexer_softmax_scale
+    return q_bshd, k_bsd, w_bsh, w_bsh_scaled
+
+
+def _indexer_topk_bshd(
+    q_bshd: Tensor,    # (B, S_q, H_q, D)
+    k_bsd: Tensor,     # (B, S_k, D)
+    w_bsh: Tensor,     # (B, S_q, H_q) — already scaled
+    topk: int,
+    ratio: int,
+) -> Tuple[Tensor, Tensor, Tensor]:
+    """Compute indexer scores and top-K selection.
+
+    Returns:
+        topk_indices: (B, S_q, topk) int32
+        topk_length: (B, S_q) int32
+        full_scores: (B, S_q, S_k) fp32
+    """
+    scores = indexer_topk_selection(q_bshd, k_bsd, w_bsh, topk, ratio)
+    topk_indices = scores["topk_indices"]
+    topk_length = scores["topk_length"]
+    full_scores = scores["full_scores"]
+    return topk_indices, topk_length, full_scores
+
+
+# ---------------------------------------------------------------------------
+# Path A / Path C: dsa_sparse_attn
+# ---------------------------------------------------------------------------
+
+
+class _DSASparseAttnFunc(torch.autograd.Function):
+    """Differentiable sparse attention using Triton kernels."""
+
+    @staticmethod
+    def forward(
+        ctx,
+        query: Tensor,     # (total_Sq, H, D)
+        kv: Tensor,        # (total_Skv, D_kv) where D_kv >= D
+        topk_idxs: Tensor, # (total_Sq, H, TopK) or (total_Sq, 1, TopK)
+        softmax_scale: float,
+        d_v: int,
+        attn_sink: Optional[Tensor],
+    ) -> Tuple[Tensor, Tensor]:
+        out, lse, _ = triton_sparse_attn_forward(
+            query, kv, topk_idxs, softmax_scale, d_v, attn_sink
+        )
+        ctx.has_attn_sink = attn_sink is not None
+        if attn_sink is not None:
+            ctx.save_for_backward(query, kv, topk_idxs, out, lse, attn_sink)
+        else:
+            ctx.save_for_backward(query, kv, topk_idxs, out, lse)
+        ctx.softmax_scale = softmax_scale
+        ctx.d_v = d_v
+        return out, lse
+
+    @staticmethod
+    def backward(ctx, grad_out, grad_lse):
+        if ctx.has_attn_sink:
+            query, kv, topk_idxs, out, lse, attn_sink = ctx.saved_tensors
+        else:
+            query, kv, topk_idxs, out, lse = ctx.saved_tensors
+            attn_sink = None
+        bwd_result = triton_sparse_attn_backward(
+            grad_out, query, kv, out, lse, topk_idxs,
+            ctx.softmax_scale, ctx.d_v, attn_sink
+        )
+        dq, dkv, d_sink = bwd_result["dq"], bwd_result["dkv"], bwd_result["d_sink"]
+        return dq, dkv, None, None, None, d_sink
+
+
+def dsa_sparse_attn(
+    query: Tensor,
+    kv: Tensor,
+    topk_idxs: Tensor,
+    softmax_scale: float,
+    d_v: int = 512,
+    attn_sink: Optional[Tensor] = None,
+    topk_length: Optional[Tensor] = None,
+    indexer_topk: int = 0,
+) -> Tuple[Tensor, Tensor, Optional[Tensor]]:
+    """Sparse attention forward (differentiable).
+
+    Drop-in replacement for the FlashMLA-based ``dsa_sparse_attn`` in
+    ``dsa_kernels.py``.
+
+    Args:
+        query: ``(total_S_q, H, D)`` bf16 — flat queries.
+        kv: ``(total_S_kv, D_kv)`` bf16 — flat KV (single-head).
+        topk_idxs: ``(total_S_q, H_kv, TopK)`` int32 — global KV indices.
+            H_kv is typically 1 for MQA.
+        softmax_scale: scaling applied to Q @ K^T.
+        d_v: value dimension (typically 512 for DSA).
+        attn_sink: ``(H,)`` f32 — per-head sink bias (optional).
+        topk_length: ``(total_S_q, H_kv)`` int32 — valid count per query (optional,
+            for compact mode). If None, -1 entries in topk_idxs are used as mask.
+        indexer_topk: if > 0, compute separate LSE for first ``indexer_topk``
+            positions (used by fused indexer path).
+
+    Returns:
+        ``(out, lse, lse_indexer)``
+        - out: ``(total_S_q, H, d_v)`` bf16.
+        - lse: ``(total_S_q, H)`` fp32.
+        - lse_indexer: ``(total_S_q, H)`` fp32 or None.
+    """
+    # Expand topk_idxs to per-head if needed (H_kv=1 -> broadcast)
+    total_Sq, H, D = query.shape
+    if topk_idxs.shape[1] == 1 and H > 1:
+        topk_idxs = topk_idxs.expand(-1, H, -1)
+
+    if indexer_topk > 0:
+        # Split computation: full attention + indexer-only LSE
+        out, lse = _DSASparseAttnFunc.apply(
+            query, kv, topk_idxs, softmax_scale, d_v, attn_sink
+        )
+        # Compute LSE for first indexer_topk positions
+        TopK = topk_idxs.shape[-1]
+        if indexer_topk >= TopK:
+            lse_indexer = lse.clone()
+        else:
+            idx_subset = topk_idxs[:, :, :indexer_topk].contiguous()
+            _, lse_indexer, _ = triton_sparse_attn_forward(
+                query, kv, idx_subset, softmax_scale, d_v, attn_sink
+            )
+        return out, lse, lse_indexer
+    else:
+        out, lse = _DSASparseAttnFunc.apply(
+            query, kv, topk_idxs, softmax_scale, d_v, attn_sink
+        )
+        return out, lse, None
+
+
+# ---------------------------------------------------------------------------
+# Path C inference: indexer_topk
+# ---------------------------------------------------------------------------
+
+
+def indexer_topk(
+    q_indexer: Tensor,
+    k_indexer: Tensor,
+    weights: Tensor,
+    topk: int,
+    ratio: int,
+    indexer_softmax_scale: float = 1.0,
+) -> Tuple[Tensor, Tensor]:
+    """Indexer scoring + top-K selection (inference path).
+
+    Drop-in replacement for the cuDNN/TRT-LLM-based ``indexer_topk``.
+
+    Args:
+        q_indexer: ``(sq, b, idx_nh, idx_hd)`` bf16 SBHD.
+        k_indexer: ``(sk, b, idx_hd)`` bf16 SBD.
+        weights:   ``(sq, b, idx_nh)`` bf16 SBH — raw (unscaled) weights.
+        topk: number of top-K indices to select.
+        ratio: compression ratio for the causal mask.
+        indexer_softmax_scale: scale applied to indexer scores.
+
+    Returns:
+        topk_indices: ``(b, sq, topk)`` int32.
+        topk_length:  ``(b, sq)`` int32.
+    """
+    q_bshd, k_bsd, _w_bsh_raw, w_bsh_scaled = _sbhd_to_bshd_indexer_inputs(
+        q_indexer, k_indexer, weights, indexer_softmax_scale
+    )
+    topk_indices, topk_length, _ = _indexer_topk_bshd(q_bshd, k_bsd, w_bsh_scaled, topk, ratio)
+    return topk_indices, topk_length
+
+
+# ---------------------------------------------------------------------------
+# Path B training: fused_indexer_sparse_attn
+# ---------------------------------------------------------------------------
+
+
+_CLIP_PROB_MIN = torch.finfo(torch.float32).tiny
+
+
+def _kl_loss_from_target_predict(
+    target: Tensor,
+    predict: Tensor,
+    topk_indices: Tensor,
+    loss_coeff: float,
+    calculate_per_token_loss: bool = False,
+) -> Tensor:
+    """KL(target || predict) reduced and scaled by loss_coeff."""
+    eps = _CLIP_PROB_MIN
+    t = target.clamp(min=eps)
+    p = predict.clamp(min=eps)
+    kl_per_row = (t * (torch.log(t) - torch.log(p))).sum(dim=-1)  # (B, S_q)
+
+    row_valid = (topk_indices >= 0).any(dim=-1)  # (B, S_q)
+    kl_per_row = torch.where(row_valid, kl_per_row, torch.zeros_like(kl_per_row))
+    loss = kl_per_row.sum() if calculate_per_token_loss else kl_per_row.mean()
+    return loss_coeff * loss
+
+
+def _kl_loss_from_dense_scores(
+    attn_score: Tensor,
+    attn_l1norm: Tensor,
+    index_score: Tensor,
+    index_lse: Tensor,
+    topk_indices: Tensor,
+    loss_coeff: float,
+    calculate_per_token_loss: bool = False,
+) -> Tensor:
+    """KL loss from dense scores (full-KV path)."""
+    eps = _CLIP_PROB_MIN
+    B, S_q, S_k = attn_score.shape
+
+    row_valid = (topk_indices >= 0).any(dim=-1)  # (B, S_q)
+    safe_l1 = attn_l1norm.clamp(min=eps)
+    safe_lse = index_lse.clone()
+    safe_lse[~row_valid] = 0.0
+
+    target = attn_score / safe_l1.unsqueeze(-1)
+    target_clamped = target.clamp(min=eps)
+    position_valid = torch.isfinite(index_score)
+    safe_index_score = torch.where(position_valid, index_score, torch.zeros_like(index_score))
+    log_predict = safe_index_score - safe_lse.unsqueeze(-1)
+
+    kl_terms = target_clamped * (torch.log(target_clamped) - log_predict)
+    kl_terms = torch.where(position_valid, kl_terms, torch.zeros_like(kl_terms))
+    kl_per_row = kl_terms.sum(dim=-1)
+    kl_per_row = torch.where(row_valid, kl_per_row, torch.zeros_like(kl_per_row))
+    loss = kl_per_row.sum() if calculate_per_token_loss else kl_per_row.mean()
+    return loss_coeff * loss
+
+
+class FusedIndexerSparseAttnFunc(torch.autograd.Function):
+    """Path B: fused indexer (+KL loss) + sparse attention.
+
+    Differentiable w.r.t. ``query``, ``kv_full``, ``attn_sink``,
+    ``q_indexer``, ``k_indexer``, ``weights``.
+
+    Two indexer-loss variants selected by ``sparse_loss``:
+    - Sparse: KL over top-K positions only.
+    - Dense: KL over all causally valid KV positions.
+    """
+
+    @staticmethod
+    def forward(
+        ctx,
+        query: Tensor,       # (sq, b, np, d)
+        kv_full: Tensor,     # (skv, b, d)
+        attn_sink: Tensor,   # (np,) f32
+        window_idxs: Tensor, # (b, sq, win_topk) int32
+        q_indexer: Tensor,   # (sq, b, idx_nh, idx_hd)
+        k_indexer: Tensor,   # (n_comp, b, idx_hd)
+        weights: Tensor,     # (sq, b, idx_nh) — raw
+        indexer_topk: int,
+        ratio: int,
+        softmax_scale: float,
+        indexer_softmax_scale: float,
+        loss_coeff: float,
+        sparse_loss: bool,
+        kv_offset: int,
+        calculate_per_token_loss: bool,
+    ) -> Tuple[Tensor, Tensor]:
+        sq, b, np_, d = query.shape
+        skv = kv_full.shape[0]
+        n_comp = k_indexer.shape[0]
+        idx_nh, idx_hd = q_indexer.shape[2], q_indexer.shape[3]
+
+        effective_topk = min(indexer_topk, n_comp)
+
+        prof = _CudaProfiler(enabled=_DSA_PROFILE)
+
+        # 1. Transpose indexer inputs SBHD -> BSHD
+        prof.start("step1_sbhd_to_bshd")
+        q_idx_bshd, k_idx_bsd, w_bsh, w_bsh_scaled = _sbhd_to_bshd_indexer_inputs(
+            q_indexer, k_indexer, weights, indexer_softmax_scale
+        )
+        prof.stop()
+
+        # 2. Indexer scoring + top-K
+        prof.start("step2_indexer_topk")
+        topk_indices_cmp, _, indexer_scores = _indexer_topk_bshd(
+            q_idx_bshd, k_idx_bsd, w_bsh_scaled, effective_topk, ratio
+        )
+        prof.stop()
+
+        # 3. Combine indices (compressed + window)
+        prof.start("step3_4_combine_flatten")
+        # Add kv_offset to compressed indices
+        topk_indices_global = topk_indices_cmp.clone()
+        valid_cmp = topk_indices_global >= 0
+        topk_indices_global[valid_cmp] += kv_offset
+
+        # Combine: compressed first, then window
+        combined_idxs = torch.cat([topk_indices_global, window_idxs], dim=-1)  # (b, sq, total_topk)
+        total_topk = combined_idxs.shape[-1]
+
+        # 4. Flatten for sparse attention
+        # Use SB (seq-major) flat layout: flat[s * b + batch_idx] = orig[s, batch_idx]
+        # query: (sq, b, np, d) -> (sq*b, np, d)  — already SB order via reshape
+        # kv_full: (skv, b, d) -> (skv*b, d)      — already SB order via reshape
+        q_flat = query.reshape(sq * b, np_, d)
+        kv_flat = kv_full.reshape(skv * b, -1)
+
+        # Convert local per-batch indices to global flat indices (SB layout).
+        # For SB flat KV: global_idx = local_kv_idx * b + batch_idx
+        # combined_idxs: (b, sq, total_topk) with local values in [0, skv)
+        batch_ids = torch.arange(b, device=query.device, dtype=combined_idxs.dtype)
+        global_idxs = combined_idxs.clone()
+        valid_mask = global_idxs >= 0
+        global_idxs = torch.where(
+            valid_mask,
+            global_idxs * b + batch_ids.view(b, 1, 1),
+            global_idxs,
+        )  # (b, sq, total_topk)
+        # Permute to SB order then flatten: (b, sq, topk) -> (sq, b, topk) -> (sq*b, topk)
+        global_idxs = global_idxs.permute(1, 0, 2).reshape(sq * b, total_topk)
+        # MLA: all heads share KV indices. Keep as (sq*b, 1, TopK) to avoid
+        # redundant np_ copies in save_for_backward and backward gather.
+        global_idxs = global_idxs.unsqueeze(1)  # (sq*b, 1, total_topk)
+        # Expand for forward (uses stride trick, no memory allocation)
+        global_idxs_expanded = global_idxs.expand(-1, np_, -1)  # (sq*b, np, total_topk)
+        prof.stop()
+
+        # 5. Sparse attention forward
+        prof.start("step5_sparse_attn_fwd")
+        # When sparse_loss is enabled, compute partial LSE for the first
+        # effective_topk positions (compressed indices) in a single pass,
+        # avoiding a redundant second forward call.
+        _indexer_topk_for_lse = effective_topk if sparse_loss else 0
+        out_flat, lse, lse_indexer_raw = triton_sparse_attn_forward(
+            q_flat, kv_flat, global_idxs_expanded, softmax_scale, d, attn_sink,
+            indexer_topk=_indexer_topk_for_lse,
+        )
+        prof.stop()
+
+        # 6. Compute indexer loss
+        # P3 optimization: skip step 6+7 entirely when loss_coeff == 0
+        if loss_coeff == 0:
+            indexer_loss = torch.zeros((), device=query.device, dtype=torch.float32)
+            precomputed_grad_q_indexer = torch.zeros_like(q_indexer)
+            precomputed_grad_k_indexer = torch.zeros_like(k_indexer)
+            precomputed_grad_weights = torch.zeros_like(weights)
+
+            # Save for backward
+            ctx.save_for_backward(
+                q_flat, kv_flat, attn_sink, global_idxs, out_flat, lse,
+                precomputed_grad_q_indexer, precomputed_grad_k_indexer, precomputed_grad_weights,
+            )
+            ctx.softmax_scale = softmax_scale
+            ctx.sq = sq
+            ctx.b = b
+            ctx.np_ = np_
+            ctx.d = d
+            ctx.skv = skv
+
+            d_v = out_flat.shape[-1]
+            output = out_flat.reshape(sq, b, np_, d_v).reshape(sq, b, np_ * d_v)
+            prof.report(f"  [sq={sq}, b={b}, np={np_}, topk={total_topk}, loss_coeff=0] ")
+            return output, indexer_loss
+
+        # 6+7. Fused: compute indexer loss AND pre-compute indexer backward in one pass.
+        # This replaces the separate step 6 (score_recompute + KL) and step 7
+        # (indexer backward), eliminating redundant gather/einsum operations.
+        prof.start("step6_7_indexer_loss_bwd")
+        needs_grad = torch.is_grad_enabled() and any(
+            t.requires_grad for t in (query, kv_full, attn_sink, q_indexer, k_indexer, weights)
+        )
+
+        # Prepare attention tensors in BSHD layout (shared by both paths).
+        # .contiguous() omitted: downstream einsum/indexing handle strided tensors.
+        q_attn_bshd = query.permute(1, 0, 2, 3)  # (b, sq, np, d)
+        lse_indexer_bsh = lse_indexer_raw.reshape(sq, b, np_).permute(1, 0, 2) if sparse_loss else None
+
+        if sparse_loss:
+            k_attn_bsd = kv_full[:, :, :d].permute(1, 0, 2)  # (b, skv, d)
+
+            if needs_grad:
+                # Fused: loss + backward in one pass (single K gather + einsum)
+                indexer_loss, precomputed_grad_q_indexer, precomputed_grad_k_indexer, precomputed_grad_weights = (
+                    fused_sparse_indexer_loss_and_backward(
+                        q_idx_bshd, k_idx_bsd, w_bsh_scaled,
+                        topk_indices_cmp,
+                        q_attn_bshd, k_attn_bsd, lse_indexer_bsh,
+                        indexer_softmax_scale=indexer_softmax_scale,
+                        softmax_scale=softmax_scale,
+                        loss_coeff=loss_coeff,
+                        calculate_per_token_loss=calculate_per_token_loss,
+                        idx_nh=idx_nh,
+                    )
+                )
+                # BSHD -> SBHD (match input layout)
+                precomputed_grad_q_indexer = precomputed_grad_q_indexer.permute(1, 0, 2, 3).contiguous()
+                precomputed_grad_k_indexer = precomputed_grad_k_indexer.permute(1, 0, 2).contiguous()
+                precomputed_grad_weights = precomputed_grad_weights.permute(1, 0, 2).contiguous()
+            else:
+                # Inference: only compute loss, no backward
+                predict_result = sparse_indexer_score_recompute(
+                    q_idx_bshd, k_idx_bsd, w_bsh_scaled, topk_indices_cmp,
+                    qhead_per_kv_head=idx_nh,
+                )
+                target_result = sparse_attn_score_recompute(
+                    q_attn_bshd, k_attn_bsd, lse_indexer_bsh, topk_indices_cmp + kv_offset,
+                    softmax_scale, qhead_per_kv_head=np_,
+                )
+                indexer_loss = _kl_loss_from_target_predict(
+                    target_result["target"], predict_result["predict"],
+                    topk_indices_cmp, loss_coeff, calculate_per_token_loss
+                )
+                precomputed_grad_q_indexer = torch.zeros_like(q_indexer)
+                precomputed_grad_k_indexer = torch.zeros_like(k_indexer)
+                precomputed_grad_weights = torch.zeros_like(weights)
+        else:
+            # Dense path
+            k_attn_bsd = kv_full[kv_offset:kv_offset + n_comp, :, :d].permute(1, 0, 2)
+            lse_bsh = lse.reshape(sq, b, np_).permute(1, 0, 2)
+
+            if needs_grad:
+                # Fused: loss + backward in one pass
+                indexer_loss, precomputed_grad_q_indexer, precomputed_grad_k_indexer, precomputed_grad_weights = (
+                    fused_dense_indexer_loss_and_backward(
+                        q_idx_bshd, k_idx_bsd, w_bsh,
+                        topk_indices_cmp,
+                        q_attn_bshd, k_attn_bsd, lse_bsh,
+                        indexer_softmax_scale=indexer_softmax_scale,
+                        softmax_scale=softmax_scale,
+                        loss_coeff=loss_coeff,
+                        ratio=ratio,
+                        calculate_per_token_loss=calculate_per_token_loss,
+                        idx_nh=idx_nh,
+                    )
+                )
+                # BSHD -> SBHD (match input layout)
+                precomputed_grad_q_indexer = precomputed_grad_q_indexer.permute(1, 0, 2, 3).contiguous()
+                precomputed_grad_k_indexer = precomputed_grad_k_indexer.permute(1, 0, 2).contiguous()
+                precomputed_grad_weights = precomputed_grad_weights.permute(1, 0, 2).contiguous()
+            else:
+                # Inference: only compute loss
+                dense_idx_result = dense_indexer_score_recompute(
+                    q_idx_bshd, k_idx_bsd, w_bsh_scaled,
+                    qhead_per_kv_head=idx_nh, sm_scale=indexer_softmax_scale, ratio=ratio,
+                )
+                dense_attn_result = dense_attn_score_recompute(
+                    q_attn_bshd, k_attn_bsd, lse_bsh,
+                    qhead_per_kv_head=np_, softmax_scale=softmax_scale, ratio=ratio,
+                )
+                indexer_loss = _kl_loss_from_dense_scores(
+                    dense_attn_result["out"], dense_attn_result["denom"],
+                    dense_idx_result["out"], dense_idx_result["denom"],
+                    topk_indices_cmp, loss_coeff, calculate_per_token_loss,
+                )
+                precomputed_grad_q_indexer = torch.zeros_like(q_indexer)
+                precomputed_grad_k_indexer = torch.zeros_like(k_indexer)
+                precomputed_grad_weights = torch.zeros_like(weights)
+
+        # Save for backward
+        prof.stop()
+        ctx.save_for_backward(
+            q_flat, kv_flat, attn_sink, global_idxs, out_flat, lse,
+            precomputed_grad_q_indexer, precomputed_grad_k_indexer, precomputed_grad_weights,
+        )
+        ctx.softmax_scale = softmax_scale
+        ctx.sq = sq
+        ctx.b = b
+        ctx.np_ = np_
+        ctx.d = d
+        ctx.skv = skv
+
+        # Return
+        d_v = out_flat.shape[-1]
+        output = out_flat.reshape(sq, b, np_, d_v).reshape(sq, b, np_ * d_v)
+
+        prof.report(f"  [sq={sq}, b={b}, np={np_}, topk={total_topk}] ")
+        return output, indexer_loss
+
+    @staticmethod
+    def backward(ctx, grad_output, grad_loss):
+        (
+            q_flat, kv_flat, attn_sink, global_idxs, out_flat, lse,
+            precomputed_grad_q_indexer, precomputed_grad_k_indexer, precomputed_grad_weights,
+        ) = ctx.saved_tensors
+
+        sq, b, np_, d = ctx.sq, ctx.b, ctx.np_, ctx.d
+        skv = ctx.skv
+
+        d_v = out_flat.shape[-1]
+        total_Sq = sq * b
+        TopK = global_idxs.shape[-1]
+        d_kv = kv_flat.shape[-1]
+
+        prof = _CudaProfiler(enabled=_DSA_PROFILE)
+
+        # Determine whether to use optimized bf16 BMM path or baseline f32 path.
+        shared_indices = (global_idxs.stride(1) == 0)
+        use_optimized_bwd = should_use_triton_bwd(total_Sq, TopK, d_kv, np_, shared_indices)
+
+        if use_optimized_bwd:
+            # --- Optimized path: bf16 BMM + Triton fused epilogues ---
+            # Key savings vs baseline:
+            #   1. No f32 upcast of kv_gathered (saves 768MB alloc + bandwidth)
+            #   2. Fused exp+mask (saves 1 kernel launch + 24MB read/write)
+            #   3. Fused mask+scatter (saves 384MB read pass)
+            prof.start("bwd_prepare_gather")
+            dO_flat = grad_output.reshape(total_Sq, np_, d_v)
+
+            # Shared indices: (total_Sq, 1, TopK) -> squeeze to (total_Sq, TopK)
+            idxs_shared = global_idxs.squeeze(1)  # (total_Sq, TopK)
+            valid_shared = idxs_shared >= 0       # (total_Sq, TopK)
+            safe_shared = idxs_shared.clamp(min=0).long()
+
+            # Gather KV once in bf16 — no f32 upcast! cuBLAS bf16 BMM does f32 accumulation.
+            flat_idxs = safe_shared.reshape(-1)   # (total_Sq * TopK)
+            kv_gathered = kv_flat[flat_idxs].reshape(total_Sq, TopK, d_kv)  # bf16, 384MB
+
+            kv_is_shared = (d == d_v == d_kv)
+
+            # Di = sum(dO * O) per (query, head) — needed for dS
+            # Use bf16 inputs, f32 reduction (accurate enough for Di)
+            Di = (dO_flat.float() * out_flat.float()).sum(dim=-1)  # (total_Sq, np)
+            prof.stop()
+
+            # --- BMM in bf16 (Tensor Core, f32 internal accumulation) ---
+            prof.start("bwd_scores_P")
+            # scores = Q @ K^T * scale: bf16 bmm → f32 output
+            # torch.bmm with bf16 inputs produces bf16 output; we need f32 scores
+            # Use torch.baddbmm or manual: bmm then scale+cast
+            scores = torch.bmm(
+                q_flat.reshape(total_Sq, np_, d),
+                kv_gathered[:, :, :d].transpose(1, 2)  # (S, D, T)
+            ).float() * ctx.softmax_scale  # bf16 bmm → bf16, then f32 cast + scale
+
+            # Fused exp + mask → P (single Triton kernel, replaces 3 ops)
+            P = fused_exp_mask(scores, lse, valid_shared, np_)
+            del scores
+            prof.stop()
+
+            prof.start("bwd_dS")
+            # dov = dO @ V^T: bf16 bmm → f32
+            dov = torch.bmm(
+                dO_flat,
+                kv_gathered[:, :, :d_v].transpose(1, 2)
+            ).float()  # (S, np, TopK) f32
+            dS = P * (dov - Di.unsqueeze(-1)) * ctx.softmax_scale
+            del dov
+            prof.stop()
+
+            prof.start("bwd_dQ")
+            # dQ = dS @ K: cast dS to bf16 for Tensor Core, keep kv in bf16
+            dq = torch.bmm(dS.to(kv_gathered.dtype), kv_gathered[:, :, :d]).float()
+            prof.stop()
+
+            prof.start("bwd_dKV")
+            # dK = dS^T @ Q and dV = P^T @ dO
+            # dS and P are f32 (small: 24MB each), q_flat and dO_flat are bf16.
+            # Upcast q and dO to f32 (only 16MB each) to use f32 BMM directly.
+            # This avoids: cast dS→bf16 + bmm + cast→f32 (3 kernels each)
+            # Instead: 1 upcast + 1 f32 bmm + 1 in-place baddbmm = 3 kernels total
+            q_f32 = q_flat.reshape(total_Sq, np_, d).float()  # 16MB
+            dO_f32 = dO_flat.float()  # 16MB
+
+            dkv_gathered = torch.bmm(dS.transpose(1, 2), q_f32)  # (S, T, D) f32
+            del dS
+            if kv_is_shared:
+                # dV = P^T @ dO: in-place add via baddbmm (1 kernel, 0 extra alloc)
+                torch.baddbmm(dkv_gathered, P.transpose(1, 2), dO_f32, out=dkv_gathered)
+            else:
+                dv = torch.bmm(P.transpose(1, 2), dO_f32)
+                dkv_tmp = torch.zeros(total_Sq, TopK, d_kv, dtype=torch.float32, device=q_flat.device)
+                dkv_tmp[:, :, :d] = dkv_gathered
+                dkv_tmp[:, :, :d_v] += dv
+                dkv_gathered = dkv_tmp
+            del P, q_f32, dO_f32
+            prof.stop()
+
+            prof.start("bwd_scatter")
+            # Fused mask + scatter_add (single Triton kernel, replaces 2 ops)
+            valid_flat = valid_shared.reshape(-1)
+            dkv = torch.zeros(skv * b, d_kv, dtype=torch.float32, device=q_flat.device)
+            fused_mask_scatter_add(dkv_gathered, flat_idxs, valid_flat, dkv)
+
+            grad_query = dq.to(q_flat.dtype).reshape(sq, b, np_, d)
+            grad_kv_full = dkv.to(kv_flat.dtype).reshape(skv, b, -1)
+            prof.stop()
+
+            # d_sink
+            d_sink = None
+            if attn_sink is not None:
+                p_sink = torch.exp(attn_sink.unsqueeze(0) - lse)  # (total_Sq, np)
+                ds_sink = -p_sink * Di  # (total_Sq, np)
+                d_sink = ds_sink.sum(0)  # (np,)
+        else:
+            # --- PyTorch BMM backward (fast for small configs) ---
+            prof.start("bwd_prepare_gather")
+            dO_flat = grad_output.reshape(total_Sq, np_, d_v).float()
+            out_f = out_flat.float()
+            q_f = q_flat.float()
+
+            # Di = sum(dO * O) per (query, head)
+            Di = (dO_flat * out_f).sum(dim=-1)  # (total_Sq, np)
+
+            # Shared indices: (total_Sq, 1, TopK) -> squeeze to (total_Sq, TopK)
+            idxs_shared = global_idxs.squeeze(1)  # (total_Sq, TopK)
+            valid_shared = idxs_shared >= 0       # (total_Sq, TopK)
+            safe_shared = idxs_shared.clamp(min=0).long()
+
+            # Gather KV once: (total_Sq * TopK) -> (total_Sq, TopK, d_kv)
+            flat_idxs = safe_shared.reshape(-1)   # (total_Sq * TopK)
+            kv_gathered = kv_flat[flat_idxs].reshape(total_Sq, TopK, d_kv)  # bf16
+
+            # In MLA/DSA, K and V share the same latent vector (d == d_v == d_kv).
+            kv_is_shared = (d == d_v == d_kv)
+
+            # Upcast kv_gathered to f32 for the full backward.
+            kv_f = kv_gathered.float()
+            del kv_gathered
+            prof.stop()
+
+            # Loop-free backward via batched BMM.
+            prof.start("bwd_scores_P")
+            scores = torch.bmm(q_f, kv_f[:, :, :d].transpose(1, 2)) * ctx.softmax_scale
+            valid_exp = valid_shared.unsqueeze(1).expand(-1, np_, -1)
+            P = torch.exp(scores - lse.unsqueeze(-1))
+            del scores
+            P.masked_fill_(~valid_exp, 0.0)
+            prof.stop()
+
+            prof.start("bwd_dS")
+            dov = torch.bmm(dO_flat, kv_f[:, :, :d_v].transpose(1, 2))
+            dS = P * (dov - Di.unsqueeze(-1)) * ctx.softmax_scale
+            del dov
+            prof.stop()
+
+            prof.start("bwd_dQ")
+            dq = torch.bmm(dS, kv_f[:, :, :d])
+            prof.stop()
+
+            prof.start("bwd_dKV")
+            dkv_gathered = torch.bmm(dS.transpose(1, 2), q_f)  # dk: (S, T, d)
+            del dS
+            if kv_is_shared:
+                torch.baddbmm(dkv_gathered, P.transpose(1, 2), dO_flat, out=dkv_gathered)
+            else:
+                dv = torch.bmm(P.transpose(1, 2), dO_flat)
+                dkv_tmp = torch.zeros(total_Sq, TopK, d_kv, dtype=torch.float32, device=q_flat.device)
+                dkv_tmp[:, :, :d] = dkv_gathered
+                dkv_tmp[:, :, :d_v] += dv
+                dkv_gathered = dkv_tmp
+            del P, kv_f
+            prof.stop()
+
+            prof.start("bwd_scatter")
+            dkv_gathered.masked_fill_(~valid_shared.unsqueeze(-1), 0.0)
+            dkv = torch.zeros(skv * b, d_kv, dtype=torch.float32, device=q_flat.device)
+            dkv.scatter_add_(
+                0,
+                flat_idxs.unsqueeze(-1).expand(-1, d_kv),
+                dkv_gathered.reshape(-1, d_kv),
+            )
+
+            grad_query = dq.to(q_flat.dtype).reshape(sq, b, np_, d)
+            grad_kv_full = dkv.to(kv_flat.dtype).reshape(skv, b, -1)
+            prof.stop()
+
+            # d_sink
+            d_sink = None
+            if attn_sink is not None:
+                p_sink = torch.exp(attn_sink.unsqueeze(0) - lse)  # (total_Sq, np)
+                ds_sink = -p_sink * Di  # (total_Sq, np)
+                d_sink = ds_sink.sum(0)  # (np,)
+
+        prof.start("bwd_indexer_grads")
+        # Scale pre-computed indexer grads by actual grad_loss
+        grad_q_indexer = precomputed_grad_q_indexer * grad_loss
+        grad_k_indexer = precomputed_grad_k_indexer * grad_loss
+        grad_weights = precomputed_grad_weights * grad_loss
+        prof.stop()
+
+        prof.report(f"  [sq={sq}, b={b}, np={np_}, topk={TopK}, optimized_bwd={use_optimized_bwd}] ")
+
+        return (
+            grad_query,
+            grad_kv_full,
+            d_sink,
+            None,  # window_idxs
+            grad_q_indexer,
+            grad_k_indexer,
+            grad_weights,
+            None, None, None, None, None, None, None, None,  # scalar args
+        )
+
+
+def fused_indexer_sparse_attn(
+    query: Tensor,
+    kv_full: Tensor,
+    attn_sink: Tensor,
+    window_idxs: Tensor,
+    q_indexer: Tensor,
+    k_indexer: Tensor,
+    weights: Tensor,
+    indexer_topk: int,
+    ratio: int,
+    softmax_scale: float,
+    indexer_softmax_scale: float,
+    loss_coeff: float,
+    sparse_loss: bool,
+    kv_offset: int,
+    calculate_per_token_loss: bool,
+) -> Tuple[Tensor, Tensor]:
+    """Fused indexer loss + sparse attention (Path B training).
+
+    Drop-in replacement for ``dsa_kernels.fused_indexer_sparse_attn``.
+
+    Returns:
+        ``(output, indexer_loss)`` where output is ``(sq, b, np * d_v)`` bf16
+        and indexer_loss is a scalar f32.
+    """
+    return FusedIndexerSparseAttnFunc.apply(
+        query,
+        kv_full,
+        attn_sink,
+        window_idxs,
+        q_indexer,
+        k_indexer,
+        weights,
+        indexer_topk,
+        ratio,
+        softmax_scale,
+        indexer_softmax_scale,
+        loss_coeff,
+        sparse_loss,
+        kv_offset,
+        calculate_per_token_loss,
+    )
+
+
+__all__ = [
+    "build_flat_topk_idxs",
+    "local_to_global_flat",
+    "dsa_sparse_attn",
+    "indexer_topk",
+    "fused_indexer_sparse_attn",
+]

--- a/megatron/plugin/dsa_kernel/triton_dsa_kernels.py
+++ b/megatron/plugin/dsa_kernel/triton_dsa_kernels.py
@@ -741,7 +741,7 @@ class FusedIndexerSparseAttnFunc(torch.autograd.Function):
         # This replaces the separate step 6 (score_recompute + KL) and step 7
         # (indexer backward), eliminating redundant gather/einsum operations.
         prof.start("step6_7_indexer_loss_bwd")
-        needs_grad = torch.is_grad_enabled() and any(
+        needs_grad = any(
             t.requires_grad for t in (query, kv_full, attn_sink, q_indexer, k_indexer, weights)
         )
 
@@ -821,10 +821,14 @@ class FusedIndexerSparseAttnFunc(torch.autograd.Function):
                 # Inference: only compute loss
                 dense_idx_result = dense_indexer_score_recompute(
                     q_idx_bshd, k_idx_bsd, w_bsh_scaled,
-                    qhead_per_kv_head=idx_nh, sm_scale=indexer_softmax_scale, ratio=ratio,
+                    qhead_per_kv_head=idx_nh, sm_scale=1.0, ratio=ratio,
                 )
+                # Pass lse=None so dense_attn_score_recompute uses self-contained
+                # softmax over compressed keys only (matching unfused reference).
+                # Using the full LSE (which includes window tokens in the
+                # denominator) would make compressed-token probabilities too small.
                 dense_attn_result = dense_attn_score_recompute(
-                    q_attn_bshd, k_attn_bsd, lse_bsh,
+                    q_attn_bshd, k_attn_bsd, None,
                     qhead_per_kv_head=np_, softmax_scale=softmax_scale, ratio=ratio,
                 )
                 indexer_loss = _kl_loss_from_dense_scores(

--- a/megatron/plugin/dsa_kernel/triton_dsa_kernels.py
+++ b/megatron/plugin/dsa_kernel/triton_dsa_kernels.py
@@ -3,14 +3,15 @@
 """
 Triton-based DSA kernel wrappers — drop-in replacement for ``dsa_kernels.py``.
 
-Provides the same public API as ``dsa_kernels.py`` but uses Triton kernels
+Provides the same high-level API as ``dsa_kernels.py`` but uses Triton kernels
 instead of cuDNN DSA namespace and FlashMLA. No external CUDA kernel
 dependencies required.
 
-Public API (identical to ``dsa_kernels.py``):
+Public API:
 
 * ``build_flat_topk_idxs`` / ``local_to_global_flat`` — index helpers.
-* ``dsa_sparse_attn`` — differentiable sparse attention (Path A / Path C step 2).
+* ``dsa_sparse_attn`` — differentiable sparse attention, flat layout (Path A / Path C step 2).
+* ``dsa_sparse_attn_sbhd`` — sparse attention with SBHD interface (used by csa.py).
 * ``indexer_topk`` — indexer scoring + top-K selection (Path C inference).
 * ``fused_indexer_sparse_attn`` — fused indexer loss + sparse attention (Path B training).
 """
@@ -102,49 +103,66 @@ class _CudaProfiler:
 
 
 def local_to_global_flat(local_idxs: Tensor, batch_size: int, seqlen_kv: int) -> Tensor:
-    """Convert local per-batch indices to global flat indices.
+    """Convert local per-batch indices to global flat indices (SB layout).
 
-    ``local_idxs`` is ``(batch, seq_q, topk)`` with values in ``[0, seqlen_kv)``.
-    Returns ``(batch * seq_q, topk)`` with global flat values suitable for
-    indexing into a ``(total_kv,)``-shaped flat KV buffer.
+    Follows the same convention as ``dsa_kernels.local_to_global_flat``:
+    flat row order is SB (seq-major); global index is ``local * B + b``
+    for valid entries and ``-1`` otherwise.
 
-    Invalid positions (value ``-1``) remain ``-1``.
+    Args:
+        local_idxs: ``(b, sq, topk)`` int, values in ``[0, seqlen_kv)`` or -1.
+        batch_size: ``B``.
+        seqlen_kv: KV sequence length per batch.
+
+    Returns:
+        ``(sq*b, topk)`` int32.
     """
-    B, S_q, TopK = local_idxs.shape
-    device = local_idxs.device
+    b, sq, topk = local_idxs.shape
+    assert b == batch_size
 
-    # Batch offsets: batch_i contributes offset batch_i * seqlen_kv
-    batch_offsets = (
-        torch.arange(B, device=device, dtype=local_idxs.dtype) * seqlen_kv
-    )  # (B,)
-    batch_offsets = batch_offsets.view(B, 1, 1)  # (B, 1, 1)
-
-    global_idxs = local_idxs.clone()
-    valid = global_idxs >= 0
-    global_idxs = torch.where(valid, global_idxs + batch_offsets, global_idxs)
-
-    return global_idxs.reshape(B * S_q, TopK)
+    # Permute to SB order: (b, sq, topk) -> (sq, b, topk) -> (sq*b, topk)
+    idxs_sb = local_idxs.permute(1, 0, 2).reshape(sq * b, topk)
+    valid = idxs_sb >= 0
+    batch_ids = torch.arange(sq * b, device=local_idxs.device) % b
+    batch_ids_exp = batch_ids.unsqueeze(1).expand_as(idxs_sb)
+    idxs_sb = torch.where(valid, idxs_sb * b + batch_ids_exp, idxs_sb)
+    return idxs_sb.int()
 
 
 def build_flat_topk_idxs(
-    window_idxs: Tensor,
-    compress_idxs: Optional[Tensor] = None,
-) -> Tensor:
-    """Concatenate window and compressed top-K indices into flat form.
+    *idx_groups: Tensor, batch_size: int, seqlen_kv: int, compact: bool = False
+) -> Tuple[Tensor, Optional[Tensor]]:
+    """Combine local per-batch index groups and convert to flat global form.
+
+    Drop-in replacement for ``dsa_kernels.build_flat_topk_idxs`` that uses
+    PyTorch argsort for compact instead of cuDNN's ``compactify_wrapper``.
+
+    Each *idx_group* is ``(b, sq, topk_i)`` with local per-batch KV indices.
+    ``-1`` marks invalid positions.
 
     Args:
-        window_idxs: ``(B, S_q, win_topk)`` int32, sliding-window indices.
-        compress_idxs: ``(B, S_q, cmp_topk)`` int32, optional compressed indices.
+        *idx_groups: one or more ``(b, sq, topk_i)`` int tensors.
+        batch_size: ``B``.
+        seqlen_kv: total KV sequence length per batch.
+        compact: if True, pack valid entries to the front of each row and
+            additionally return ``topk_length``; if False, leave as-is.
 
     Returns:
-        flat_idxs: ``(B * S_q, total_topk)`` int32.
+        ``(topk_idxs, topk_length)`` where
+        ``topk_idxs`` is ``(sq*b, total_topk)`` int32 (flat global) and
+        ``topk_length`` is ``(sq*b,)`` int32 when ``compact``, else ``None``.
     """
-    if compress_idxs is not None:
-        combined = torch.cat([compress_idxs, window_idxs], dim=-1)  # (B, S_q, total_topk)
-    else:
-        combined = window_idxs
-    B, S_q, TopK = combined.shape
-    return combined.reshape(B * S_q, TopK)
+    combined = torch.cat(idx_groups, dim=-1)  # (b, sq, total_topk)
+    global_idxs = local_to_global_flat(combined, batch_size, seqlen_kv)
+
+    topk_length_flat = None
+    if compact:
+        valid_mask = global_idxs >= 0
+        sorted_indices = valid_mask.int().argsort(dim=-1, descending=True, stable=True)
+        global_idxs = global_idxs.gather(-1, sorted_indices)
+        topk_length_flat = valid_mask.sum(dim=-1).int()
+
+    return global_idxs, topk_length_flat
 
 
 # ---------------------------------------------------------------------------
@@ -447,6 +465,48 @@ def dsa_sparse_attn(
         return out, lse, None
 
 
+def dsa_sparse_attn_sbhd(
+    query: Tensor,
+    kv: Tensor,
+    attn_sink: Tensor,
+    topk_idxs: Tensor,
+    softmax_scale: float,
+    topk_length: Optional[Tensor] = None,
+    indexer_topk: int = 0,
+) -> Tensor:
+    """Sparse attention with SBHD interface (matches dsa_kernels.dsa_sparse_attn).
+
+    Reshapes from ``(sq, b, np, d)`` layout to flat ``(total_Sq, H, D)`` and
+    delegates to :func:`dsa_sparse_attn`.
+
+    Args:
+        query: ``(sq, b, np, d)`` bf16 SBHD.
+        kv:    ``(skv, b, d)`` bf16 SBD (K=V).
+        attn_sink: ``(np,)`` f32.
+        topk_idxs: ``(sq*b, topk)`` int32 — flat global indices.
+        softmax_scale: scalar float.
+        topk_length: ``(sq*b,)`` int32 — optional compact fast-path.
+        indexer_topk: int; 0 for Paths A/C, positive for Path B.
+
+    Returns:
+        ``(sq, b, np * d_v)`` bf16 output.
+    """
+    sq, b, np_, d = query.shape
+    skv = kv.shape[0]
+    q_flat = query.reshape(sq * b, np_, d)
+    kv_flat = kv.reshape(skv * b, d)
+    # dsa_sparse_attn expects (total_Sq, H_kv, TopK); core produces (total_Sq, TopK)
+    idxs = topk_idxs.unsqueeze(1) if topk_idxs.dim() == 2 else topk_idxs
+    tlen = topk_length
+    if tlen is not None and tlen.dim() == 1:
+        tlen = tlen.unsqueeze(1)
+    out_flat, _lse, _ = dsa_sparse_attn(
+        q_flat, kv_flat, idxs, softmax_scale, d, attn_sink, tlen, indexer_topk
+    )
+    d_v = out_flat.shape[-1]
+    return out_flat.reshape(sq, b, np_ * d_v)
+
+
 # ---------------------------------------------------------------------------
 # Path C inference: indexer_topk
 # ---------------------------------------------------------------------------
@@ -705,6 +765,7 @@ class FusedIndexerSparseAttnFunc(torch.autograd.Function):
                         loss_coeff=loss_coeff,
                         calculate_per_token_loss=calculate_per_token_loss,
                         idx_nh=idx_nh,
+                        kv_offset=kv_offset,
                     )
                 )
                 # BSHD -> SBHD (match input layout)
@@ -717,8 +778,12 @@ class FusedIndexerSparseAttnFunc(torch.autograd.Function):
                     q_idx_bshd, k_idx_bsd, w_bsh_scaled, topk_indices_cmp,
                     qhead_per_kv_head=idx_nh,
                 )
+                # Shift valid compressed indices by kv_offset, keep -1 as-is
+                topk_for_target = topk_indices_cmp.clone()
+                valid_cmp_mask = topk_for_target >= 0
+                topk_for_target[valid_cmp_mask] += kv_offset
                 target_result = sparse_attn_score_recompute(
-                    q_attn_bshd, k_attn_bsd, lse_indexer_bsh, topk_indices_cmp + kv_offset,
+                    q_attn_bshd, k_attn_bsd, lse_indexer_bsh, topk_for_target,
                     softmax_scale, qhead_per_kv_head=np_,
                 )
                 indexer_loss = _kl_loss_from_target_predict(
@@ -1062,6 +1127,7 @@ __all__ = [
     "build_flat_topk_idxs",
     "local_to_global_flat",
     "dsa_sparse_attn",
+    "dsa_sparse_attn_sbhd",
     "indexer_topk",
     "fused_indexer_sparse_attn",
 ]

--- a/megatron/plugin/dsa_kernel/triton_dsa_kernels.py
+++ b/megatron/plugin/dsa_kernel/triton_dsa_kernels.py
@@ -32,7 +32,6 @@ from megatron.plugin.dsa_kernel.triton_sparse_attn import (
 from megatron.plugin.dsa_kernel.triton_sparse_attn_bwd import (
     fused_mask_scatter_add,
     fused_exp_mask,
-    should_use_triton_bwd,
 )
 from megatron.plugin.dsa_kernel.triton_indexer_kernels import (
     sparse_indexer_score_recompute,
@@ -216,18 +215,16 @@ def _indexer_topk_bshd(
 
 
 class _DSASparseAttnFunc(torch.autograd.Function):
-    """Differentiable sparse attention using Triton kernels.
+    """Differentiable sparse attention using pure Triton kernels.
 
-    The backward path adapts to match the forward path's dot-product method:
-    - When forward used PyTorch BMM (TopK <= 512), backward also uses BMM to
-      ensure the recomputed scores are numerically consistent with the saved LSE.
-    - When forward used the Triton kernel (TopK > 512), backward uses the Triton
-      kernel which shares the same accumulation order.
+    Forward dispatches to HP WGMMA or 2D-tiled Triton kernel (no PyTorch BMM).
+
+    The backward adapts to match the forward path's dot-product method:
+    - When forward used the HP WGMMA kernel (tl.dot f16×f16→f32), backward uses
+      cuBLAS BMM with f16 inputs for numerically consistent score recomputation.
+    - When forward used the 2D Triton kernel (tl.sum(q*k)), backward uses the
+      Triton per-position kernel which shares the same accumulation order.
     """
-
-    # Mirror the forward dispatch thresholds from triton_sparse_attn.py
-    _PYTORCH_FWD_TOPK_THRESHOLD = 256
-    _PYTORCH_FWD_MAX_GATHER_ELEMENTS = 1 * 1024 * 1024
 
     @staticmethod
     def forward(
@@ -244,38 +241,22 @@ class _DSASparseAttnFunc(torch.autograd.Function):
         )
         ctx.has_attn_sink = attn_sink is not None
 
-        # Determine if the forward used the PyTorch BMM path (same logic as
-        # triton_sparse_attn_fwd dispatch).  If so, the backward must also use
-        # BMM to keep the score recomputation numerically consistent with LSE.
-        TopK = topk_idxs.shape[-1]
-        total_Sq, H = topk_idxs.shape[0], topk_idxs.shape[1]
+        # Determine if the HP WGMMA kernel was used (shared + aligned dims).
+        # Backward needs this to select numerically consistent score recomputation.
         D = query.shape[-1]
+        H = topk_idxs.shape[1]
         shared = (topk_idxs.stride(1) == 0)
-        gather_elements = total_Sq * TopK if shared else total_Sq * H * TopK
 
-        # Check if head-parallel WGMMA kernel was used (shared + aligned dims)
-        hp_eligible = (
+        ctx.used_hp_fwd = (
             shared and H >= 16 and (H % 16 == 0)
             and (D % 16 == 0) and (d_v % 16 == 0)
         )
 
-        ctx.used_pytorch_fwd = (
-            not hp_eligible
-            and TopK <= _DSASparseAttnFunc._PYTORCH_FWD_TOPK_THRESHOLD
-            and gather_elements <= _DSASparseAttnFunc._PYTORCH_FWD_MAX_GATHER_ELEMENTS
-        )
-        # When HP kernel was used, backward must recompute scores with f16 inputs
-        # (matching tl.dot f16×f16→f32) instead of f32 inputs.
-        ctx.used_hp_fwd = hp_eligible
-        ctx.shared_indices = shared
-
         logger.debug(
             "_DSASparseAttnFunc.forward: total_Sq=%d, H=%d, TopK=%d, shared=%s, "
             "fwd_path=%s",
-            total_Sq, H, TopK, shared,
-            "hp_wgmma" if hp_eligible else (
-                "pytorch_bmm" if ctx.used_pytorch_fwd else "triton"
-            ),
+            topk_idxs.shape[0], H, topk_idxs.shape[-1], shared,
+            "hp_wgmma" if ctx.used_hp_fwd else "triton_2d",
         )
 
         if attn_sink is not None:
@@ -295,12 +276,9 @@ class _DSASparseAttnFunc(torch.autograd.Function):
             attn_sink = None
 
         logger.debug(
-            "_DSASparseAttnFunc.backward: used_pytorch_fwd=%s, used_hp_fwd=%s, "
-            "shared_indices=%s, bwd_path=%s",
-            ctx.used_pytorch_fwd, ctx.used_hp_fwd, ctx.shared_indices,
-            "bmm_f16" if ctx.used_hp_fwd else (
-                "bmm_f32" if (ctx.used_pytorch_fwd and ctx.shared_indices) else "triton"
-            ),
+            "_DSASparseAttnFunc.backward: used_hp_fwd=%s, bwd_path=%s",
+            ctx.used_hp_fwd,
+            "bmm_f16" if ctx.used_hp_fwd else "triton",
         )
 
         if ctx.used_hp_fwd:
@@ -308,20 +286,12 @@ class _DSASparseAttnFunc(torch.autograd.Function):
             # HP forward used tl.dot(Q_f16, K_f16^T) → f32 accumulator.
             # cuBLAS BMM with f16 inputs also does f16×f16→f32 accumulation,
             # so exp(scores_bwd - lse_fwd) is numerically consistent.
-            dq, dkv, d_sink = _DSASparseAttnFunc._bmm_backward(
+            dq, dkv, d_sink = _DSASparseAttnFunc._hp_bmm_backward(
                 grad_out, query, kv, topk_idxs, out, lse, attn_sink,
-                ctx.softmax_scale, ctx.d_v, score_dtype=torch.float16,
-            )
-        elif ctx.used_pytorch_fwd and ctx.shared_indices:
-            # --- BMM backward: matches the PyTorch BMM forward path ---
-            # Recomputes scores via cuBLAS BMM (f32 inputs, same accumulation as forward)
-            # so that exp(scores - lse) is numerically consistent.
-            dq, dkv, d_sink = _DSASparseAttnFunc._bmm_backward(
-                grad_out, query, kv, topk_idxs, out, lse, attn_sink,
-                ctx.softmax_scale, ctx.d_v, score_dtype=torch.float32,
+                ctx.softmax_scale, ctx.d_v,
             )
         else:
-            # --- Triton backward: forward also used Triton kernel ---
+            # --- Triton backward: forward used 2D Triton kernel ---
             # Both fwd and bwd use tl.sum(q * k) → same dot product, consistent.
             bwd_result = triton_sparse_attn_backward(
                 grad_out, query, kv, out, lse, topk_idxs,
@@ -332,7 +302,7 @@ class _DSASparseAttnFunc(torch.autograd.Function):
         return dq, dkv, None, None, None, d_sink
 
     @staticmethod
-    def _bmm_backward(
+    def _hp_bmm_backward(
         grad_out: Tensor,   # (total_Sq, H, d_v) bf16
         query: Tensor,      # (total_Sq, H, D) bf16
         kv: Tensor,         # (total_Skv, D_full) bf16
@@ -342,17 +312,12 @@ class _DSASparseAttnFunc(torch.autograd.Function):
         attn_sink: Optional[Tensor],  # (H,) f32 or None
         softmax_scale: float,
         d_v: int,
-        score_dtype: torch.dtype = torch.float32,
     ) -> Tuple[Tensor, Tensor, Optional[Tensor]]:
-        """BMM-based backward for shared-index sparse attention.
+        """BMM-based backward for HP WGMMA forward path.
 
-        Adapted from FusedIndexerSparseAttnFunc.backward (optimized path).
-        Uses cuBLAS BMM for score recomputation to match the forward's LSE.
-
-        Args:
-            score_dtype: dtype for score recomputation inputs.
-                - torch.float32: matches PyTorch BMM forward (f32 × f32 → f32).
-                - torch.float16: matches HP WGMMA forward (f16 × f16 → f32 acc).
+        Uses cuBLAS BMM with f16 inputs for score recomputation, matching the
+        HP forward kernel's tl.dot(Q_f16, K_f16^T) → f32 accumulation.
+        This ensures exp(scores_bwd - lse_fwd) is numerically consistent.
         """
         total_Sq, H, D = query.shape
         total_Skv = kv.shape[0]
@@ -373,11 +338,10 @@ class _DSASparseAttnFunc(torch.autograd.Function):
         # Di = sum(dO * O) per (query, head)
         Di = (grad_out.float() * out.float()).sum(dim=-1)  # (total_Sq, H)
 
-        # Recompute scores via BMM — must match the forward's dot-product precision.
-        # score_dtype=f32: matches PyTorch BMM fwd (torch.bmm(q.float(), k.float().T))
-        # score_dtype=f16: matches HP WGMMA fwd (tl.dot(Q_f16, K_f16^T) → f32 acc)
-        q_score = query.to(score_dtype)  # (S, H, D)
-        k_score = kv_gathered[:, :, :D].to(score_dtype)  # (S, TopK, D)
+        # Recompute scores via BMM in f16 — matches HP WGMMA forward
+        # (tl.dot(Q_f16, K_f16^T) → f32 accumulator)
+        q_score = query.to(torch.float16)  # (S, H, D)
+        k_score = kv_gathered[:, :, :D].to(torch.float16)  # (S, TopK, D)
         scores = torch.bmm(
             q_score, k_score.transpose(1, 2)
         ).float() * softmax_scale  # always f32 output
@@ -909,190 +873,99 @@ class FusedIndexerSparseAttnFunc(torch.autograd.Function):
 
         prof = _CudaProfiler(enabled=_DSA_PROFILE)
 
-        # Determine whether to use optimized bf16 BMM path or baseline f32 path.
-        shared_indices = (global_idxs.stride(1) == 0)
-        use_optimized_bwd = should_use_triton_bwd(total_Sq, TopK, d_kv, np_, shared_indices)
-
         logger.debug(
             "FusedIndexerSparseAttnFunc.backward: sq=%d, b=%d, np=%d, "
-            "TopK=%d, d_kv=%d, shared_indices=%s, bwd_path=%s",
-            sq, b, np_, TopK, d_kv, shared_indices,
-            "optimized_bf16_bmm" if use_optimized_bwd else "baseline_f32",
+            "TopK=%d, d_kv=%d, bwd_path=optimized_bf16_bmm",
+            sq, b, np_, TopK, d_kv,
         )
 
-        if use_optimized_bwd:
-            # --- Optimized path: bf16 BMM + Triton fused epilogues ---
-            # Key savings vs baseline:
-            #   1. No f32 upcast of kv_gathered (saves 768MB alloc + bandwidth)
-            #   2. Fused exp+mask (saves 1 kernel launch + 24MB read/write)
-            #   3. Fused mask+scatter (saves 384MB read pass)
-            prof.start("bwd_prepare_gather")
-            dO_flat = grad_output.reshape(total_Sq, np_, d_v)
+        # --- Optimized path: bf16 BMM + Triton fused epilogues ---
+        # Training always uses this path (shared indices, large TopK).
+        # Key savings vs legacy f32 path:
+        #   1. No f32 upcast of kv_gathered (saves 768MB alloc + bandwidth)
+        #   2. Fused exp+mask (saves 1 kernel launch + 24MB read/write)
+        #   3. Fused mask+scatter (saves 384MB read pass)
+        prof.start("bwd_prepare_gather")
+        dO_flat = grad_output.reshape(total_Sq, np_, d_v)
 
-            # Shared indices: (total_Sq, 1, TopK) -> squeeze to (total_Sq, TopK)
-            idxs_shared = global_idxs.squeeze(1)  # (total_Sq, TopK)
-            valid_shared = idxs_shared >= 0       # (total_Sq, TopK)
-            safe_shared = idxs_shared.clamp(min=0).long()
+        # Shared indices: (total_Sq, 1, TopK) -> squeeze to (total_Sq, TopK)
+        idxs_shared = global_idxs.squeeze(1)  # (total_Sq, TopK)
+        valid_shared = idxs_shared >= 0       # (total_Sq, TopK)
+        safe_shared = idxs_shared.clamp(min=0).long()
 
-            # Gather KV once in bf16 — no f32 upcast! cuBLAS bf16 BMM does f32 accumulation.
-            flat_idxs = safe_shared.reshape(-1)   # (total_Sq * TopK)
-            kv_gathered = kv_flat[flat_idxs].reshape(total_Sq, TopK, d_kv)  # bf16, 384MB
+        # Gather KV once in bf16 — no f32 upcast! cuBLAS bf16 BMM does f32 accumulation.
+        flat_idxs = safe_shared.reshape(-1)   # (total_Sq * TopK)
+        kv_gathered = kv_flat[flat_idxs].reshape(total_Sq, TopK, d_kv)  # bf16, 384MB
 
-            kv_is_shared = (d == d_v == d_kv)
+        kv_is_shared = (d == d_v == d_kv)
 
-            # Di = sum(dO * O) per (query, head) — needed for dS
-            # Use bf16 inputs, f32 reduction (accurate enough for Di)
-            Di = (dO_flat.float() * out_flat.float()).sum(dim=-1)  # (total_Sq, np)
-            prof.stop()
+        # Di = sum(dO * O) per (query, head) — needed for dS
+        # Use bf16 inputs, f32 reduction (accurate enough for Di)
+        Di = (dO_flat.float() * out_flat.float()).sum(dim=-1)  # (total_Sq, np)
+        prof.stop()
 
-            # --- BMM in bf16 (Tensor Core, f32 internal accumulation) ---
-            prof.start("bwd_scores_P")
-            # scores = Q @ K^T * scale: bf16 bmm → f32 output
-            # torch.bmm with bf16 inputs produces bf16 output; we need f32 scores
-            # Use torch.baddbmm or manual: bmm then scale+cast
-            scores = torch.bmm(
-                q_flat.reshape(total_Sq, np_, d),
-                kv_gathered[:, :, :d].transpose(1, 2)  # (S, D, T)
-            ).float() * ctx.softmax_scale  # bf16 bmm → bf16, then f32 cast + scale
+        # --- BMM in bf16 (Tensor Core, f32 internal accumulation) ---
+        prof.start("bwd_scores_P")
+        scores = torch.bmm(
+            q_flat.reshape(total_Sq, np_, d),
+            kv_gathered[:, :, :d].transpose(1, 2)  # (S, D, T)
+        ).float() * ctx.softmax_scale  # bf16 bmm → bf16, then f32 cast + scale
 
-            # Fused exp + mask → P (single Triton kernel, replaces 3 ops)
-            P = fused_exp_mask(scores, lse, valid_shared, np_)
-            del scores
-            prof.stop()
+        # Fused exp + mask → P (single Triton kernel, replaces 3 ops)
+        P = fused_exp_mask(scores, lse, valid_shared, np_)
+        del scores
+        prof.stop()
 
-            prof.start("bwd_dS")
-            # dov = dO @ V^T: bf16 bmm → f32
-            dov = torch.bmm(
-                dO_flat,
-                kv_gathered[:, :, :d_v].transpose(1, 2)
-            ).float()  # (S, np, TopK) f32
-            dS = P * (dov - Di.unsqueeze(-1)) * ctx.softmax_scale
-            del dov
-            prof.stop()
+        prof.start("bwd_dS")
+        # dov = dO @ V^T: bf16 bmm → f32
+        dov = torch.bmm(
+            dO_flat,
+            kv_gathered[:, :, :d_v].transpose(1, 2)
+        ).float()  # (S, np, TopK) f32
+        dS = P * (dov - Di.unsqueeze(-1)) * ctx.softmax_scale
+        del dov
+        prof.stop()
 
-            prof.start("bwd_dQ")
-            # dQ = dS @ K: cast dS to bf16 for Tensor Core, keep kv in bf16
-            dq = torch.bmm(dS.to(kv_gathered.dtype), kv_gathered[:, :, :d]).float()
-            prof.stop()
+        prof.start("bwd_dQ")
+        # dQ = dS @ K: cast dS to bf16 for Tensor Core, keep kv in bf16
+        dq = torch.bmm(dS.to(kv_gathered.dtype), kv_gathered[:, :, :d]).float()
+        prof.stop()
 
-            prof.start("bwd_dKV")
-            # dK = dS^T @ Q and dV = P^T @ dO
-            # dS and P are f32 (small: 24MB each), q_flat and dO_flat are bf16.
-            # Upcast q and dO to f32 (only 16MB each) to use f32 BMM directly.
-            # This avoids: cast dS→bf16 + bmm + cast→f32 (3 kernels each)
-            # Instead: 1 upcast + 1 f32 bmm + 1 in-place baddbmm = 3 kernels total
-            q_f32 = q_flat.reshape(total_Sq, np_, d).float()  # 16MB
-            dO_f32 = dO_flat.float()  # 16MB
+        prof.start("bwd_dKV")
+        # dK = dS^T @ Q and dV = P^T @ dO
+        q_f32 = q_flat.reshape(total_Sq, np_, d).float()
+        dO_f32 = dO_flat.float()
 
-            dkv_gathered = torch.bmm(dS.transpose(1, 2), q_f32)  # (S, T, D) f32
-            del dS
-            if kv_is_shared:
-                # dV = P^T @ dO: in-place add via baddbmm (1 kernel, 0 extra alloc)
-                torch.baddbmm(dkv_gathered, P.transpose(1, 2), dO_f32, out=dkv_gathered)
-            else:
-                dv = torch.bmm(P.transpose(1, 2), dO_f32)
-                dkv_tmp = torch.zeros(total_Sq, TopK, d_kv, dtype=torch.float32, device=q_flat.device)
-                dkv_tmp[:, :, :d] = dkv_gathered
-                dkv_tmp[:, :, :d_v] += dv
-                dkv_gathered = dkv_tmp
-            del P, q_f32, dO_f32
-            prof.stop()
-
-            prof.start("bwd_scatter")
-            # Fused mask + scatter_add (single Triton kernel, replaces 2 ops)
-            valid_flat = valid_shared.reshape(-1)
-            dkv = torch.zeros(skv * b, d_kv, dtype=torch.float32, device=q_flat.device)
-            fused_mask_scatter_add(dkv_gathered, flat_idxs, valid_flat, dkv)
-
-            grad_query = dq.to(q_flat.dtype).reshape(sq, b, np_, d)
-            grad_kv_full = dkv.to(kv_flat.dtype).reshape(skv, b, -1)
-            prof.stop()
-
-            # d_sink
-            d_sink = None
-            if attn_sink is not None:
-                p_sink = torch.exp(attn_sink.unsqueeze(0) - lse)  # (total_Sq, np)
-                ds_sink = -p_sink * Di  # (total_Sq, np)
-                d_sink = ds_sink.sum(0)  # (np,)
+        dkv_gathered = torch.bmm(dS.transpose(1, 2), q_f32)  # (S, T, D) f32
+        del dS
+        if kv_is_shared:
+            # dV = P^T @ dO: in-place add via baddbmm (1 kernel, 0 extra alloc)
+            torch.baddbmm(dkv_gathered, P.transpose(1, 2), dO_f32, out=dkv_gathered)
         else:
-            # --- PyTorch BMM backward (fast for small configs) ---
-            prof.start("bwd_prepare_gather")
-            dO_flat = grad_output.reshape(total_Sq, np_, d_v).float()
-            out_f = out_flat.float()
-            q_f = q_flat.float()
+            dv = torch.bmm(P.transpose(1, 2), dO_f32)
+            dkv_tmp = torch.zeros(total_Sq, TopK, d_kv, dtype=torch.float32, device=q_flat.device)
+            dkv_tmp[:, :, :d] = dkv_gathered
+            dkv_tmp[:, :, :d_v] += dv
+            dkv_gathered = dkv_tmp
+        del P, q_f32, dO_f32
+        prof.stop()
 
-            # Di = sum(dO * O) per (query, head)
-            Di = (dO_flat * out_f).sum(dim=-1)  # (total_Sq, np)
+        prof.start("bwd_scatter")
+        # Fused mask + scatter_add (single Triton kernel, replaces 2 ops)
+        valid_flat = valid_shared.reshape(-1)
+        dkv = torch.zeros(skv * b, d_kv, dtype=torch.float32, device=q_flat.device)
+        fused_mask_scatter_add(dkv_gathered, flat_idxs, valid_flat, dkv)
 
-            # Shared indices: (total_Sq, 1, TopK) -> squeeze to (total_Sq, TopK)
-            idxs_shared = global_idxs.squeeze(1)  # (total_Sq, TopK)
-            valid_shared = idxs_shared >= 0       # (total_Sq, TopK)
-            safe_shared = idxs_shared.clamp(min=0).long()
+        grad_query = dq.to(q_flat.dtype).reshape(sq, b, np_, d)
+        grad_kv_full = dkv.to(kv_flat.dtype).reshape(skv, b, -1)
+        prof.stop()
 
-            # Gather KV once: (total_Sq * TopK) -> (total_Sq, TopK, d_kv)
-            flat_idxs = safe_shared.reshape(-1)   # (total_Sq * TopK)
-            kv_gathered = kv_flat[flat_idxs].reshape(total_Sq, TopK, d_kv)  # bf16
-
-            # In MLA/DSA, K and V share the same latent vector (d == d_v == d_kv).
-            kv_is_shared = (d == d_v == d_kv)
-
-            # Upcast kv_gathered to f32 for the full backward.
-            kv_f = kv_gathered.float()
-            del kv_gathered
-            prof.stop()
-
-            # Loop-free backward via batched BMM.
-            prof.start("bwd_scores_P")
-            scores = torch.bmm(q_f, kv_f[:, :, :d].transpose(1, 2)) * ctx.softmax_scale
-            valid_exp = valid_shared.unsqueeze(1).expand(-1, np_, -1)
-            P = torch.exp(scores - lse.unsqueeze(-1))
-            del scores
-            P.masked_fill_(~valid_exp, 0.0)
-            prof.stop()
-
-            prof.start("bwd_dS")
-            dov = torch.bmm(dO_flat, kv_f[:, :, :d_v].transpose(1, 2))
-            dS = P * (dov - Di.unsqueeze(-1)) * ctx.softmax_scale
-            del dov
-            prof.stop()
-
-            prof.start("bwd_dQ")
-            dq = torch.bmm(dS, kv_f[:, :, :d])
-            prof.stop()
-
-            prof.start("bwd_dKV")
-            dkv_gathered = torch.bmm(dS.transpose(1, 2), q_f)  # dk: (S, T, d)
-            del dS
-            if kv_is_shared:
-                torch.baddbmm(dkv_gathered, P.transpose(1, 2), dO_flat, out=dkv_gathered)
-            else:
-                dv = torch.bmm(P.transpose(1, 2), dO_flat)
-                dkv_tmp = torch.zeros(total_Sq, TopK, d_kv, dtype=torch.float32, device=q_flat.device)
-                dkv_tmp[:, :, :d] = dkv_gathered
-                dkv_tmp[:, :, :d_v] += dv
-                dkv_gathered = dkv_tmp
-            del P, kv_f
-            prof.stop()
-
-            prof.start("bwd_scatter")
-            dkv_gathered.masked_fill_(~valid_shared.unsqueeze(-1), 0.0)
-            dkv = torch.zeros(skv * b, d_kv, dtype=torch.float32, device=q_flat.device)
-            dkv.scatter_add_(
-                0,
-                flat_idxs.unsqueeze(-1).expand(-1, d_kv),
-                dkv_gathered.reshape(-1, d_kv),
-            )
-
-            grad_query = dq.to(q_flat.dtype).reshape(sq, b, np_, d)
-            grad_kv_full = dkv.to(kv_flat.dtype).reshape(skv, b, -1)
-            prof.stop()
-
-            # d_sink
-            d_sink = None
-            if attn_sink is not None:
-                p_sink = torch.exp(attn_sink.unsqueeze(0) - lse)  # (total_Sq, np)
-                ds_sink = -p_sink * Di  # (total_Sq, np)
-                d_sink = ds_sink.sum(0)  # (np,)
+        # d_sink
+        d_sink = None
+        if attn_sink is not None:
+            p_sink = torch.exp(attn_sink.unsqueeze(0) - lse)  # (total_Sq, np)
+            ds_sink = -p_sink * Di  # (total_Sq, np)
+            d_sink = ds_sink.sum(0)  # (np,)
 
         prof.start("bwd_indexer_grads")
         # Scale pre-computed indexer grads by actual grad_loss
@@ -1101,7 +974,7 @@ class FusedIndexerSparseAttnFunc(torch.autograd.Function):
         grad_weights = precomputed_grad_weights * grad_loss
         prof.stop()
 
-        prof.report(f"  [sq={sq}, b={b}, np={np_}, topk={TopK}, optimized_bwd={use_optimized_bwd}] ")
+        prof.report(f"  [sq={sq}, b={b}, np={np_}, topk={TopK}] ")
 
         return (
             grad_query,

--- a/megatron/plugin/dsa_kernel/triton_dsa_kernels.py
+++ b/megatron/plugin/dsa_kernel/triton_dsa_kernels.py
@@ -32,6 +32,9 @@ from megatron.plugin.dsa_kernel.triton_sparse_attn import (
 from megatron.plugin.dsa_kernel.triton_sparse_attn_bwd import (
     fused_mask_scatter_add,
     fused_exp_mask,
+    fused_dq,
+    fused_dkv,
+    sorted_scatter_add,
 )
 from megatron.plugin.dsa_kernel.triton_indexer_kernels import (
     sparse_indexer_score_recompute,
@@ -313,11 +316,17 @@ class _DSASparseAttnFunc(torch.autograd.Function):
         softmax_scale: float,
         d_v: int,
     ) -> Tuple[Tensor, Tensor, Optional[Tensor]]:
-        """BMM-based backward for HP WGMMA forward path.
+        """Fused backward for HP WGMMA forward path.
 
-        Uses cuBLAS BMM with f16 inputs for score recomputation, matching the
-        HP forward kernel's tl.dot(Q_f16, K_f16^T) → f32 accumulation.
-        This ensures exp(scores_bwd - lse_fwd) is numerically consistent.
+        Uses cuBLAS BMM with f16 inputs for score recomputation (numerical
+        consistency with forward tl.dot), then fused Triton kernels for dQ
+        and dKV that keep P, dov, dS in registers — eliminating ~768MB of
+        intermediate GMEM allocations.
+
+        For D==DV (shared latent, always true in training):
+          - fused_dq: scores + lse + Di + dO + K → dQ (no P/dov/dS materialized)
+          - fused_dkv: scores + lse + Di + dO + Q + K → dKV (no P/dov/dS materialized)
+          - sorted_scatter_add: local reduction before atomic (less contention)
         """
         total_Sq, H, D = query.shape
         total_Skv = kv.shape[0]
@@ -333,59 +342,36 @@ class _DSASparseAttnFunc(torch.autograd.Function):
         flat_idxs = safe_shared.reshape(-1)  # (total_Sq * TopK)
         kv_gathered = kv[flat_idxs].reshape(total_Sq, TopK, D_full)  # bf16
 
-        kv_is_shared = (D == d_v == D_full)
-
         # Di = sum(dO * O) per (query, head)
         Di = (grad_out.float() * out.float()).sum(dim=-1)  # (total_Sq, H)
 
-        # Recompute scores via BMM in f16 — matches HP WGMMA forward
+        # Recompute scores via cuBLAS BMM in f16 — matches HP WGMMA forward
         # (tl.dot(Q_f16, K_f16^T) → f32 accumulator)
         q_score = query.to(torch.float16)  # (S, H, D)
         k_score = kv_gathered[:, :, :D].to(torch.float16)  # (S, TopK, D)
         scores = torch.bmm(
             q_score, k_score.transpose(1, 2)
-        ).float() * softmax_scale  # always f32 output
+        ).float() * softmax_scale  # (S, H, TopK) f32
         del q_score, k_score
 
-        # P = exp(scores - lse) * valid_mask
-        P = fused_exp_mask(scores, lse, valid_shared, H)
+        # --- Fused dQ: eliminates P, dov, dS materialization ---
+        # dQ = sum_k( exp(scores-lse)*valid * (dO@K^T - Di) * scale ) @ K
+        dq = fused_dq(
+            scores, lse, Di, grad_out, kv_gathered[:, :, :D], valid_shared, softmax_scale
+        )
+
+        # --- Fused dKV: eliminates P, dov, dS materialization ---
+        # dKV[q,k,:] = sum_h( dS[q,h,k]*Q[q,h,:] + P[q,h,k]*dO[q,h,:] )
+        dkv_gathered = fused_dkv(
+            scores, lse, Di, grad_out, query, kv_gathered[:, :, :D],
+            valid_shared, softmax_scale
+        )
         del scores
 
-        # dov = dO @ V^T (f32 for precision in dS computation)
-        dov = torch.bmm(
-            grad_out.float(), kv_gathered[:, :, :d_v].float().transpose(1, 2)
-        )  # (S, H, TopK) f32
-
-        # dS = P * (dov - Di) * scale
-        dS = P * (dov - Di.unsqueeze(-1)) * softmax_scale
-        del dov
-
-        # dQ = dS @ K (f32 for precision)
-        dq = torch.bmm(dS, kv_gathered[:, :, :D].float())  # (S, H, D) f32
-
-        # dKV: dK = dS^T @ Q, dV = P^T @ dO
-        q_f32 = query.float()
-        dO_f32 = grad_out.float()
-
-        dkv_gathered = torch.bmm(dS.transpose(1, 2), q_f32)  # (S, TopK, D) f32
-        del dS
-        if kv_is_shared:
-            # dV = P^T @ dO: in-place add (dK + dV into same buffer)
-            torch.baddbmm(dkv_gathered, P.transpose(1, 2), dO_f32, out=dkv_gathered)
-        else:
-            dv = torch.bmm(P.transpose(1, 2), dO_f32)
-            dkv_tmp = torch.zeros(
-                total_Sq, TopK, D_full, dtype=torch.float32, device=query.device
-            )
-            dkv_tmp[:, :, :D] = dkv_gathered
-            dkv_tmp[:, :, :d_v] += dv
-            dkv_gathered = dkv_tmp
-        del P, q_f32, dO_f32
-
-        # Scatter dkv_gathered back to full KV positions
+        # --- Scatter with sorted local reduction ---
         valid_flat = valid_shared.reshape(-1)
         dkv = torch.zeros(total_Skv, D_full, dtype=torch.float32, device=query.device)
-        fused_mask_scatter_add(dkv_gathered, flat_idxs, valid_flat, dkv)
+        sorted_scatter_add(dkv_gathered, flat_idxs, valid_flat, dkv)
 
         dq_out = dq.to(query.dtype)
         dkv_out = dkv.to(kv.dtype)

--- a/megatron/plugin/dsa_kernel/triton_dsa_kernels.py
+++ b/megatron/plugin/dsa_kernel/triton_dsa_kernels.py
@@ -30,8 +30,6 @@ from megatron.plugin.dsa_kernel.triton_sparse_attn import (
     triton_sparse_attn_backward,
 )
 from megatron.plugin.dsa_kernel.triton_sparse_attn_bwd import (
-    fused_mask_scatter_add,
-    fused_exp_mask,
     fused_dq,
     fused_dkv,
     sorted_scatter_add,
@@ -345,14 +343,11 @@ class _DSASparseAttnFunc(torch.autograd.Function):
         # Di = sum(dO * O) per (query, head)
         Di = (grad_out.float() * out.float()).sum(dim=-1)  # (total_Sq, H)
 
-        # Recompute scores via cuBLAS BMM in f16 — matches HP WGMMA forward
-        # (tl.dot(Q_f16, K_f16^T) → f32 accumulator)
-        q_score = query.to(torch.float16)  # (S, H, D)
-        k_score = kv_gathered[:, :, :D].to(torch.float16)  # (S, TopK, D)
+        # Recompute scores via cuBLAS BMM in bf16 — matches HP WGMMA forward
+        # (tl.dot(Q_bf16, K_bf16^T) → f32 accumulator, training dtype is bf16)
         scores = torch.bmm(
-            q_score, k_score.transpose(1, 2)
+            query, kv_gathered[:, :, :D].transpose(1, 2)
         ).float() * softmax_scale  # (S, H, TopK) f32
-        del q_score, k_score
 
         # --- Fused dQ: eliminates P, dov, dS materialization ---
         # dQ = sum_k( exp(scores-lse)*valid * (dO@K^T - Di) * scale ) @ K
@@ -861,16 +856,18 @@ class FusedIndexerSparseAttnFunc(torch.autograd.Function):
 
         logger.debug(
             "FusedIndexerSparseAttnFunc.backward: sq=%d, b=%d, np=%d, "
-            "TopK=%d, d_kv=%d, bwd_path=optimized_bf16_bmm",
+            "TopK=%d, d_kv=%d, bwd_path=fused_dq_dkv",
             sq, b, np_, TopK, d_kv,
         )
 
-        # --- Optimized path: bf16 BMM + Triton fused epilogues ---
-        # Training always uses this path (shared indices, large TopK).
-        # Key savings vs legacy f32 path:
-        #   1. No f32 upcast of kv_gathered (saves 768MB alloc + bandwidth)
-        #   2. Fused exp+mask (saves 1 kernel launch + 24MB read/write)
-        #   3. Fused mask+scatter (saves 384MB read pass)
+        # --- Optimized path: bf16 BMM scores + Triton fused dQ/dKV ---
+        # Uses fused_dq and fused_dkv kernels that keep P, dov, dS in registers,
+        # eliminating ~768MB of intermediate GMEM allocations.
+        # Key savings vs previous torch.bmm path:
+        #   1. No P (S,H,TopK) materialization in GMEM
+        #   2. No dov (S,H,TopK) materialization in GMEM
+        #   3. No dS (S,H,TopK) materialization in GMEM
+        #   4. Fused mask+scatter (saves 384MB read pass)
         prof.start("bwd_prepare_gather")
         dO_flat = grad_output.reshape(total_Sq, np_, d_v)
 
@@ -883,64 +880,44 @@ class FusedIndexerSparseAttnFunc(torch.autograd.Function):
         flat_idxs = safe_shared.reshape(-1)   # (total_Sq * TopK)
         kv_gathered = kv_flat[flat_idxs].reshape(total_Sq, TopK, d_kv)  # bf16, 384MB
 
-        kv_is_shared = (d == d_v == d_kv)
-
         # Di = sum(dO * O) per (query, head) — needed for dS
         # Use bf16 inputs, f32 reduction (accurate enough for Di)
         Di = (dO_flat.float() * out_flat.float()).sum(dim=-1)  # (total_Sq, np)
         prof.stop()
 
-        # --- BMM in bf16 (Tensor Core, f32 internal accumulation) ---
-        prof.start("bwd_scores_P")
+        # --- Recompute scores via cuBLAS BMM in bf16 (matches HP WGMMA forward) ---
+        # Forward uses tl.dot(Q_bf16, K_bf16^T) → f32 accumulator.
+        # cuBLAS bf16 BMM also does bf16×bf16→f32 accumulation internally,
+        # ensuring exp(scores_bwd - lse_fwd) is numerically consistent.
+        prof.start("bwd_scores")
         scores = torch.bmm(
             q_flat.reshape(total_Sq, np_, d),
-            kv_gathered[:, :, :d].transpose(1, 2)  # (S, D, T)
-        ).float() * ctx.softmax_scale  # bf16 bmm → bf16, then f32 cast + scale
+            kv_gathered[:, :, :d].transpose(1, 2)
+        ).float() * ctx.softmax_scale  # (S, H, TopK) f32
+        prof.stop()
 
-        # Fused exp + mask → P (single Triton kernel, replaces 3 ops)
-        P = fused_exp_mask(scores, lse, valid_shared, np_)
+        # --- Fused dQ: eliminates P, dov, dS materialization ---
+        prof.start("bwd_dQ")
+        dq = fused_dq(
+            scores, lse, Di, dO_flat, kv_gathered[:, :, :d],
+            valid_shared, ctx.softmax_scale
+        )
+        prof.stop()
+
+        # --- Fused dKV: eliminates P, dov, dS materialization ---
+        prof.start("bwd_dKV")
+        dkv_gathered = fused_dkv(
+            scores, lse, Di, dO_flat, q_flat.reshape(total_Sq, np_, d),
+            kv_gathered[:, :, :d], valid_shared, ctx.softmax_scale
+        )
         del scores
         prof.stop()
 
-        prof.start("bwd_dS")
-        # dov = dO @ V^T: bf16 bmm → f32
-        dov = torch.bmm(
-            dO_flat,
-            kv_gathered[:, :, :d_v].transpose(1, 2)
-        ).float()  # (S, np, TopK) f32
-        dS = P * (dov - Di.unsqueeze(-1)) * ctx.softmax_scale
-        del dov
-        prof.stop()
-
-        prof.start("bwd_dQ")
-        # dQ = dS @ K: cast dS to bf16 for Tensor Core, keep kv in bf16
-        dq = torch.bmm(dS.to(kv_gathered.dtype), kv_gathered[:, :, :d]).float()
-        prof.stop()
-
-        prof.start("bwd_dKV")
-        # dK = dS^T @ Q and dV = P^T @ dO
-        q_f32 = q_flat.reshape(total_Sq, np_, d).float()
-        dO_f32 = dO_flat.float()
-
-        dkv_gathered = torch.bmm(dS.transpose(1, 2), q_f32)  # (S, T, D) f32
-        del dS
-        if kv_is_shared:
-            # dV = P^T @ dO: in-place add via baddbmm (1 kernel, 0 extra alloc)
-            torch.baddbmm(dkv_gathered, P.transpose(1, 2), dO_f32, out=dkv_gathered)
-        else:
-            dv = torch.bmm(P.transpose(1, 2), dO_f32)
-            dkv_tmp = torch.zeros(total_Sq, TopK, d_kv, dtype=torch.float32, device=q_flat.device)
-            dkv_tmp[:, :, :d] = dkv_gathered
-            dkv_tmp[:, :, :d_v] += dv
-            dkv_gathered = dkv_tmp
-        del P, q_f32, dO_f32
-        prof.stop()
-
         prof.start("bwd_scatter")
-        # Fused mask + scatter_add (single Triton kernel, replaces 2 ops)
+        # Sorted scatter with local reduction (less atomic contention)
         valid_flat = valid_shared.reshape(-1)
         dkv = torch.zeros(skv * b, d_kv, dtype=torch.float32, device=q_flat.device)
-        fused_mask_scatter_add(dkv_gathered, flat_idxs, valid_flat, dkv)
+        sorted_scatter_add(dkv_gathered, flat_idxs, valid_flat, dkv)
 
         grad_query = dq.to(q_flat.dtype).reshape(sq, b, np_, d)
         grad_kv_full = dkv.to(kv_flat.dtype).reshape(skv, b, -1)

--- a/megatron/plugin/dsa_kernel/triton_dsa_kernels.py
+++ b/megatron/plugin/dsa_kernel/triton_dsa_kernels.py
@@ -17,6 +17,7 @@ Public API (identical to ``dsa_kernels.py``):
 
 from __future__ import annotations
 
+import logging
 import os
 from typing import Optional, Tuple
 
@@ -41,6 +42,9 @@ from megatron.plugin.dsa_kernel.triton_indexer_kernels import (
     fused_sparse_indexer_loss_and_backward,
     fused_dense_indexer_loss_and_backward,
 )
+
+
+logger = logging.getLogger(__name__)
 
 
 # ---------------------------------------------------------------------------
@@ -194,7 +198,18 @@ def _indexer_topk_bshd(
 
 
 class _DSASparseAttnFunc(torch.autograd.Function):
-    """Differentiable sparse attention using Triton kernels."""
+    """Differentiable sparse attention using Triton kernels.
+
+    The backward path adapts to match the forward path's dot-product method:
+    - When forward used PyTorch BMM (TopK <= 512), backward also uses BMM to
+      ensure the recomputed scores are numerically consistent with the saved LSE.
+    - When forward used the Triton kernel (TopK > 512), backward uses the Triton
+      kernel which shares the same accumulation order.
+    """
+
+    # Mirror the forward dispatch thresholds from triton_sparse_attn.py
+    _PYTORCH_FWD_TOPK_THRESHOLD = 512
+    _PYTORCH_FWD_MAX_GATHER_ELEMENTS = 2 * 1024 * 1024
 
     @staticmethod
     def forward(
@@ -210,6 +225,27 @@ class _DSASparseAttnFunc(torch.autograd.Function):
             query, kv, topk_idxs, softmax_scale, d_v, attn_sink
         )
         ctx.has_attn_sink = attn_sink is not None
+
+        # Determine if the forward used the PyTorch BMM path (same logic as
+        # triton_sparse_attn_fwd dispatch).  If so, the backward must also use
+        # BMM to keep the score recomputation numerically consistent with LSE.
+        TopK = topk_idxs.shape[-1]
+        total_Sq, H = topk_idxs.shape[0], topk_idxs.shape[1]
+        shared = (topk_idxs.stride(1) == 0)
+        gather_elements = total_Sq * TopK if shared else total_Sq * H * TopK
+        ctx.used_pytorch_fwd = (
+            TopK <= _DSASparseAttnFunc._PYTORCH_FWD_TOPK_THRESHOLD
+            and gather_elements <= _DSASparseAttnFunc._PYTORCH_FWD_MAX_GATHER_ELEMENTS
+        )
+        ctx.shared_indices = shared
+
+        logger.debug(
+            "_DSASparseAttnFunc.forward: total_Sq=%d, H=%d, TopK=%d, shared=%s, "
+            "fwd_path=%s",
+            total_Sq, H, TopK, shared,
+            "pytorch_bmm" if ctx.used_pytorch_fwd else "triton",
+        )
+
         if attn_sink is not None:
             ctx.save_for_backward(query, kv, topk_idxs, out, lse, attn_sink)
         else:
@@ -225,12 +261,129 @@ class _DSASparseAttnFunc(torch.autograd.Function):
         else:
             query, kv, topk_idxs, out, lse = ctx.saved_tensors
             attn_sink = None
-        bwd_result = triton_sparse_attn_backward(
-            grad_out, query, kv, out, lse, topk_idxs,
-            ctx.softmax_scale, ctx.d_v, attn_sink
+
+        logger.debug(
+            "_DSASparseAttnFunc.backward: used_pytorch_fwd=%s, shared_indices=%s, "
+            "bwd_path=%s",
+            ctx.used_pytorch_fwd, ctx.shared_indices,
+            "bmm" if (ctx.used_pytorch_fwd and ctx.shared_indices) else "triton",
         )
-        dq, dkv, d_sink = bwd_result["dq"], bwd_result["dkv"], bwd_result["d_sink"]
+
+        if ctx.used_pytorch_fwd and ctx.shared_indices:
+            # --- BMM backward: matches the PyTorch BMM forward path ---
+            # Recomputes scores via cuBLAS BMM (same accumulation as forward)
+            # so that exp(scores - lse) is numerically consistent.
+            dq, dkv, d_sink = _DSASparseAttnFunc._bmm_backward(
+                grad_out, query, kv, topk_idxs, out, lse, attn_sink,
+                ctx.softmax_scale, ctx.d_v,
+            )
+        else:
+            # --- Triton backward: forward also used Triton kernel ---
+            # Both fwd and bwd use tl.sum(q * k) → same dot product, consistent.
+            bwd_result = triton_sparse_attn_backward(
+                grad_out, query, kv, out, lse, topk_idxs,
+                ctx.softmax_scale, ctx.d_v, attn_sink
+            )
+            dq, dkv, d_sink = bwd_result["dq"], bwd_result["dkv"], bwd_result["d_sink"]
+
         return dq, dkv, None, None, None, d_sink
+
+    @staticmethod
+    def _bmm_backward(
+        grad_out: Tensor,   # (total_Sq, H, d_v) bf16
+        query: Tensor,      # (total_Sq, H, D) bf16
+        kv: Tensor,         # (total_Skv, D_full) bf16
+        topk_idxs: Tensor,  # (total_Sq, H, TopK) int32, shared (stride(1)==0)
+        out: Tensor,        # (total_Sq, H, d_v) bf16
+        lse: Tensor,        # (total_Sq, H) f32
+        attn_sink: Optional[Tensor],  # (H,) f32 or None
+        softmax_scale: float,
+        d_v: int,
+    ) -> Tuple[Tensor, Tensor, Optional[Tensor]]:
+        """BMM-based backward for shared-index sparse attention.
+
+        Adapted from FusedIndexerSparseAttnFunc.backward (optimized path).
+        Uses cuBLAS BMM for score recomputation to match the forward's LSE.
+        """
+        total_Sq, H, D = query.shape
+        total_Skv = kv.shape[0]
+        D_full = kv.shape[-1] if kv.dim() > 1 else D
+        TopK = topk_idxs.shape[-1]
+
+        # Shared indices: (total_Sq, H, TopK) with stride(1)==0 → use head 0
+        idxs_shared = topk_idxs[:, 0, :]  # (total_Sq, TopK)
+        valid_shared = idxs_shared >= 0    # (total_Sq, TopK)
+        safe_shared = idxs_shared.clamp(min=0).long()
+
+        # Gather KV once in bf16 (cuBLAS bf16 BMM does f32 internal accumulation)
+        flat_idxs = safe_shared.reshape(-1)  # (total_Sq * TopK)
+        kv_gathered = kv[flat_idxs].reshape(total_Sq, TopK, D_full)  # bf16
+
+        kv_is_shared = (D == d_v == D_full)
+
+        # Di = sum(dO * O) per (query, head)
+        Di = (grad_out.float() * out.float()).sum(dim=-1)  # (total_Sq, H)
+
+        # Recompute scores via f32 BMM — must match _pytorch_sparse_attn_fwd
+        # which uses torch.bmm(q.float(), k.float().T) * scale.
+        # Using f32 inputs ensures identical accumulation and thus exp(s - lse) ≈ 1
+        # at the correct positions (no bf16 truncation mismatch).
+        scores = torch.bmm(
+            query.float(),  # (S, H, D) f32
+            kv_gathered[:, :, :D].float().transpose(1, 2)  # (S, D, TopK) f32
+        ) * softmax_scale  # f32
+
+        # P = exp(scores - lse) * valid_mask
+        P = fused_exp_mask(scores, lse, valid_shared, H)
+        del scores
+
+        # dov = dO @ V^T (f32 for precision in dS computation)
+        dov = torch.bmm(
+            grad_out.float(), kv_gathered[:, :, :d_v].float().transpose(1, 2)
+        )  # (S, H, TopK) f32
+
+        # dS = P * (dov - Di) * scale
+        dS = P * (dov - Di.unsqueeze(-1)) * softmax_scale
+        del dov
+
+        # dQ = dS @ K (f32 for precision)
+        dq = torch.bmm(dS, kv_gathered[:, :, :D].float())  # (S, H, D) f32
+
+        # dKV: dK = dS^T @ Q, dV = P^T @ dO
+        q_f32 = query.float()
+        dO_f32 = grad_out.float()
+
+        dkv_gathered = torch.bmm(dS.transpose(1, 2), q_f32)  # (S, TopK, D) f32
+        del dS
+        if kv_is_shared:
+            # dV = P^T @ dO: in-place add (dK + dV into same buffer)
+            torch.baddbmm(dkv_gathered, P.transpose(1, 2), dO_f32, out=dkv_gathered)
+        else:
+            dv = torch.bmm(P.transpose(1, 2), dO_f32)
+            dkv_tmp = torch.zeros(
+                total_Sq, TopK, D_full, dtype=torch.float32, device=query.device
+            )
+            dkv_tmp[:, :, :D] = dkv_gathered
+            dkv_tmp[:, :, :d_v] += dv
+            dkv_gathered = dkv_tmp
+        del P, q_f32, dO_f32
+
+        # Scatter dkv_gathered back to full KV positions
+        valid_flat = valid_shared.reshape(-1)
+        dkv = torch.zeros(total_Skv, D_full, dtype=torch.float32, device=query.device)
+        fused_mask_scatter_add(dkv_gathered, flat_idxs, valid_flat, dkv)
+
+        dq_out = dq.to(query.dtype)
+        dkv_out = dkv.to(kv.dtype)
+
+        # d_sink: gradient of the bias-only attention sink
+        d_sink = None
+        if attn_sink is not None:
+            p_sink = torch.exp(attn_sink.unsqueeze(0) - lse)  # (total_Sq, H)
+            ds_sink = -p_sink * Di  # (total_Sq, H)
+            d_sink = ds_sink.sum(0)  # (H,)
+
+        return dq_out, dkv_out, d_sink
 
 
 def dsa_sparse_attn(
@@ -425,6 +578,13 @@ class FusedIndexerSparseAttnFunc(torch.autograd.Function):
         idx_nh, idx_hd = q_indexer.shape[2], q_indexer.shape[3]
 
         effective_topk = min(indexer_topk, n_comp)
+
+        logger.debug(
+            "FusedIndexerSparseAttnFunc.forward: sq=%d, b=%d, np=%d, d=%d, "
+            "skv=%d, n_comp=%d, effective_topk=%d, sparse_loss=%s, "
+            "loss_coeff=%.4g",
+            sq, b, np_, d, skv, n_comp, effective_topk, sparse_loss, loss_coeff,
+        )
 
         prof = _CudaProfiler(enabled=_DSA_PROFILE)
 
@@ -651,6 +811,13 @@ class FusedIndexerSparseAttnFunc(torch.autograd.Function):
         # Determine whether to use optimized bf16 BMM path or baseline f32 path.
         shared_indices = (global_idxs.stride(1) == 0)
         use_optimized_bwd = should_use_triton_bwd(total_Sq, TopK, d_kv, np_, shared_indices)
+
+        logger.debug(
+            "FusedIndexerSparseAttnFunc.backward: sq=%d, b=%d, np=%d, "
+            "TopK=%d, d_kv=%d, shared_indices=%s, bwd_path=%s",
+            sq, b, np_, TopK, d_kv, shared_indices,
+            "optimized_bf16_bmm" if use_optimized_bwd else "baseline_f32",
+        )
 
         if use_optimized_bwd:
             # --- Optimized path: bf16 BMM + Triton fused epilogues ---

--- a/megatron/plugin/dsa_kernel/triton_dsa_kernels.py
+++ b/megatron/plugin/dsa_kernel/triton_dsa_kernels.py
@@ -260,10 +260,14 @@ class _DSASparseAttnFunc(torch.autograd.Function):
             "hp_wgmma" if ctx.used_hp_fwd else "triton_2d",
         )
 
+        # Downstream fused inverse-RoPE mutates the returned output in-place.
+        # Backward needs the original attention result for Di = sum(dO * O),
+        # so retain an independent copy inside the DSA kernel boundary.
+        out_for_backward = out.clone()
         if attn_sink is not None:
-            ctx.save_for_backward(query, kv, topk_idxs, out, lse, attn_sink)
+            ctx.save_for_backward(query, kv, topk_idxs, out_for_backward, lse, attn_sink)
         else:
-            ctx.save_for_backward(query, kv, topk_idxs, out, lse)
+            ctx.save_for_backward(query, kv, topk_idxs, out_for_backward, lse)
         ctx.softmax_scale = softmax_scale
         ctx.d_v = d_v
         return out, lse
@@ -526,6 +530,7 @@ def indexer_topk(
 
 
 _CLIP_PROB_MIN = torch.finfo(torch.float32).tiny
+_SPARSE_KL_EPS = 1e-10
 
 
 def _kl_loss_from_target_predict(
@@ -536,10 +541,14 @@ def _kl_loss_from_target_predict(
     calculate_per_token_loss: bool = False,
 ) -> Tensor:
     """KL(target || predict) reduced and scaled by loss_coeff."""
-    eps = _CLIP_PROB_MIN
-    t = target.clamp(min=eps)
-    p = predict.clamp(min=eps)
-    kl_per_row = (t * (torch.log(t) - torch.log(p))).sum(dim=-1)  # (B, S_q)
+    # Keep inference/no-grad loss reporting identical to compute_dsa_indexer_loss.
+    kl_per_row = (
+        target
+        * (
+            torch.log(target + _SPARSE_KL_EPS)
+            - torch.log(predict + _SPARSE_KL_EPS)
+        )
+    ).sum(dim=-1)
 
     row_valid = (topk_indices >= 0).any(dim=-1)  # (B, S_q)
     kl_per_row = torch.where(row_valid, kl_per_row, torch.zeros_like(kl_per_row))
@@ -688,7 +697,6 @@ class FusedIndexerSparseAttnFunc(torch.autograd.Function):
             indexer_topk=_indexer_topk_for_lse,
         )
         prof.stop()
-
         # 6. Compute indexer loss
         # P3 optimization: skip step 6+7 entirely when loss_coeff == 0
         if loss_coeff == 0:
@@ -699,7 +707,7 @@ class FusedIndexerSparseAttnFunc(torch.autograd.Function):
 
             # Save for backward
             ctx.save_for_backward(
-                q_flat, kv_flat, attn_sink, global_idxs, out_flat, lse,
+                q_flat, kv_flat, attn_sink, global_idxs, out_flat.clone(), lse,
                 precomputed_grad_q_indexer, precomputed_grad_k_indexer, precomputed_grad_weights,
             )
             ctx.softmax_scale = softmax_scale
@@ -826,7 +834,7 @@ class FusedIndexerSparseAttnFunc(torch.autograd.Function):
         # Save for backward
         prof.stop()
         ctx.save_for_backward(
-            q_flat, kv_flat, attn_sink, global_idxs, out_flat, lse,
+            q_flat, kv_flat, attn_sink, global_idxs, out_flat.clone(), lse,
             precomputed_grad_q_indexer, precomputed_grad_k_indexer, precomputed_grad_weights,
         )
         ctx.softmax_scale = softmax_scale
@@ -839,7 +847,6 @@ class FusedIndexerSparseAttnFunc(torch.autograd.Function):
         # Return
         d_v = out_flat.shape[-1]
         output = out_flat.reshape(sq, b, np_, d_v).reshape(sq, b, np_ * d_v)
-
         prof.report(f"  [sq={sq}, b={b}, np={np_}, topk={total_topk}] ")
         return output, indexer_loss
 

--- a/megatron/plugin/dsa_kernel/triton_dsa_kernels.py
+++ b/megatron/plugin/dsa_kernel/triton_dsa_kernels.py
@@ -749,6 +749,10 @@ class FusedIndexerSparseAttnFunc(torch.autograd.Function):
                 precomputed_grad_q_indexer = precomputed_grad_q_indexer.permute(1, 0, 2, 3).contiguous()
                 precomputed_grad_k_indexer = precomputed_grad_k_indexer.permute(1, 0, 2).contiguous()
                 precomputed_grad_weights = precomputed_grad_weights.permute(1, 0, 2).contiguous()
+                # Chain rule: w_scaled = w_raw * indexer_softmax_scale (done in
+                # _sbhd_to_bshd_indexer_inputs). The fused function returns
+                # ∂L/∂w_scaled; convert to ∂L/∂w_raw for the autograd Function.
+                precomputed_grad_weights = precomputed_grad_weights * indexer_softmax_scale
             else:
                 # Inference: only compute loss, no backward
                 predict_result = sparse_indexer_score_recompute(
@@ -779,7 +783,7 @@ class FusedIndexerSparseAttnFunc(torch.autograd.Function):
                 # Fused: loss + backward in one pass
                 indexer_loss, precomputed_grad_q_indexer, precomputed_grad_k_indexer, precomputed_grad_weights = (
                     fused_dense_indexer_loss_and_backward(
-                        q_idx_bshd, k_idx_bsd, w_bsh,
+                        q_idx_bshd, k_idx_bsd, w_bsh_scaled,
                         topk_indices_cmp,
                         q_attn_bshd, k_attn_bsd, lse_bsh,
                         indexer_softmax_scale=indexer_softmax_scale,
@@ -794,6 +798,8 @@ class FusedIndexerSparseAttnFunc(torch.autograd.Function):
                 precomputed_grad_q_indexer = precomputed_grad_q_indexer.permute(1, 0, 2, 3).contiguous()
                 precomputed_grad_k_indexer = precomputed_grad_k_indexer.permute(1, 0, 2).contiguous()
                 precomputed_grad_weights = precomputed_grad_weights.permute(1, 0, 2).contiguous()
+                # Chain rule: same as sparse path
+                precomputed_grad_weights = precomputed_grad_weights * indexer_softmax_scale
             else:
                 # Inference: only compute loss
                 dense_idx_result = dense_indexer_score_recompute(

--- a/megatron/plugin/dsa_kernel/triton_dsa_utils.py
+++ b/megatron/plugin/dsa_kernel/triton_dsa_utils.py
@@ -1,0 +1,247 @@
+# Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
+
+"""
+Triton DSA/CSA utility functions.
+
+Shared helpers for the Triton-based DSA sparse attention and indexer kernels,
+including causal mask computation, online softmax primitives, and autotune configs.
+"""
+
+from __future__ import annotations
+
+from typing import List, Tuple
+
+import torch
+import triton
+import triton.language as tl
+
+
+# ---------------------------------------------------------------------------
+# Triton autotune configurations
+# ---------------------------------------------------------------------------
+
+
+def get_sparse_attn_autotune_configs(D: int) -> List[triton.Config]:
+    """Generate autotune configs for sparse attention kernels based on head dim."""
+    configs = []
+    # For typical DSA head dims (D=512 or D=128)
+    if D >= 256:
+        configs.extend([
+            triton.Config({"BLOCK_Q": 16, "BLOCK_K": 64}, num_warps=4, num_stages=2),
+            triton.Config({"BLOCK_Q": 16, "BLOCK_K": 32}, num_warps=4, num_stages=3),
+            triton.Config({"BLOCK_Q": 32, "BLOCK_K": 32}, num_warps=4, num_stages=2),
+        ])
+    else:
+        configs.extend([
+            triton.Config({"BLOCK_Q": 32, "BLOCK_K": 64}, num_warps=4, num_stages=3),
+            triton.Config({"BLOCK_Q": 64, "BLOCK_K": 64}, num_warps=4, num_stages=2),
+            triton.Config({"BLOCK_Q": 32, "BLOCK_K": 128}, num_warps=8, num_stages=2),
+            triton.Config({"BLOCK_Q": 64, "BLOCK_K": 128}, num_warps=8, num_stages=2),
+        ])
+    return configs
+
+
+def get_indexer_autotune_configs() -> List[triton.Config]:
+    """Generate autotune configs for indexer scoring kernels."""
+    return [
+        triton.Config({"BLOCK_Q": 32, "BLOCK_K": 64}, num_warps=4, num_stages=2),
+        triton.Config({"BLOCK_Q": 32, "BLOCK_K": 128}, num_warps=4, num_stages=2),
+        triton.Config({"BLOCK_Q": 64, "BLOCK_K": 64}, num_warps=4, num_stages=3),
+        triton.Config({"BLOCK_Q": 64, "BLOCK_K": 128}, num_warps=8, num_stages=2),
+    ]
+
+
+# ---------------------------------------------------------------------------
+# PyTorch-level utilities
+# ---------------------------------------------------------------------------
+
+
+def compute_ratio_causal_mask(
+    S_q: int,
+    S_k: int,
+    ratio: int,
+    device: torch.device,
+    dtype: torch.dtype = torch.float32,
+) -> torch.Tensor:
+    """Generate a ratio-based causal mask.
+
+    In DSA, compressed KV positions use a coarser causal constraint:
+    query at position q can attend to compressed position k if
+    ``k < ceil(q / ratio)`` (i.e., the compressed token was produced from
+    original tokens all earlier than q).
+
+    Args:
+        S_q: number of query positions.
+        S_k: number of KV positions (compressed).
+        ratio: compression ratio.
+        device: target device.
+        dtype: output dtype (default float32).
+
+    Returns:
+        mask: ``(S_q, S_k)`` tensor, 0 for valid positions, ``-inf`` for masked.
+    """
+    q_idx = torch.arange(S_q, device=device, dtype=torch.int64)
+    k_idx = torch.arange(S_k, device=device, dtype=torch.int64)
+    # query q can attend to compressed position k if k < ceil((q+1) / ratio)
+    # equivalently: k * ratio < q + 1, i.e., k * ratio <= q
+    valid = k_idx.unsqueeze(0) * ratio <= q_idx.unsqueeze(1)  # (S_q, S_k)
+    mask = torch.where(valid, torch.zeros(1, device=device, dtype=dtype),
+                       torch.full((1,), float("-inf"), device=device, dtype=dtype))
+    return mask
+
+
+def topk_with_causal_mask(
+    scores: torch.Tensor,
+    k: int,
+    ratio: int,
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    """Select top-K from scores with ratio-based causal masking.
+
+    Args:
+        scores: ``(B, S_q, S_k)`` float32 — raw indexer scores.
+        k: number of top-K indices to select.
+        ratio: compression ratio for causal masking.
+
+    Returns:
+        topk_indices: ``(B, S_q, k)`` int32 — indices into S_k, -1 for invalid.
+        topk_length: ``(B, S_q)`` int32 — number of valid positions per query.
+    """
+    B, S_q, S_k = scores.shape
+    device = scores.device
+
+    # Apply ratio causal mask
+    mask = compute_ratio_causal_mask(S_q, S_k, ratio, device, scores.dtype)
+    masked_scores = scores + mask.unsqueeze(0)  # (B, S_q, S_k)
+
+    # Effective k — cannot exceed S_k
+    effective_k = min(k, S_k)
+
+    # Top-K selection
+    _, indices = masked_scores.topk(effective_k, dim=-1)  # (B, S_q, effective_k)
+    indices = indices.to(torch.int32)
+
+    # Mark invalid positions (those that were -inf before topk)
+    # A position is invalid if its masked score is -inf
+    gathered_scores = torch.gather(masked_scores, 2, indices.long())
+    invalid = torch.isinf(gathered_scores) & (gathered_scores < 0)
+    indices = torch.where(invalid, torch.full_like(indices, -1), indices)
+
+    # Compute valid length per query
+    topk_length = (~invalid).sum(dim=-1).to(torch.int32)  # (B, S_q)
+
+    # Pad to requested k if effective_k < k
+    if effective_k < k:
+        pad_width = k - effective_k
+        indices = torch.nn.functional.pad(indices, (0, pad_width), value=-1)
+
+    return indices, topk_length
+
+
+# ---------------------------------------------------------------------------
+# Triton-level primitives (used inside kernels)
+# ---------------------------------------------------------------------------
+
+
+@triton.jit
+def _online_softmax_update(
+    m_prev,  # running max, shape matches a row
+    l_prev,  # running sum of exp, shape matches a row
+    acc_prev,  # running weighted accumulator
+    m_new_block,  # max of new block scores
+    scores_block,  # new block scores (before exp)
+    v_block,  # new block V values
+):
+    """Online softmax update step (used inside attention kernel loops).
+
+    Given:
+        - Previous state: (m_prev, l_prev, acc_prev)
+        - New block: scores_block, v_block
+
+    Returns updated: (m_new, l_new, acc_new)
+    """
+    # New global max
+    m_new = tl.maximum(m_prev, m_new_block)
+    # Rescale previous accumulator
+    alpha = tl.exp(m_prev - m_new)
+    # Exp of new scores with new max
+    p_block = tl.exp(scores_block - m_new[:, None])
+    # Update sum
+    l_new = l_prev * alpha + tl.sum(p_block, axis=1)
+    # Update accumulator: rescale old + add new contribution
+    acc_new = acc_prev * alpha[:, None] + tl.dot(p_block.to(v_block.dtype), v_block)
+    return m_new, l_new, acc_new
+
+
+@triton.jit
+def _compute_ratio_mask_triton(
+    q_pos,  # scalar or vector of query positions
+    k_pos,  # scalar or vector of kv positions
+    ratio: tl.constexpr,
+):
+    """Compute ratio-based causal mask in Triton.
+
+    Returns True (valid) if k_pos * ratio <= q_pos.
+    """
+    return k_pos * ratio <= q_pos
+
+
+@triton.jit
+def _safe_load_with_mask(ptr, mask, other=0.0):
+    """Load from pointer with mask, returning `other` for masked positions."""
+    return tl.load(ptr, mask=mask, other=other)
+
+
+# ---------------------------------------------------------------------------
+# Block size selection
+# ---------------------------------------------------------------------------
+
+
+def select_block_sizes(D: int, TopK: int) -> Tuple[int, int]:
+    """Select BLOCK_Q and BLOCK_K sizes based on head dim and topk.
+
+    Heuristic: keep BLOCK_K * D fitting in shared memory, and BLOCK_Q small
+    enough for good occupancy.
+
+    Args:
+        D: head dimension.
+        TopK: number of top-K positions per query.
+
+    Returns:
+        (BLOCK_Q, BLOCK_K) tuple.
+    """
+    if D >= 512:
+        # Large head dim — use smaller blocks
+        BLOCK_Q = 16
+        BLOCK_K = min(32, TopK) if TopK >= 32 else TopK
+    elif D >= 128:
+        BLOCK_Q = 32
+        BLOCK_K = min(64, TopK) if TopK >= 64 else min(32, TopK)
+    else:
+        BLOCK_Q = 64
+        BLOCK_K = min(128, TopK)
+    # Ensure BLOCK_K is power of 2 and >= 16
+    BLOCK_K = max(16, 1 << (BLOCK_K - 1).bit_length())
+    return BLOCK_Q, BLOCK_K
+
+
+# ---------------------------------------------------------------------------
+# Padding / alignment helpers
+# ---------------------------------------------------------------------------
+
+
+def pad_to_multiple(x: torch.Tensor, dim: int, multiple: int, value=0) -> torch.Tensor:
+    """Pad tensor along `dim` to the next multiple of `multiple`."""
+    size = x.shape[dim]
+    if size % multiple == 0:
+        return x
+    pad_size = multiple - (size % multiple)
+    pad_widths = [0] * (2 * x.ndim)
+    # F.pad uses reversed dim order
+    pad_idx = 2 * (x.ndim - 1 - dim)
+    pad_widths[pad_idx + 1] = pad_size
+    return torch.nn.functional.pad(x, pad_widths, value=value)
+
+
+def ceildiv(a: int, b: int) -> int:
+    """Integer ceiling division."""
+    return (a + b - 1) // b

--- a/megatron/plugin/dsa_kernel/triton_dsa_utils.py
+++ b/megatron/plugin/dsa_kernel/triton_dsa_utils.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
+# Copyright (c) 2026, FlagOS Contributors. All rights reserved.
 
 """
 Triton DSA/CSA utility functions.

--- a/megatron/plugin/dsa_kernel/triton_dsa_utils.py
+++ b/megatron/plugin/dsa_kernel/triton_dsa_utils.py
@@ -65,10 +65,11 @@ def compute_ratio_causal_mask(
 ) -> torch.Tensor:
     """Generate a ratio-based causal mask.
 
-    In DSA, compressed KV positions use a coarser causal constraint:
-    query at position q can attend to compressed position k if
-    ``k < ceil(q / ratio)`` (i.e., the compressed token was produced from
-    original tokens all earlier than q).
+    In DSA, compressed KV positions use a coarser causal constraint.  A
+    compressed token becomes visible only after its full ``ratio``-token
+    source group exists.  For zero-based query position ``q`` and compressed
+    position ``k``, the CSA reference contract is
+    ``k < floor((q + 1) / ratio)``.
 
     Args:
         S_q: number of query positions.
@@ -82,9 +83,11 @@ def compute_ratio_causal_mask(
     """
     q_idx = torch.arange(S_q, device=device, dtype=torch.int64)
     k_idx = torch.arange(S_k, device=device, dtype=torch.int64)
-    # query q can attend to compressed position k if k < ceil((q+1) / ratio)
-    # equivalently: k * ratio < q + 1, i.e., k * ratio <= q
-    valid = k_idx.unsqueeze(0) * ratio <= q_idx.unsqueeze(1)  # (S_q, S_k)
+    # Match CSA._forward_unfused exactly:
+    #   valid_count(q) = floor((q + 1) / ratio)
+    #   valid(q, k)    = k < valid_count(q)
+    valid_count = (q_idx + 1) // ratio
+    valid = k_idx.unsqueeze(0) < valid_count.unsqueeze(1)  # (S_q, S_k)
     mask = torch.where(valid, torch.zeros(1, device=device, dtype=dtype),
                        torch.full((1,), float("-inf"), device=device, dtype=dtype))
     return mask
@@ -180,9 +183,11 @@ def _compute_ratio_mask_triton(
 ):
     """Compute ratio-based causal mask in Triton.
 
-    Returns True (valid) if k_pos * ratio <= q_pos.
+    Returns True when the full source group for compressed position ``k_pos``
+    is available at query ``q_pos``.  This matches
+    ``k_pos < floor((q_pos + 1) / ratio)`` from the unfused CSA path.
     """
-    return k_pos * ratio <= q_pos
+    return (k_pos + 1) * ratio <= q_pos + 1
 
 
 @triton.jit

--- a/megatron/plugin/dsa_kernel/triton_indexer_kernels.py
+++ b/megatron/plugin/dsa_kernel/triton_indexer_kernels.py
@@ -235,7 +235,7 @@ def dense_indexer_score_recompute(
 def dense_attn_score_recompute(
     q_attn: Tensor,
     k_attn: Tensor,
-    lse: Tensor,
+    lse: "Tensor | None",
     softmax_scale: float,
     qhead_per_kv_head: int = 1,
     ratio: int = 1,
@@ -248,7 +248,12 @@ def dense_attn_score_recompute(
     Args:
         q_attn: ``(B, S_q, H_q, D)`` bf16.
         k_attn: ``(B, S_k, D)`` bf16.
-        lse:    ``(B, S_q, H_q)`` fp32.
+        lse:    ``(B, S_q, H_q)`` fp32, or ``None``.
+                When ``None``, a self-contained softmax over compressed keys is
+                used instead of ``exp(score - external_lse)``.  This matches the
+                unfused reference (``FusedDSAIndexerLoss``) where attention probs
+                are computed over compressed keys only, without window tokens in
+                the denominator.
         softmax_scale: attention scale.
         qhead_per_kv_head: MQA ratio.
         ratio: compression ratio for causal mask.
@@ -271,17 +276,26 @@ def dense_attn_score_recompute(
     for q_start in range(0, S_q, BLOCK_Q):
         q_end = min(q_start + BLOCK_Q, S_q)
         q_block = q_attn[:, q_start:q_end].float()  # (B, block, H_q, D)
-        lse_block = lse[:, q_start:q_end]  # (B, block, H_q)
         mask_block = mask[q_start:q_end]  # (block, S_k)
 
         # Compute scores: (B, block, H_q, S_k)
         scores_block = torch.einsum("bqhd,bkd->bqhk", q_block, k) * softmax_scale
 
-        # Apply ratio causal mask to scores (before exp)
+        # Apply ratio causal mask to scores (before exp/softmax)
         scores_block = scores_block + mask_block.unsqueeze(0).unsqueeze(2)
 
-        # exp(score - LSE): (B, block, H_q, S_k)
-        attn_probs_block = torch.exp(scores_block - lse_block.unsqueeze(-1))
+        if lse is not None:
+            # Use external LSE (includes window tokens in denominator)
+            lse_block = lse[:, q_start:q_end]  # (B, block, H_q)
+            attn_probs_block = torch.exp(scores_block - lse_block.unsqueeze(-1))
+        else:
+            # Self-contained softmax over compressed keys only (no window tokens)
+            attn_probs_block = torch.softmax(scores_block, dim=-1)  # (B, block, H_q, S_k)
+            # Zero out masked positions after softmax (they got -inf before softmax
+            # so they should already be ~0, but mask explicitly for safety)
+            attn_probs_block = attn_probs_block.masked_fill(
+                mask_block.unsqueeze(0).unsqueeze(2) != 0, 0.0
+            )
 
         # Sum over heads: (B, block, S_k)
         out[:, q_start:q_end] = attn_probs_block.sum(dim=2)
@@ -410,7 +424,7 @@ def sparse_indexer_backward(
     k_gathered = k_indexer.float()[batch_idx, idx_expanded]  # (B, S_q, topk, D)
 
     # Recompute forward scores
-    per_head_scores = torch.einsum("bqhd,bqtd->bqht", q, k_gathered) * indexer_softmax_scale
+    per_head_scores = torch.einsum("bqhd,bqtd->bqht", q, k_gathered)
     relu_mask = per_head_scores > 0
     per_head_scores = torch.relu(per_head_scores)  # (B, S_q, H_q, topk)
     combined = (per_head_scores * w.unsqueeze(-1)).sum(dim=2)  # (B, S_q, topk)
@@ -430,7 +444,6 @@ def sparse_indexer_backward(
 
     # Grad through ReLU
     grad_pre_relu = grad_relu_scores * relu_mask.float()  # (B, S_q, H_q, topk)
-    grad_pre_relu = grad_pre_relu * indexer_softmax_scale
 
     # Grad through Q @ K^T
     grad_q = torch.einsum("bqht,bqtd->bqhd", grad_pre_relu, k_gathered)
@@ -531,7 +544,7 @@ def dense_indexer_backward(
         grad_logits_block = grad_logits[:, q_start:q_end]  # (B, block, S_k)
 
         # Recompute per-head scores for this Q block
-        per_head_scores = torch.einsum("bqhd,bkd->bqhk", q_block, k) * indexer_softmax_scale
+        per_head_scores = torch.einsum("bqhd,bkd->bqhk", q_block, k)
         relu_mask = per_head_scores > 0
         per_head_scores_relu = torch.relu(per_head_scores)  # (B, block, H_q, S_k)
 
@@ -542,7 +555,7 @@ def dense_indexer_backward(
         grad_w[:, q_start:q_end] = (grad_logits_block.unsqueeze(2) * per_head_scores_relu).sum(dim=-1)
 
         # Grad through ReLU
-        grad_pre_relu = grad_relu * relu_mask.float() * indexer_softmax_scale  # (B, block, H_q, S_k)
+        grad_pre_relu = grad_relu * relu_mask.float()  # (B, block, H_q, S_k)
 
         # Grad through matmul
         grad_q[:, q_start:q_end] = torch.einsum("bqhk,bkd->bqhd", grad_pre_relu, k)
@@ -600,6 +613,7 @@ def fused_sparse_indexer_loss_and_backward(
     Returns:
         (indexer_loss, grad_q_indexer, grad_k_indexer, grad_weights)
     """
+
     B, S_q, H_q, D_idx = q_idx_bshd.shape
     topk = topk_indices_cmp.shape[-1]
     eps = torch.finfo(torch.float32).tiny
@@ -618,7 +632,7 @@ def fused_sparse_indexer_loss_and_backward(
     # --- Compute predict (indexer distribution) ---
     q_idx = q_idx_bshd.float()
     w = w_bsh.float()
-    per_head_scores = torch.einsum("bqhd,bqtd->bqht", q_idx, k_idx_gathered) * indexer_softmax_scale
+    per_head_scores = torch.einsum("bqhd,bqtd->bqht", q_idx, k_idx_gathered)
     relu_mask = per_head_scores > 0
     per_head_scores_relu = torch.relu(per_head_scores)  # (B, S_q, H_q, topk)
     combined = (per_head_scores_relu * w.unsqueeze(-1)).sum(dim=2)  # (B, S_q, topk)
@@ -643,9 +657,16 @@ def fused_sparse_indexer_loss_and_backward(
     loss = kl_per_row.sum() if calculate_per_token_loss else kl_per_row.mean()
     indexer_loss = loss_coeff * loss
 
-    # --- Indexer backward (grad_loss=1, will be scaled later) ---
+    # --- Indexer backward ---
+    # grad through KL + softmax: (predict - target) is d(KL)/d(logits)
     grad_combined = (predict - target)  # (B, S_q, topk)
     grad_combined = grad_combined.masked_fill(invalid_mask, 0.0)
+
+    # Apply loss_coeff and mean normalization to match unfused bwd_fused_indexer_loss_naive
+    if not calculate_per_token_loss:
+        grad_combined = grad_combined * (loss_coeff / (B * S_q))
+    else:
+        grad_combined = grad_combined * loss_coeff
 
     # grad_relu_scores[h,t] = grad_combined[t] * w[h]
     grad_relu_scores = grad_combined.unsqueeze(2) * w.unsqueeze(-1)  # (B, S_q, H_q, topk)
@@ -654,7 +675,7 @@ def fused_sparse_indexer_loss_and_backward(
     grad_w = (grad_combined.unsqueeze(2) * per_head_scores_relu).sum(dim=-1)  # (B, S_q, H_q)
 
     # Grad through ReLU
-    grad_pre_relu = grad_relu_scores * relu_mask.float() * indexer_softmax_scale
+    grad_pre_relu = grad_relu_scores * relu_mask.float()
 
     # Grad through Q @ K^T
     grad_q = torch.einsum("bqht,bqtd->bqhd", grad_pre_relu, k_idx_gathered)
@@ -687,7 +708,7 @@ def fused_dense_indexer_loss_and_backward(
     topk_indices_cmp: Tensor,
     q_attn_bshd: Tensor,
     k_attn_bsd: Tensor,
-    lse_bsh: Tensor,
+    lse_bsh: Tensor,  # noqa: ARG001 — kept for API compat; dense uses self-contained softmax
     indexer_softmax_scale: float,
     softmax_scale: float,
     loss_coeff: float,
@@ -729,7 +750,8 @@ def fused_dense_indexer_loss_and_backward(
     k_attn = k_attn_bsd.float()  # (B, S_k, D_attn)
 
     # Causal mask: which KV positions each query can attend to
-    causal_mask = compute_ratio_causal_mask(S_q, S_k, ratio, q_idx_bshd.device)  # (S_q, S_k)
+    causal_mask_float = compute_ratio_causal_mask(S_q, S_k, ratio, q_idx_bshd.device)  # (S_q, S_k)
+    causal_mask = (causal_mask_float == 0)  # bool: True = valid position
 
     # Row validity from topk_indices
     row_valid = (topk_indices_cmp >= 0).any(dim=-1)  # (B, S_q)
@@ -749,7 +771,6 @@ def fused_dense_indexer_loss_and_backward(
         q_idx_block = q_idx_bshd[:, q_start:q_end].float()  # (B, block, H_q, D_idx)
         w_block = w_bsh[:, q_start:q_end].float()  # (B, block, H_q)
         q_attn_block = q_attn_bshd[:, q_start:q_end].float()  # (B, block, np, D_attn)
-        lse_block = lse_bsh[:, q_start:q_end]  # (B, block, np)
         mask_block = causal_mask[q_start:q_end]  # (block, S_k)
         row_valid_block = row_valid[:, q_start:q_end]  # (B, block)
 
@@ -764,9 +785,14 @@ def fused_dense_indexer_loss_and_backward(
         index_score = combined  # keep for KL
 
         # --- Attention scores (target) ---
+        # For the dense path, compute self-contained softmax over compressed keys
+        # (matching unfused FusedDSAIndexerLoss which does softmax(Q@K_comp*scale+mask))
         attn_per_head = torch.einsum("bqhd,bkd->bqhk", q_attn_block, k_attn) * softmax_scale
-        # (B, block, np, S_k)
-        attn_probs = torch.exp(attn_per_head - lse_block.unsqueeze(-1))
+        # (B, block, np, S_k) — apply causal mask before softmax
+        attn_per_head = attn_per_head.masked_fill(~mask_block.unsqueeze(0).unsqueeze(2), float("-inf"))
+        # Self-contained softmax per head over S_k (no external LSE)
+        attn_probs = torch.softmax(attn_per_head, dim=-1)  # (B, block, np, S_k)
+        attn_probs = attn_probs.masked_fill(~mask_block.unsqueeze(0).unsqueeze(2), 0.0)
         attn_score = attn_probs.sum(dim=2)  # (B, block, S_k)
         attn_score = attn_score.masked_fill(~mask_block.unsqueeze(0), 0.0)
         attn_l1norm = attn_score.sum(dim=-1)  # (B, block)
@@ -795,6 +821,12 @@ def fused_dense_indexer_loss_and_backward(
         grad_logits = predict_prob - target_prob  # (B, block, S_k)
         grad_logits = grad_logits.masked_fill(~row_valid_block.unsqueeze(-1), 0.0)
 
+        # Apply loss_coeff and mean normalization (matches unfused bwd_fused_indexer_loss_naive)
+        if not calculate_per_token_loss:
+            grad_logits = grad_logits * (loss_coeff / (B * S_q))
+        else:
+            grad_logits = grad_logits * loss_coeff
+
         # grad_relu[b,q,h,k] = grad_logits[b,q,k] * W[b,q,h]
         grad_relu = grad_logits.unsqueeze(2) * w_block.unsqueeze(-1)  # (B, block, H_q, S_k)
 
@@ -802,11 +834,12 @@ def fused_dense_indexer_loss_and_backward(
         grad_w[:, q_start:q_end] = (grad_logits.unsqueeze(2) * per_head_scores_relu).sum(dim=-1)
 
         # Grad through ReLU
-        grad_pre_relu = grad_relu * relu_mask.float() * indexer_softmax_scale
+        grad_pre_relu = grad_relu * relu_mask.float()
 
-        # Grad through matmul
-        grad_q[:, q_start:q_end] = torch.einsum("bqhk,bkd->bqhd", grad_pre_relu, k_idx)
-        grad_k += torch.einsum("bqhk,bqhd->bkd", grad_pre_relu, q_idx_block)
+        # Grad through matmul: score = Q@K * scale, so d/dQ = grad * K * scale
+        grad_pre_relu_scaled = grad_pre_relu * indexer_softmax_scale
+        grad_q[:, q_start:q_end] = torch.einsum("bqhk,bkd->bqhd", grad_pre_relu_scaled, k_idx)
+        grad_k += torch.einsum("bqhk,bqhd->bkd", grad_pre_relu_scaled, q_idx_block)
 
     # Final loss
     loss = kl_acc.sum() if calculate_per_token_loss else kl_acc.mean()

--- a/megatron/plugin/dsa_kernel/triton_indexer_kernels.py
+++ b/megatron/plugin/dsa_kernel/triton_indexer_kernels.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
+# Copyright (c) 2026, FlagOS Contributors. All rights reserved.
 
 """
 Triton indexer scoring and backward kernels for DSA.

--- a/megatron/plugin/dsa_kernel/triton_indexer_kernels.py
+++ b/megatron/plugin/dsa_kernel/triton_indexer_kernels.py
@@ -574,6 +574,7 @@ def fused_sparse_indexer_loss_and_backward(
     loss_coeff: float,
     calculate_per_token_loss: bool = False,
     idx_nh: int = 1,
+    kv_offset: int = 0,
 ) -> Tuple[Tensor, Tensor, Tensor, Tensor]:
     """One-pass fused: predict + target + KL loss + indexer backward.
 
@@ -585,15 +586,16 @@ def fused_sparse_indexer_loss_and_backward(
         q_idx_bshd: ``(B, S_q, H_q, D_idx)`` bf16 — indexer queries.
         k_idx_bsd: ``(B, S_k, D_idx)`` bf16 — indexer keys.
         w_bsh: ``(B, S_q, H_q)`` bf16 — raw (unscaled) weights.
-        topk_indices_cmp: ``(B, S_q, topk)`` int32.
+        topk_indices_cmp: ``(B, S_q, topk)`` int32 — indices into [0, n_comp).
         q_attn_bshd: ``(B, S_q, np, D_attn)`` bf16 — attention queries.
-        k_attn_bsd: ``(B, S_k, D_attn)`` bf16 — attention keys.
+        k_attn_bsd: ``(B, S_kv, D_attn)`` bf16 — attention keys (full KV buffer).
         lse_bsh: ``(B, S_q, np)`` fp32 — LSE from attention forward.
         indexer_softmax_scale: scale for indexer scores.
         softmax_scale: scale for attention scores.
         loss_coeff: KL loss coefficient.
         calculate_per_token_loss: if True, use sum instead of mean.
         idx_nh: number of indexer heads (qhead_per_kv_head).
+        kv_offset: offset into k_attn_bsd where compressed KV starts.
 
     Returns:
         (indexer_loss, grad_q_indexer, grad_k_indexer, grad_weights)
@@ -602,11 +604,14 @@ def fused_sparse_indexer_loss_and_backward(
     topk = topk_indices_cmp.shape[-1]
     eps = torch.finfo(torch.float32).tiny
 
-    # --- Single gather (shared between indexer and attn) ---
+    # --- Gather indexer keys (0-based into k_idx_bsd of shape (B, n_comp, D_idx)) ---
     idx_expanded = topk_indices_cmp.long().clamp(min=0)  # (B, S_q, topk)
     batch_idx = torch.arange(B, device=k_idx_bsd.device)[:, None, None]  # (B, 1, 1)
     k_idx_gathered = k_idx_bsd.float()[batch_idx, idx_expanded]  # (B, S_q, topk, D_idx)
-    k_attn_gathered = k_attn_bsd.float()[batch_idx, idx_expanded]  # (B, S_q, topk, D_attn)
+
+    # --- Gather attention keys (offset-based into full KV buffer) ---
+    idx_attn_expanded = (topk_indices_cmp.long() + kv_offset).clamp(min=0)  # (B, S_q, topk)
+    k_attn_gathered = k_attn_bsd.float()[batch_idx, idx_attn_expanded]  # (B, S_q, topk, D_attn)
 
     invalid_mask = topk_indices_cmp == -1  # (B, S_q, topk)
 

--- a/megatron/plugin/dsa_kernel/triton_indexer_kernels.py
+++ b/megatron/plugin/dsa_kernel/triton_indexer_kernels.py
@@ -1,0 +1,815 @@
+# Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
+
+"""
+Triton indexer scoring and backward kernels for DSA.
+
+Replaces the dependency on ``cudnn.DSA`` indexer-related wrappers:
+- sparse_indexer_score_recompute_wrapper
+- sparse_attn_score_recompute_wrapper
+- dense_indexer_score_recompute_wrapper
+- dense_attn_score_recompute_wrapper
+- sparse_indexer_backward
+- dense_indexer_backward
+
+Also provides the indexer top-K selection (replacing TRT-LLM radix top-K).
+
+Optimized to avoid materializing O(S_q × S_k) intermediates where possible:
+- Sparse functions use direct batch advanced indexing instead of expand+gather.
+- Dense functions tile over the Q dimension in blocks of _DENSE_BLOCK_Q.
+- Sparse backward uses vectorized scatter_add_ instead of a Python for-loop.
+"""
+
+from __future__ import annotations
+
+from typing import Dict, Optional, Tuple
+
+import torch
+from torch import Tensor
+
+import triton
+import triton.language as tl
+
+from megatron.plugin.dsa_kernel.triton_dsa_utils import (
+    compute_ratio_causal_mask,
+    topk_with_causal_mask,
+)
+
+
+# Block size for dense Q-tiling. Trades peak memory for kernel-launch overhead.
+# 64 is a good default; lower to 32 if D >= 512 and GPU memory is very tight.
+_DENSE_BLOCK_Q = 512
+
+
+# ---------------------------------------------------------------------------
+# Sparse indexer score: compute ``predict`` distribution
+# ---------------------------------------------------------------------------
+
+
+def sparse_indexer_score_recompute(
+    q_indexer: Tensor,
+    k_indexer: Tensor,
+    weights: Tensor,
+    topk_indices: Tensor,
+    qhead_per_kv_head: int = 1,
+) -> Dict[str, Tensor]:
+    """Compute ``predict`` distribution (softmax over top-K of indexer scores).
+
+    Pure PyTorch implementation matching cudnn.DSA.sparse_indexer_score_recompute_wrapper.
+
+    Args:
+        q_indexer: ``(B, S_q, H_q, D)`` bf16.
+        k_indexer: ``(B, S_k, D)`` bf16.
+        weights:   ``(B, S_q, H_q)`` bf16.
+        topk_indices: ``(B, S_q, topk)`` int32.
+        qhead_per_kv_head: number of Q heads per KV head (MQA ratio).
+
+    Returns:
+        dict with "predict": ``(B, S_q, topk)`` fp32 softmax distribution.
+    """
+    B, S_q, H_q, D = q_indexer.shape
+    topk = topk_indices.shape[-1]
+
+    q = q_indexer.float()  # (B, S_q, H_q, D)
+    w = weights.float()  # (B, S_q, H_q)
+
+    # Gather K at topk positions using batch advanced indexing — O(B*S_q*topk*D)
+    # No S_q×S_k expansion needed.
+    idx_expanded = topk_indices.long().clamp(min=0)  # (B, S_q, topk)
+    batch_idx = torch.arange(B, device=k_indexer.device)[:, None, None]  # (B, 1, 1)
+    k_gathered = k_indexer.float()[batch_idx, idx_expanded]  # (B, S_q, topk, D)
+
+    # Compute scores: (B, S_q, H_q, topk) = Q @ K^T
+    scores = torch.einsum("bqhd,bqtd->bqht", q, k_gathered)  # (B, S_q, H_q, topk)
+
+    # ReLU activation
+    scores = torch.relu(scores)
+
+    # Weight by per-head weights: (B, S_q, H_q, topk) * (B, S_q, H_q, 1)
+    weighted_scores = scores * w.unsqueeze(-1)
+
+    # Sum over heads: (B, S_q, topk)
+    combined_scores = weighted_scores.sum(dim=2)
+
+    # Mask invalid positions (topk_indices == -1)
+    invalid_mask = topk_indices == -1  # (B, S_q, topk)
+    combined_scores = combined_scores.masked_fill(invalid_mask, float("-inf"))
+
+    # Softmax over topk dimension -> predict
+    predict = torch.softmax(combined_scores, dim=-1)
+    # Zero out invalid positions (softmax of all -inf gives nan -> 0)
+    predict = predict.masked_fill(invalid_mask, 0.0)
+
+    return {"predict": predict}
+
+
+# ---------------------------------------------------------------------------
+# Sparse attention score recompute: compute ``target`` distribution
+# ---------------------------------------------------------------------------
+
+
+def sparse_attn_score_recompute(
+    q_attn: Tensor,
+    k_attn: Tensor,
+    lse: Tensor,
+    topk_indices: Tensor,
+    softmax_scale: float,
+    qhead_per_kv_head: int = 1,
+) -> Dict[str, Tensor]:
+    """Compute ``target`` distribution (L1-normalised head-sum softmax).
+
+    Pure PyTorch implementation matching cudnn.DSA.sparse_attn_score_recompute_wrapper.
+
+    Args:
+        q_attn: ``(B, S_q, H_q, D)`` bf16.
+        k_attn: ``(B, S_k, D)`` bf16.
+        lse:    ``(B, S_q, H_q)`` fp32 — log-sum-exp from attention forward.
+        topk_indices: ``(B, S_q, topk)`` int32.
+        softmax_scale: attention scale factor.
+        qhead_per_kv_head: MQA ratio.
+
+    Returns:
+        dict with "target": ``(B, S_q, topk)`` fp32 L1-normalized distribution.
+    """
+    B, S_q, H_q, D = q_attn.shape
+    topk = topk_indices.shape[-1]
+
+    q = q_attn.float()  # (B, S_q, H_q, D)
+
+    # Gather K at topk positions — O(B*S_q*topk*D), no S_k expansion
+    idx_expanded = topk_indices.long().clamp(min=0)  # (B, S_q, topk)
+    batch_idx = torch.arange(B, device=k_attn.device)[:, None, None]  # (B, 1, 1)
+    k_gathered = k_attn.float()[batch_idx, idx_expanded]  # (B, S_q, topk, D)
+
+    # Compute attention scores: (B, S_q, H_q, topk)
+    scores = torch.einsum("bqhd,bqtd->bqht", q, k_gathered) * softmax_scale
+
+    # Subtract LSE and exp: exp(score - lse) per head
+    # lse: (B, S_q, H_q) -> (B, S_q, H_q, 1)
+    attn_probs = torch.exp(scores - lse.unsqueeze(-1))  # (B, S_q, H_q, topk)
+
+    # Sum over heads: (B, S_q, topk)
+    head_sum = attn_probs.sum(dim=2)
+
+    # Mask invalid
+    invalid_mask = topk_indices == -1
+    head_sum = head_sum.masked_fill(invalid_mask, 0.0)
+
+    # L1 normalize over topk dimension
+    denom = head_sum.sum(dim=-1, keepdim=True).clamp(min=1e-12)
+    target = head_sum / denom
+
+    return {"target": target}
+
+
+# ---------------------------------------------------------------------------
+# Dense indexer score: full S_k scoring — tiled over Q blocks
+# ---------------------------------------------------------------------------
+
+
+def dense_indexer_score_recompute(
+    q_indexer: Tensor,
+    k_indexer: Tensor,
+    weights: Tensor,
+    qhead_per_kv_head: int = 1,
+    sm_scale: float = 1.0,
+    ratio: int = 1,
+) -> Dict[str, Tensor]:
+    """Dense indexer score forward over the full S_k axis.
+
+    Pure PyTorch implementation matching cudnn.DSA.dense_indexer_score_recompute_wrapper.
+    Tiles over the Q dimension to avoid materializing (B, S_q, H_q, S_k) at once.
+
+    Args:
+        q_indexer: ``(B, S_q, H_q, D)`` bf16.
+        k_indexer: ``(B, S_k, D)`` bf16.
+        weights:   ``(B, S_q, H_q)`` bf16.
+        qhead_per_kv_head: MQA ratio.
+        sm_scale: indexer softmax scale.
+        ratio: compression ratio for causal mask.
+
+    Returns:
+        dict with "out": ``(B, S_q, S_k)`` fp32 and "denom": ``(B, S_q)`` fp32.
+    """
+    B, S_q, H_q, D = q_indexer.shape
+    S_k = k_indexer.shape[1]
+
+    k = k_indexer.float()  # (B, S_k, D)
+
+    # Pre-compute ratio causal mask (only S_q × S_k, typically small fp32)
+    mask = compute_ratio_causal_mask(S_q, S_k, ratio, q_indexer.device)  # (S_q, S_k)
+
+    # Output buffer
+    out = torch.empty(B, S_q, S_k, dtype=torch.float32, device=q_indexer.device)
+
+    BLOCK_Q = _DENSE_BLOCK_Q
+    for q_start in range(0, S_q, BLOCK_Q):
+        q_end = min(q_start + BLOCK_Q, S_q)
+        q_block = q_indexer[:, q_start:q_end].float()  # (B, block, H_q, D)
+        w_block = weights[:, q_start:q_end].float()  # (B, block, H_q)
+
+        # Compute scores: (B, block, H_q, S_k)
+        scores_block = torch.einsum("bqhd,bkd->bqhk", q_block, k) * sm_scale
+
+        # ReLU
+        scores_block = torch.relu(scores_block)
+
+        # Weight and sum over heads: (B, block, S_k)
+        out_block = (scores_block * w_block.unsqueeze(-1)).sum(dim=2)
+
+        # Apply ratio causal mask
+        out_block = out_block + mask[q_start:q_end].unsqueeze(0)
+
+        out[:, q_start:q_end] = out_block
+
+    # Compute LSE (denom)
+    denom = torch.logsumexp(out, dim=-1)  # (B, S_q)
+
+    return {"out": out, "denom": denom}
+
+
+# ---------------------------------------------------------------------------
+# Dense attention score: full S_k scoring — tiled over Q blocks
+# ---------------------------------------------------------------------------
+
+
+def dense_attn_score_recompute(
+    q_attn: Tensor,
+    k_attn: Tensor,
+    lse: Tensor,
+    softmax_scale: float,
+    qhead_per_kv_head: int = 1,
+    ratio: int = 1,
+) -> Dict[str, Tensor]:
+    """Dense attention score forward over the full S_k axis.
+
+    Pure PyTorch implementation matching cudnn.DSA.dense_attn_score_recompute_wrapper.
+    Tiles over the Q dimension to avoid materializing (B, S_q, H_q, S_k) at once.
+
+    Args:
+        q_attn: ``(B, S_q, H_q, D)`` bf16.
+        k_attn: ``(B, S_k, D)`` bf16.
+        lse:    ``(B, S_q, H_q)`` fp32.
+        softmax_scale: attention scale.
+        qhead_per_kv_head: MQA ratio.
+        ratio: compression ratio for causal mask.
+
+    Returns:
+        dict with "out": ``(B, S_q, S_k)`` fp32 and "denom": ``(B, S_q)`` fp32.
+    """
+    B, S_q, H_q, D = q_attn.shape
+    S_k = k_attn.shape[1]
+
+    k = k_attn.float()  # (B, S_k, D)
+
+    # Pre-compute ratio causal mask
+    mask = compute_ratio_causal_mask(S_q, S_k, ratio, q_attn.device)  # (S_q, S_k)
+
+    # Output buffer
+    out = torch.empty(B, S_q, S_k, dtype=torch.float32, device=q_attn.device)
+
+    BLOCK_Q = _DENSE_BLOCK_Q
+    for q_start in range(0, S_q, BLOCK_Q):
+        q_end = min(q_start + BLOCK_Q, S_q)
+        q_block = q_attn[:, q_start:q_end].float()  # (B, block, H_q, D)
+        lse_block = lse[:, q_start:q_end]  # (B, block, H_q)
+        mask_block = mask[q_start:q_end]  # (block, S_k)
+
+        # Compute scores: (B, block, H_q, S_k)
+        scores_block = torch.einsum("bqhd,bkd->bqhk", q_block, k) * softmax_scale
+
+        # Apply ratio causal mask to scores (before exp)
+        scores_block = scores_block + mask_block.unsqueeze(0).unsqueeze(2)
+
+        # exp(score - LSE): (B, block, H_q, S_k)
+        attn_probs_block = torch.exp(scores_block - lse_block.unsqueeze(-1))
+
+        # Sum over heads: (B, block, S_k)
+        out[:, q_start:q_end] = attn_probs_block.sum(dim=2)
+
+    # L1 norm denom
+    denom = out.sum(dim=-1)  # (B, S_q)
+
+    return {"out": out, "denom": denom}
+
+
+# ---------------------------------------------------------------------------
+# Indexer top-K selection — tiled over Q blocks
+# ---------------------------------------------------------------------------
+
+
+def indexer_topk_selection(
+    q_indexer: Tensor,
+    k_indexer: Tensor,
+    weights: Tensor,
+    topk: int,
+    ratio: int,
+    indexer_softmax_scale: float = 1.0,
+) -> Dict[str, Tensor]:
+    """Compute indexer scores and select top-K with ratio causal masking.
+
+    Replaces TRT-LLM's radix top-K kernel.
+    Tiles over the Q dimension to avoid materializing (B, S_q, H_q, S_k) at once.
+
+    Args:
+        q_indexer: ``(B, S_q, H_q, D)`` bf16.
+        k_indexer: ``(B, S_k, D)`` bf16.
+        weights:   ``(B, S_q, H_q)`` bf16 — scaled weights.
+        topk: number of top-K indices.
+        ratio: compression ratio for causal mask.
+        indexer_softmax_scale: scale for indexer scores.
+
+    Returns:
+        dict with:
+            "topk_indices": ``(B, S_q, topk)`` int32.
+            "topk_length": ``(B, S_q)`` int32.
+            "full_scores": ``(B, S_q, S_k)`` fp32 — full indexer scores (for backward).
+    """
+    B, S_q, H_q, D = q_indexer.shape
+    S_k = k_indexer.shape[1]
+
+    k = k_indexer.float()  # (B, S_k, D)
+
+    # Output buffer for full scores
+    scores = torch.empty(B, S_q, S_k, dtype=torch.float32, device=q_indexer.device)
+
+    BLOCK_Q = _DENSE_BLOCK_Q
+    for q_start in range(0, S_q, BLOCK_Q):
+        q_end = min(q_start + BLOCK_Q, S_q)
+        q_block = q_indexer[:, q_start:q_end].float()  # (B, block, H_q, D)
+        w_block = weights[:, q_start:q_end].float()  # (B, block, H_q)
+
+        # Compute per-head scores: (B, block, H_q, S_k)
+        per_head_block = torch.einsum("bqhd,bkd->bqhk", q_block, k) * indexer_softmax_scale
+        per_head_block = torch.relu(per_head_block)
+
+        # Weight and sum over heads: (B, block, S_k)
+        scores[:, q_start:q_end] = (per_head_block * w_block.unsqueeze(-1)).sum(dim=2)
+
+    # Top-K with causal mask (operates on the full (B, S_q, S_k) scores)
+    topk_indices, topk_length = topk_with_causal_mask(scores, topk, ratio)
+
+    return {"topk_indices": topk_indices, "topk_length": topk_length, "full_scores": scores}
+
+
+# Keep the old name as an alias for backward compatibility with imports
+indexer_topk_select = indexer_topk_selection
+
+
+# ---------------------------------------------------------------------------
+# Indexer backward — sparse path
+# ---------------------------------------------------------------------------
+
+
+def sparse_indexer_backward(
+    grad_loss: Tensor,
+    q_indexer: Tensor,
+    k_indexer: Tensor,
+    weights: Tensor,
+    topk_indices: Tensor,
+    predict: Tensor,
+    target: Tensor,
+    qhead_per_kv_head: int = 1,
+    indexer_softmax_scale: float = 1.0,
+) -> Tuple[Tensor, Tensor, Tensor]:
+    """Backward through the sparse indexer path.
+
+    Computes gradients w.r.t. q_indexer, k_indexer, and weights given the KL loss.
+
+    The forward computes:
+        scores[h,t] = ReLU(Q[h] · K[t]^T) * scale
+        combined[t] = sum_h(scores[h,t] * W[h])
+        predict[t] = softmax(combined)[t]
+        loss = KL(target || predict)
+
+    Uses batch advanced indexing for gather (no S_k expansion) and vectorized
+    scatter_add_ (no Python for-loop over S_q).
+
+    Args:
+        grad_loss: scalar gradient from loss.
+        q_indexer: ``(B, S_q, H_q, D)`` bf16.
+        k_indexer: ``(B, S_k, D)`` bf16.
+        weights: ``(B, S_q, H_q)`` bf16.
+        topk_indices: ``(B, S_q, topk)`` int32.
+        predict: ``(B, S_q, topk)`` fp32.
+        target: ``(B, S_q, topk)`` fp32.
+        qhead_per_kv_head: MQA ratio.
+        indexer_softmax_scale: scale factor.
+
+    Returns:
+        (grad_q_indexer, grad_k_indexer, grad_weights)
+    """
+    B, S_q, H_q, D = q_indexer.shape
+    topk = topk_indices.shape[-1]
+
+    q = q_indexer.float()
+    w = weights.float()
+
+    # Gather K at topk positions — batch advanced indexing, no S_k expansion
+    idx_expanded = topk_indices.long().clamp(min=0)  # (B, S_q, topk)
+    batch_idx = torch.arange(B, device=k_indexer.device)[:, None, None]
+    k_gathered = k_indexer.float()[batch_idx, idx_expanded]  # (B, S_q, topk, D)
+
+    # Recompute forward scores
+    per_head_scores = torch.einsum("bqhd,bqtd->bqht", q, k_gathered) * indexer_softmax_scale
+    relu_mask = per_head_scores > 0
+    per_head_scores = torch.relu(per_head_scores)  # (B, S_q, H_q, topk)
+    combined = (per_head_scores * w.unsqueeze(-1)).sum(dim=2)  # (B, S_q, topk)
+
+    # Grad through KL + softmax: d_loss/d_combined
+    invalid_mask = topk_indices == -1
+    grad_combined = (predict - target) * grad_loss  # (B, S_q, topk)
+    grad_combined = grad_combined.masked_fill(invalid_mask, 0.0)
+
+    # Grad through head-sum + weight multiply
+    # combined[t] = sum_h(relu_score[h,t] * w[h])
+    # grad_relu_score[h,t] = grad_combined[t] * w[h]
+    grad_relu_scores = grad_combined.unsqueeze(2) * w.unsqueeze(-1)  # (B, S_q, H_q, topk)
+
+    # grad_weights[h] = sum_t(grad_combined[t] * relu_score[h,t])
+    grad_w = (grad_combined.unsqueeze(2) * per_head_scores).sum(dim=-1)  # (B, S_q, H_q)
+
+    # Grad through ReLU
+    grad_pre_relu = grad_relu_scores * relu_mask.float()  # (B, S_q, H_q, topk)
+    grad_pre_relu = grad_pre_relu * indexer_softmax_scale
+
+    # Grad through Q @ K^T
+    grad_q = torch.einsum("bqht,bqtd->bqhd", grad_pre_relu, k_gathered)
+
+    # grad_k_gathered = grad_pre_relu^T @ q: (B, S_q, topk, D)
+    grad_k_gathered = torch.einsum("bqht,bqhd->bqtd", grad_pre_relu, q)
+
+    # Scatter grad_k_gathered back to full k_indexer — vectorized, no Python loop
+    grad_k = torch.zeros_like(k_indexer, dtype=torch.float32)  # (B, S_k, D)
+    # Flatten S_q and topk dims for a single scatter_add_ call
+    flat_idx = idx_expanded.reshape(B, S_q * topk, 1).expand(-1, -1, D)  # (B, S_q*topk, D)
+    flat_grad = grad_k_gathered.reshape(B, S_q * topk, D)  # (B, S_q*topk, D)
+    grad_k.scatter_add_(1, flat_idx, flat_grad)
+
+    return (
+        grad_q.to(q_indexer.dtype),
+        grad_k.to(k_indexer.dtype),
+        grad_w.to(weights.dtype),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Indexer backward — dense path (tiled over Q blocks)
+# ---------------------------------------------------------------------------
+
+
+def dense_indexer_backward(
+    grad_loss: Tensor,
+    q_indexer: Tensor,
+    k_indexer: Tensor,
+    weights: Tensor,
+    indexer_out: Tensor,
+    indexer_denom: Tensor,
+    attn_out: Tensor,
+    attn_denom: Tensor,
+    qhead_per_kv_head: int = 1,
+    indexer_softmax_scale: float = 1.0,
+    ratio: int = 1,
+    calculate_per_token_loss: bool = False,
+) -> Tuple[Tensor, Tensor, Tensor]:
+    """Backward through the dense indexer loss path.
+
+    Tiles over S_q to avoid materializing (B, S_q, H_q, S_k) per-head scores.
+
+    The dense path computes KL(target || predict) over all S_k positions where:
+        predict = softmax(indexer_out)  [over S_k]
+        target = attn_out / attn_denom  [L1 normalized]
+
+    Args:
+        grad_loss: scalar gradient.
+        q_indexer: ``(B, S_q, H_q, D)`` bf16.
+        k_indexer: ``(B, S_k, D)`` bf16.
+        weights: ``(B, S_q, H_q)`` bf16.
+        indexer_out: ``(B, S_q, S_k)`` fp32 — raw indexer scores.
+        indexer_denom: ``(B, S_q)`` fp32 — LSE of indexer_out.
+        attn_out: ``(B, S_q, S_k)`` fp32 — head-summed attention weights.
+        attn_denom: ``(B, S_q)`` fp32 — L1 norm of attn_out.
+        qhead_per_kv_head: MQA ratio.
+        indexer_softmax_scale: scale factor.
+        ratio: compression ratio.
+        calculate_per_token_loss: whether loss is per-token sum or mean.
+
+    Returns:
+        (grad_q_indexer, grad_k_indexer, grad_weights)
+    """
+    B, S_q, H_q, D = q_indexer.shape
+    S_k = k_indexer.shape[1]
+
+    # Recompute predict and target (these are (B, S_q, S_k) — already stored)
+    predict = torch.softmax(indexer_out, dim=-1)  # (B, S_q, S_k)
+    safe_denom = attn_denom.clamp(min=1e-12).unsqueeze(-1)
+    target = attn_out / safe_denom  # (B, S_q, S_k)
+
+    # Grad through KL: d_KL/d_indexer_logit = (predict - target) * grad_loss
+    mask = compute_ratio_causal_mask(S_q, S_k, ratio, q_indexer.device)
+    valid = mask.unsqueeze(0) == 0  # (1, S_q, S_k)
+
+    grad_logits = (predict - target) * grad_loss  # (B, S_q, S_k)
+    grad_logits = grad_logits.masked_fill(~valid, 0.0)
+
+    if not calculate_per_token_loss:
+        grad_logits = grad_logits / (B * S_q)
+
+    # Backward through indexer score computation — tiled over Q blocks
+    # indexer_out[b, q, k] = sum_h(ReLU(Q[b,q,h] · K[b,k]^T * scale) * W[b,q,h])
+    k = k_indexer.float()  # (B, S_k, D)
+
+    grad_q = torch.empty(B, S_q, H_q, D, dtype=torch.float32, device=q_indexer.device)
+    grad_k = torch.zeros(B, S_k, D, dtype=torch.float32, device=k_indexer.device)
+    grad_w = torch.empty(B, S_q, H_q, dtype=torch.float32, device=weights.device)
+
+    BLOCK_Q = _DENSE_BLOCK_Q
+    for q_start in range(0, S_q, BLOCK_Q):
+        q_end = min(q_start + BLOCK_Q, S_q)
+
+        q_block = q_indexer[:, q_start:q_end].float()  # (B, block, H_q, D)
+        w_block = weights[:, q_start:q_end].float()  # (B, block, H_q)
+        grad_logits_block = grad_logits[:, q_start:q_end]  # (B, block, S_k)
+
+        # Recompute per-head scores for this Q block
+        per_head_scores = torch.einsum("bqhd,bkd->bqhk", q_block, k) * indexer_softmax_scale
+        relu_mask = per_head_scores > 0
+        per_head_scores_relu = torch.relu(per_head_scores)  # (B, block, H_q, S_k)
+
+        # grad_relu[b,q,h,k] = grad_logits[b,q,k] * W[b,q,h]
+        grad_relu = grad_logits_block.unsqueeze(2) * w_block.unsqueeze(-1)  # (B, block, H_q, S_k)
+
+        # grad_weights[b,q,h] = sum_k(grad_logits[b,q,k] * relu_score[b,q,h,k])
+        grad_w[:, q_start:q_end] = (grad_logits_block.unsqueeze(2) * per_head_scores_relu).sum(dim=-1)
+
+        # Grad through ReLU
+        grad_pre_relu = grad_relu * relu_mask.float() * indexer_softmax_scale  # (B, block, H_q, S_k)
+
+        # Grad through matmul
+        grad_q[:, q_start:q_end] = torch.einsum("bqhk,bkd->bqhd", grad_pre_relu, k)
+        # Accumulate grad_k from this block
+        grad_k += torch.einsum("bqhk,bqhd->bkd", grad_pre_relu, q_block)
+
+    return (
+        grad_q.to(q_indexer.dtype),
+        grad_k.to(k_indexer.dtype),
+        grad_w.to(weights.dtype),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Fused sparse indexer loss + backward (P0 optimization)
+# ---------------------------------------------------------------------------
+
+
+def fused_sparse_indexer_loss_and_backward(
+    q_idx_bshd: Tensor,
+    k_idx_bsd: Tensor,
+    w_bsh: Tensor,
+    topk_indices_cmp: Tensor,
+    q_attn_bshd: Tensor,
+    k_attn_bsd: Tensor,
+    lse_bsh: Tensor,
+    indexer_softmax_scale: float,
+    softmax_scale: float,
+    loss_coeff: float,
+    calculate_per_token_loss: bool = False,
+    idx_nh: int = 1,
+) -> Tuple[Tensor, Tensor, Tensor, Tensor]:
+    """One-pass fused: predict + target + KL loss + indexer backward.
+
+    Merges ``sparse_indexer_score_recompute`` + ``sparse_attn_score_recompute`` +
+    ``_kl_loss_from_target_predict`` + ``sparse_indexer_backward`` into a single
+    pass, sharing the K gather and intermediate computations.
+
+    Args:
+        q_idx_bshd: ``(B, S_q, H_q, D_idx)`` bf16 — indexer queries.
+        k_idx_bsd: ``(B, S_k, D_idx)`` bf16 — indexer keys.
+        w_bsh: ``(B, S_q, H_q)`` bf16 — raw (unscaled) weights.
+        topk_indices_cmp: ``(B, S_q, topk)`` int32.
+        q_attn_bshd: ``(B, S_q, np, D_attn)`` bf16 — attention queries.
+        k_attn_bsd: ``(B, S_k, D_attn)`` bf16 — attention keys.
+        lse_bsh: ``(B, S_q, np)`` fp32 — LSE from attention forward.
+        indexer_softmax_scale: scale for indexer scores.
+        softmax_scale: scale for attention scores.
+        loss_coeff: KL loss coefficient.
+        calculate_per_token_loss: if True, use sum instead of mean.
+        idx_nh: number of indexer heads (qhead_per_kv_head).
+
+    Returns:
+        (indexer_loss, grad_q_indexer, grad_k_indexer, grad_weights)
+    """
+    B, S_q, H_q, D_idx = q_idx_bshd.shape
+    topk = topk_indices_cmp.shape[-1]
+    eps = torch.finfo(torch.float32).tiny
+
+    # --- Single gather (shared between indexer and attn) ---
+    idx_expanded = topk_indices_cmp.long().clamp(min=0)  # (B, S_q, topk)
+    batch_idx = torch.arange(B, device=k_idx_bsd.device)[:, None, None]  # (B, 1, 1)
+    k_idx_gathered = k_idx_bsd.float()[batch_idx, idx_expanded]  # (B, S_q, topk, D_idx)
+    k_attn_gathered = k_attn_bsd.float()[batch_idx, idx_expanded]  # (B, S_q, topk, D_attn)
+
+    invalid_mask = topk_indices_cmp == -1  # (B, S_q, topk)
+
+    # --- Compute predict (indexer distribution) ---
+    q_idx = q_idx_bshd.float()
+    w = w_bsh.float()
+    per_head_scores = torch.einsum("bqhd,bqtd->bqht", q_idx, k_idx_gathered) * indexer_softmax_scale
+    relu_mask = per_head_scores > 0
+    per_head_scores_relu = torch.relu(per_head_scores)  # (B, S_q, H_q, topk)
+    combined = (per_head_scores_relu * w.unsqueeze(-1)).sum(dim=2)  # (B, S_q, topk)
+    combined = combined.masked_fill(invalid_mask, float("-inf"))
+    predict = torch.softmax(combined, dim=-1).masked_fill(invalid_mask, 0.0)
+
+    # --- Compute target (attention distribution) ---
+    q_attn = q_attn_bshd.float()
+    attn_scores = torch.einsum("bqhd,bqtd->bqht", q_attn, k_attn_gathered) * softmax_scale
+    attn_probs = torch.exp(attn_scores - lse_bsh.unsqueeze(-1))  # (B, S_q, np, topk)
+    head_sum = attn_probs.sum(dim=2)  # (B, S_q, topk)
+    head_sum = head_sum.masked_fill(invalid_mask, 0.0)
+    denom = head_sum.sum(dim=-1, keepdim=True).clamp(min=1e-12)
+    target = head_sum / denom  # (B, S_q, topk)
+
+    # --- KL loss ---
+    t = target.clamp(min=eps)
+    p = predict.clamp(min=eps)
+    kl_per_row = (t * (torch.log(t) - torch.log(p))).sum(dim=-1)  # (B, S_q)
+    row_valid = (~invalid_mask).any(dim=-1)  # (B, S_q)
+    kl_per_row = torch.where(row_valid, kl_per_row, torch.zeros_like(kl_per_row))
+    loss = kl_per_row.sum() if calculate_per_token_loss else kl_per_row.mean()
+    indexer_loss = loss_coeff * loss
+
+    # --- Indexer backward (grad_loss=1, will be scaled later) ---
+    grad_combined = (predict - target)  # (B, S_q, topk)
+    grad_combined = grad_combined.masked_fill(invalid_mask, 0.0)
+
+    # grad_relu_scores[h,t] = grad_combined[t] * w[h]
+    grad_relu_scores = grad_combined.unsqueeze(2) * w.unsqueeze(-1)  # (B, S_q, H_q, topk)
+
+    # grad_weights[h] = sum_t(grad_combined[t] * relu_score[h,t])
+    grad_w = (grad_combined.unsqueeze(2) * per_head_scores_relu).sum(dim=-1)  # (B, S_q, H_q)
+
+    # Grad through ReLU
+    grad_pre_relu = grad_relu_scores * relu_mask.float() * indexer_softmax_scale
+
+    # Grad through Q @ K^T
+    grad_q = torch.einsum("bqht,bqtd->bqhd", grad_pre_relu, k_idx_gathered)
+    grad_k_gathered = torch.einsum("bqht,bqhd->bqtd", grad_pre_relu, q_idx)
+
+    # Scatter grad_k_gathered back to full k_indexer
+    S_k = k_idx_bsd.shape[1]
+    grad_k = torch.zeros(B, S_k, D_idx, dtype=torch.float32, device=k_idx_bsd.device)
+    flat_idx = idx_expanded.reshape(B, S_q * topk, 1).expand(-1, -1, D_idx)
+    flat_grad = grad_k_gathered.reshape(B, S_q * topk, D_idx)
+    grad_k.scatter_add_(1, flat_idx, flat_grad)
+
+    return (
+        indexer_loss,
+        grad_q.to(q_idx_bshd.dtype),
+        grad_k.to(k_idx_bsd.dtype),
+        grad_w.to(w_bsh.dtype),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Fused dense indexer loss + backward (P0 optimization)
+# ---------------------------------------------------------------------------
+
+
+def fused_dense_indexer_loss_and_backward(
+    q_idx_bshd: Tensor,
+    k_idx_bsd: Tensor,
+    w_bsh: Tensor,
+    topk_indices_cmp: Tensor,
+    q_attn_bshd: Tensor,
+    k_attn_bsd: Tensor,
+    lse_bsh: Tensor,
+    indexer_softmax_scale: float,
+    softmax_scale: float,
+    loss_coeff: float,
+    ratio: int = 1,
+    calculate_per_token_loss: bool = False,
+    idx_nh: int = 1,
+) -> Tuple[Tensor, Tensor, Tensor, Tensor]:
+    """One-pass fused dense: indexer score + attn score + KL loss + backward.
+
+    Merges ``dense_indexer_score_recompute`` + ``dense_attn_score_recompute`` +
+    ``_kl_loss_from_dense_scores`` + ``dense_indexer_backward`` into a single
+    tiled pass over Q blocks.
+
+    Args:
+        q_idx_bshd: ``(B, S_q, H_q, D_idx)`` bf16 — indexer queries.
+        k_idx_bsd: ``(B, S_k, D_idx)`` bf16 — indexer keys (compressed range).
+        w_bsh: ``(B, S_q, H_q)`` bf16 — raw weights.
+        topk_indices_cmp: ``(B, S_q, topk)`` int32 — for row validity.
+        q_attn_bshd: ``(B, S_q, np, D_attn)`` bf16 — attention queries.
+        k_attn_bsd: ``(B, S_k, D_attn)`` bf16 — attention keys (compressed range).
+        lse_bsh: ``(B, S_q, np)`` fp32 — LSE from attention forward.
+        indexer_softmax_scale: scale for indexer scores.
+        softmax_scale: scale for attention scores.
+        loss_coeff: KL loss coefficient.
+        ratio: compression ratio for causal mask.
+        calculate_per_token_loss: if True, use sum instead of mean.
+        idx_nh: number of indexer heads.
+
+    Returns:
+        (indexer_loss, grad_q_indexer, grad_k_indexer, grad_weights)
+    """
+    B, S_q, H_q, D_idx = q_idx_bshd.shape
+    S_k = k_idx_bsd.shape[1]
+    np_ = q_attn_bshd.shape[2]
+    D_attn = q_attn_bshd.shape[3]
+    eps = torch.finfo(torch.float32).tiny
+
+    k_idx = k_idx_bsd.float()  # (B, S_k, D_idx)
+    k_attn = k_attn_bsd.float()  # (B, S_k, D_attn)
+
+    # Causal mask: which KV positions each query can attend to
+    causal_mask = compute_ratio_causal_mask(S_q, S_k, ratio, q_idx_bshd.device)  # (S_q, S_k)
+
+    # Row validity from topk_indices
+    row_valid = (topk_indices_cmp >= 0).any(dim=-1)  # (B, S_q)
+
+    # Accumulators
+    grad_q = torch.empty(B, S_q, H_q, D_idx, dtype=torch.float32, device=q_idx_bshd.device)
+    grad_k = torch.zeros(B, S_k, D_idx, dtype=torch.float32, device=k_idx_bsd.device)
+    grad_w = torch.empty(B, S_q, H_q, dtype=torch.float32, device=w_bsh.device)
+    kl_acc = torch.zeros(B, S_q, dtype=torch.float32, device=q_idx_bshd.device)
+
+    BLOCK_Q = _DENSE_BLOCK_Q
+    for q_start in range(0, S_q, BLOCK_Q):
+        q_end = min(q_start + BLOCK_Q, S_q)
+        block_len = q_end - q_start
+
+        # Slice inputs for this Q block
+        q_idx_block = q_idx_bshd[:, q_start:q_end].float()  # (B, block, H_q, D_idx)
+        w_block = w_bsh[:, q_start:q_end].float()  # (B, block, H_q)
+        q_attn_block = q_attn_bshd[:, q_start:q_end].float()  # (B, block, np, D_attn)
+        lse_block = lse_bsh[:, q_start:q_end]  # (B, block, np)
+        mask_block = causal_mask[q_start:q_end]  # (block, S_k)
+        row_valid_block = row_valid[:, q_start:q_end]  # (B, block)
+
+        # --- Indexer scores (predict) ---
+        per_head_scores = torch.einsum("bqhd,bkd->bqhk", q_idx_block, k_idx) * indexer_softmax_scale
+        relu_mask = per_head_scores > 0
+        per_head_scores_relu = torch.relu(per_head_scores)  # (B, block, H_q, S_k)
+        combined = (per_head_scores_relu * w_block.unsqueeze(-1)).sum(dim=2)  # (B, block, S_k)
+        # Apply causal mask
+        combined = combined.masked_fill(~mask_block.unsqueeze(0), float("-inf"))
+        index_lse = torch.logsumexp(combined, dim=-1)  # (B, block)
+        index_score = combined  # keep for KL
+
+        # --- Attention scores (target) ---
+        attn_per_head = torch.einsum("bqhd,bkd->bqhk", q_attn_block, k_attn) * softmax_scale
+        # (B, block, np, S_k)
+        attn_probs = torch.exp(attn_per_head - lse_block.unsqueeze(-1))
+        attn_score = attn_probs.sum(dim=2)  # (B, block, S_k)
+        attn_score = attn_score.masked_fill(~mask_block.unsqueeze(0), 0.0)
+        attn_l1norm = attn_score.sum(dim=-1)  # (B, block)
+
+        # --- KL loss for this block ---
+        safe_l1 = attn_l1norm.clamp(min=eps)
+        safe_lse = index_lse.clone()
+        safe_lse[~row_valid_block] = 0.0
+        target_block = attn_score / safe_l1.unsqueeze(-1)
+        target_clamped = target_block.clamp(min=eps)
+        position_valid = torch.isfinite(index_score)
+        safe_index_score = torch.where(position_valid, index_score, torch.zeros_like(index_score))
+        log_predict = safe_index_score - safe_lse.unsqueeze(-1)
+        kl_terms = target_clamped * (torch.log(target_clamped) - log_predict)
+        kl_terms = torch.where(position_valid, kl_terms, torch.zeros_like(kl_terms))
+        kl_per_row_block = kl_terms.sum(dim=-1)  # (B, block)
+        kl_per_row_block = torch.where(row_valid_block, kl_per_row_block, torch.zeros_like(kl_per_row_block))
+        kl_acc[:, q_start:q_end] = kl_per_row_block
+
+        # --- Dense indexer backward for this block ---
+        # grad through KL + logsumexp: predict_prob - target_prob
+        predict_prob = torch.softmax(combined.masked_fill(~mask_block.unsqueeze(0), float("-inf")), dim=-1)
+        predict_prob = predict_prob.masked_fill(~mask_block.unsqueeze(0), 0.0)
+        target_prob = target_block.masked_fill(~mask_block.unsqueeze(0), 0.0)
+
+        grad_logits = predict_prob - target_prob  # (B, block, S_k)
+        grad_logits = grad_logits.masked_fill(~row_valid_block.unsqueeze(-1), 0.0)
+
+        # grad_relu[b,q,h,k] = grad_logits[b,q,k] * W[b,q,h]
+        grad_relu = grad_logits.unsqueeze(2) * w_block.unsqueeze(-1)  # (B, block, H_q, S_k)
+
+        # grad_weights[b,q,h] = sum_k(grad_logits[b,q,k] * relu_score[b,q,h,k])
+        grad_w[:, q_start:q_end] = (grad_logits.unsqueeze(2) * per_head_scores_relu).sum(dim=-1)
+
+        # Grad through ReLU
+        grad_pre_relu = grad_relu * relu_mask.float() * indexer_softmax_scale
+
+        # Grad through matmul
+        grad_q[:, q_start:q_end] = torch.einsum("bqhk,bkd->bqhd", grad_pre_relu, k_idx)
+        grad_k += torch.einsum("bqhk,bqhd->bkd", grad_pre_relu, q_idx_block)
+
+    # Final loss
+    loss = kl_acc.sum() if calculate_per_token_loss else kl_acc.mean()
+    indexer_loss = loss_coeff * loss
+
+    return (
+        indexer_loss,
+        grad_q.to(q_idx_bshd.dtype),
+        grad_k.to(k_idx_bsd.dtype),
+        grad_w.to(w_bsh.dtype),
+    )

--- a/megatron/plugin/dsa_kernel/triton_indexer_kernels.py
+++ b/megatron/plugin/dsa_kernel/triton_indexer_kernels.py
@@ -39,6 +39,18 @@ from megatron.plugin.dsa_kernel.triton_dsa_utils import (
 # 64 is a good default; lower to 32 if D >= 512 and GPU memory is very tight.
 _DENSE_BLOCK_Q = 512
 
+# Match compute_dsa_indexer_loss exactly.  This is intentionally much larger
+# than float32.tiny: the reference objective uses additive smoothing in both
+# logarithms, which also changes the gradient when predict is very small.
+_SPARSE_KL_EPS = 1e-10
+
+
+def _sparse_kl_grad_logits(predict: Tensor, target: Tensor) -> Tensor:
+    """Differentiate ``-sum(target * log(predict + eps))`` through softmax."""
+    scaled_target = target / (predict + _SPARSE_KL_EPS)
+    correction = (scaled_target * predict).sum(dim=-1, keepdim=True)
+    return predict * (correction - scaled_target)
+
 
 # ---------------------------------------------------------------------------
 # Sparse indexer score: compute ``predict`` distribution
@@ -429,9 +441,9 @@ def sparse_indexer_backward(
     per_head_scores = torch.relu(per_head_scores)  # (B, S_q, H_q, topk)
     combined = (per_head_scores * w.unsqueeze(-1)).sum(dim=2)  # (B, S_q, topk)
 
-    # Grad through KL + softmax: d_loss/d_combined
+    # Grad through the same epsilon-smoothed KL used by the reference path.
     invalid_mask = topk_indices == -1
-    grad_combined = (predict - target) * grad_loss  # (B, S_q, topk)
+    grad_combined = _sparse_kl_grad_logits(predict, target) * grad_loss
     grad_combined = grad_combined.masked_fill(invalid_mask, 0.0)
 
     # Grad through head-sum + weight multiply
@@ -616,8 +628,6 @@ def fused_sparse_indexer_loss_and_backward(
 
     B, S_q, H_q, D_idx = q_idx_bshd.shape
     topk = topk_indices_cmp.shape[-1]
-    eps = torch.finfo(torch.float32).tiny
-
     # --- Gather indexer keys (0-based into k_idx_bsd of shape (B, n_comp, D_idx)) ---
     idx_expanded = topk_indices_cmp.long().clamp(min=0)  # (B, S_q, topk)
     batch_idx = torch.arange(B, device=k_idx_bsd.device)[:, None, None]  # (B, 1, 1)
@@ -649,17 +659,21 @@ def fused_sparse_indexer_loss_and_backward(
     target = head_sum / denom  # (B, S_q, topk)
 
     # --- KL loss ---
-    t = target.clamp(min=eps)
-    p = predict.clamp(min=eps)
-    kl_per_row = (t * (torch.log(t) - torch.log(p))).sum(dim=-1)  # (B, S_q)
+    kl_per_row = (
+        target
+        * (
+            torch.log(target + _SPARSE_KL_EPS)
+            - torch.log(predict + _SPARSE_KL_EPS)
+        )
+    ).sum(dim=-1)
     row_valid = (~invalid_mask).any(dim=-1)  # (B, S_q)
     kl_per_row = torch.where(row_valid, kl_per_row, torch.zeros_like(kl_per_row))
     loss = kl_per_row.sum() if calculate_per_token_loss else kl_per_row.mean()
     indexer_loss = loss_coeff * loss
 
     # --- Indexer backward ---
-    # grad through KL + softmax: (predict - target) is d(KL)/d(logits)
-    grad_combined = (predict - target)  # (B, S_q, topk)
+    # Differentiate the epsilon-smoothed sparse KL through predict=softmax(logits).
+    grad_combined = _sparse_kl_grad_logits(predict, target)
     grad_combined = grad_combined.masked_fill(invalid_mask, 0.0)
 
     # Apply loss_coeff and mean normalization to match unfused bwd_fused_indexer_loss_naive

--- a/megatron/plugin/dsa_kernel/triton_indexer_kernels.py
+++ b/megatron/plugin/dsa_kernel/triton_indexer_kernels.py
@@ -59,7 +59,7 @@ def sparse_indexer_score_recompute(
     Args:
         q_indexer: ``(B, S_q, H_q, D)`` bf16.
         k_indexer: ``(B, S_k, D)`` bf16.
-        weights:   ``(B, S_q, H_q)`` bf16.
+        weights:   ``(B, S_q, H_q)`` bf16 — scaled weights (w_raw * indexer_softmax_scale).
         topk_indices: ``(B, S_q, topk)`` int32.
         qhead_per_kv_head: number of Q heads per KV head (MQA ratio).
 
@@ -78,8 +78,8 @@ def sparse_indexer_score_recompute(
     batch_idx = torch.arange(B, device=k_indexer.device)[:, None, None]  # (B, 1, 1)
     k_gathered = k_indexer.float()[batch_idx, idx_expanded]  # (B, S_q, topk, D)
 
-    # Compute scores: (B, S_q, H_q, topk) = Q @ K^T
-    scores = torch.einsum("bqhd,bqtd->bqht", q, k_gathered)  # (B, S_q, H_q, topk)
+    # Compute scores: (B, S_q, H_q, topk) = Q @ K^T (no scale — embedded in weights)
+    scores = torch.einsum("bqhd,bqtd->bqht", q, k_gathered)
 
     # ReLU activation
     scores = torch.relu(scores)
@@ -598,7 +598,7 @@ def fused_sparse_indexer_loss_and_backward(
     Args:
         q_idx_bshd: ``(B, S_q, H_q, D_idx)`` bf16 — indexer queries.
         k_idx_bsd: ``(B, S_k, D_idx)`` bf16 — indexer keys.
-        w_bsh: ``(B, S_q, H_q)`` bf16 — raw (unscaled) weights.
+        w_bsh: ``(B, S_q, H_q)`` bf16 — scaled weights (w_raw * indexer_softmax_scale).
         topk_indices_cmp: ``(B, S_q, topk)`` int32 — indices into [0, n_comp).
         q_attn_bshd: ``(B, S_q, np, D_attn)`` bf16 — attention queries.
         k_attn_bsd: ``(B, S_kv, D_attn)`` bf16 — attention keys (full KV buffer).
@@ -677,7 +677,7 @@ def fused_sparse_indexer_loss_and_backward(
     # Grad through ReLU
     grad_pre_relu = grad_relu_scores * relu_mask.float()
 
-    # Grad through Q @ K^T
+    # Grad through Q @ K^T (no scale on scores, matching unfused)
     grad_q = torch.einsum("bqht,bqtd->bqhd", grad_pre_relu, k_idx_gathered)
     grad_k_gathered = torch.einsum("bqht,bqhd->bqtd", grad_pre_relu, q_idx)
 
@@ -709,7 +709,7 @@ def fused_dense_indexer_loss_and_backward(
     q_attn_bshd: Tensor,
     k_attn_bsd: Tensor,
     lse_bsh: Tensor,  # noqa: ARG001 — kept for API compat; dense uses self-contained softmax
-    indexer_softmax_scale: float,
+    indexer_softmax_scale: float,  # noqa: ARG001 — scale is embedded in w_bsh; kept for API compat
     softmax_scale: float,
     loss_coeff: float,
     ratio: int = 1,
@@ -775,7 +775,7 @@ def fused_dense_indexer_loss_and_backward(
         row_valid_block = row_valid[:, q_start:q_end]  # (B, block)
 
         # --- Indexer scores (predict) ---
-        per_head_scores = torch.einsum("bqhd,bkd->bqhk", q_idx_block, k_idx) * indexer_softmax_scale
+        per_head_scores = torch.einsum("bqhd,bkd->bqhk", q_idx_block, k_idx)
         relu_mask = per_head_scores > 0
         per_head_scores_relu = torch.relu(per_head_scores)  # (B, block, H_q, S_k)
         combined = (per_head_scores_relu * w_block.unsqueeze(-1)).sum(dim=2)  # (B, block, S_k)
@@ -836,10 +836,9 @@ def fused_dense_indexer_loss_and_backward(
         # Grad through ReLU
         grad_pre_relu = grad_relu * relu_mask.float()
 
-        # Grad through matmul: score = Q@K * scale, so d/dQ = grad * K * scale
-        grad_pre_relu_scaled = grad_pre_relu * indexer_softmax_scale
-        grad_q[:, q_start:q_end] = torch.einsum("bqhk,bkd->bqhd", grad_pre_relu_scaled, k_idx)
-        grad_k += torch.einsum("bqhk,bqhd->bkd", grad_pre_relu_scaled, q_idx_block)
+        # Grad through matmul: score = Q@K (no scale — embedded in weights)
+        grad_q[:, q_start:q_end] = torch.einsum("bqhk,bkd->bqhd", grad_pre_relu, k_idx)
+        grad_k += torch.einsum("bqhk,bqhd->bkd", grad_pre_relu, q_idx_block)
 
     # Final loss
     loss = kl_acc.sum() if calculate_per_token_loss else kl_acc.mean()

--- a/megatron/plugin/dsa_kernel/triton_sparse_attn.py
+++ b/megatron/plugin/dsa_kernel/triton_sparse_attn.py
@@ -165,6 +165,238 @@ def _sparse_attn_fwd_kernel(
 
 
 # ---------------------------------------------------------------------------
+# Head-Parallel Forward kernel (WGMMA, shared indices)
+# ---------------------------------------------------------------------------
+
+
+def _hp_fwd_configs():
+    """Autotune configs for HP forward kernel.
+
+    Varies BLOCK_K (tile size over TopK) and num_warps.
+    - BLOCK_K=16: lower register pressure, more loop iterations
+    - BLOCK_K=32: balanced
+    - BLOCK_K=64: fewer iterations, higher register pressure
+    - num_warps=4: better for memory-bound (D=512 with small TopK)
+    - num_warps=8: better for compute-bound (large TopK, occupancy limited)
+    """
+    configs = []
+    for block_k in [16, 32, 64]:
+        for nw in [4, 8]:
+            configs.append(
+                triton.Config({"BLOCK_K": block_k}, num_warps=nw, num_stages=2)
+            )
+    return configs
+
+
+@triton.autotune(
+    configs=_hp_fwd_configs(),
+    key=["TopK", "D", "DV", "H"],
+)
+@triton.jit
+def _sparse_attn_fwd_hp_kernel(
+    Q_ptr, KV_ptr, IDX_ptr, OUT_ptr, LSE_ptr,
+    SINK_ptr, LSE_IDX_ptr,
+    softmax_scale,
+    total_Sq, total_Skv, TopK: tl.constexpr, D: tl.constexpr, DV: tl.constexpr,
+    H: tl.constexpr,
+    stride_q_s, stride_q_h, stride_q_d,
+    stride_kv_s, stride_kv_d,
+    stride_idx_s, stride_idx_k,
+    stride_out_s, stride_out_h, stride_out_d,
+    stride_lse_s, stride_lse_h,
+    HAS_SINK: tl.constexpr,
+    HAS_LSE_IDX: tl.constexpr,
+    INDEXER_TOPK: tl.constexpr,
+    BLOCK_H: tl.constexpr,
+    BLOCK_K: tl.constexpr,
+):
+    """Head-parallel sparse attention forward using tl.dot (WGMMA on Hopper).
+
+    Exploits MLA shared-index structure: all heads share the same TopK indices
+    for each query position. This allows a single KV gather to be amortized
+    across BLOCK_H heads, and both score computation and output accumulation
+    use tl.dot() which maps to WGMMA (Tensor Core matrix multiply).
+
+    Program mapping: (pid_q, pid_hb) where pid_q is the query position and
+    pid_hb selects the head block [pid_hb * BLOCK_H : (pid_hb+1) * BLOCK_H].
+
+    GEMM dimensions:
+      Score:  Q_tile(BLOCK_H, D) @ K_tile^T(D, BLOCK_K) → (BLOCK_H, BLOCK_K)
+      Output: P_tile(BLOCK_H, BLOCK_K) @ V_tile(BLOCK_K, DV) → (BLOCK_H, DV)
+
+    Both satisfy WGMMA alignment: M=BLOCK_H≥16, K=D or BLOCK_K≥16, N≥16.
+    """
+    pid_q = tl.program_id(0)
+    pid_hb = tl.program_id(1)
+
+    if pid_q >= total_Sq:
+        return
+
+    h_start = pid_hb * BLOCK_H
+    h_range = h_start + tl.arange(0, BLOCK_H)  # (BLOCK_H,)
+    d_range = tl.arange(0, D)                   # (D,)
+    dv_range = tl.arange(0, DV)                 # (DV,)
+
+    # =========================================================================
+    # Load Q tile: (BLOCK_H, D) — loaded once, reused across all TopK tiles
+    # =========================================================================
+    # Q layout: (total_Sq, H, D) — load BLOCK_H heads for this query
+    q_base = pid_q * stride_q_s
+    Q_tile = tl.load(
+        Q_ptr + q_base + h_range[:, None] * stride_q_h + d_range[None, :] * stride_q_d,
+        mask=(h_range[:, None] < H) & (d_range[None, :] < D),
+        other=0.0,
+    ).to(tl.float16)  # (BLOCK_H, D) f16 for tl.dot
+
+    # =========================================================================
+    # Online softmax state: per-head running max and sum
+    # =========================================================================
+    m_i = tl.full([BLOCK_H], float("-inf"), dtype=tl.float32)  # running max
+    l_i = tl.zeros([BLOCK_H], dtype=tl.float32)                # running sum(exp)
+    acc = tl.zeros([BLOCK_H, DV], dtype=tl.float32)            # output accumulator
+
+    # Handle attention sink FIRST — initializes running max from sink bias.
+    # Processing sink before TopK ensures the running max starts from a meaningful
+    # baseline, reducing accumulator rescale magnitude during the TopK loop.
+    if HAS_SINK:
+        sink_vals = tl.load(SINK_ptr + h_range, mask=h_range < H, other=0.0)  # (BLOCK_H,)
+        m_i = tl.maximum(m_i, sink_vals)
+        p_sink = tl.exp(sink_vals - m_i)
+        l_i = l_i + p_sink
+        # Sink contributes no value (bias-only), so acc stays zero
+
+    # Indexer LSE tracking (optional)
+    if HAS_LSE_IDX:
+        m_idx = tl.full([BLOCK_H], float("-inf"), dtype=tl.float32)
+        l_idx = tl.zeros([BLOCK_H], dtype=tl.float32)
+
+    # =========================================================================
+    # Tiled iteration over TopK positions in groups of BLOCK_K
+    # =========================================================================
+    # Indices layout: (total_Sq, 1, TopK) with stride_idx_h=0 (shared)
+    # We use head-0 slice: IDX_ptr + pid_q * stride_idx_s + k * stride_idx_k
+    idx_base = pid_q * stride_idx_s
+
+    for tile_start in range(0, TopK, BLOCK_K):
+        k_range = tile_start + tl.arange(0, BLOCK_K)  # (BLOCK_K,)
+        k_valid = k_range < TopK
+
+        # --- Load BLOCK_K indices (shared across heads) ---
+        kv_indices = tl.load(
+            IDX_ptr + idx_base + k_range * stride_idx_k,
+            mask=k_valid,
+            other=-1,
+        )  # (BLOCK_K,) int32
+        valid_mask = (kv_indices >= 0) & k_valid  # (BLOCK_K,)
+        safe_indices = tl.where(valid_mask, kv_indices, 0)  # clamp for safe load
+
+        # --- Gather K tile: (BLOCK_K, D) ---
+        kv_bases = safe_indices * stride_kv_s  # (BLOCK_K,)
+        K_tile = tl.load(
+            KV_ptr + kv_bases[:, None] + d_range[None, :] * stride_kv_d,
+            mask=valid_mask[:, None] & (d_range[None, :] < D),
+            other=0.0,
+        ).to(tl.float16)  # (BLOCK_K, D) f16
+
+        # --- Score GEMM: (BLOCK_H, D) @ (D, BLOCK_K) → (BLOCK_H, BLOCK_K) ---
+        # tl.dot uses f16 inputs with f32 accumulator (WGMMA on Hopper)
+        scores = tl.dot(Q_tile, tl.trans(K_tile))  # (BLOCK_H, BLOCK_K) f32
+        scores = scores * softmax_scale
+
+        # Mask invalid positions
+        scores = tl.where(
+            valid_mask[None, :],  # broadcast (1, BLOCK_K) over (BLOCK_H, BLOCK_K)
+            scores,
+            float("-inf"),
+        )
+
+        # --- Tiled online softmax update ---
+        tile_max = tl.max(scores, axis=1)  # (BLOCK_H,)
+        m_new = tl.maximum(m_i, tile_max)
+
+        # Rescale existing accumulator
+        exp_old = tl.exp(m_i - m_new)  # (BLOCK_H,)
+        acc = acc * exp_old[:, None]
+        l_i = l_i * exp_old
+
+        # Compute attention weights for this tile
+        P_tile = tl.exp(scores - m_new[:, None])  # (BLOCK_H, BLOCK_K) f32
+        P_tile = tl.where(valid_mask[None, :], P_tile, 0.0)
+        tile_sum = tl.sum(P_tile, axis=1)  # (BLOCK_H,)
+        l_i = l_i + tile_sum
+        m_i = m_new
+
+        # --- Gather V tile: (BLOCK_K, DV) ---
+        V_tile = tl.load(
+            KV_ptr + kv_bases[:, None] + dv_range[None, :] * stride_kv_d,
+            mask=valid_mask[:, None] & (dv_range[None, :] < DV),
+            other=0.0,
+        ).to(tl.float16)  # (BLOCK_K, DV) f16
+
+        # --- Output GEMM: (BLOCK_H, BLOCK_K) @ (BLOCK_K, DV) → (BLOCK_H, DV) ---
+        acc += tl.dot(P_tile.to(tl.float16), V_tile)  # WGMMA, f32 accumulator
+
+        # --- Indexer LSE tracking (first INDEXER_TOPK positions) ---
+        if HAS_LSE_IDX:
+            if tile_start < INDEXER_TOPK:
+                # Only count k-positions within [0, INDEXER_TOPK)
+                idx_valid = valid_mask & (k_range < INDEXER_TOPK)  # (BLOCK_K,)
+                idx_scores = tl.where(
+                    idx_valid[None, :],
+                    scores,
+                    float("-inf"),
+                )  # (BLOCK_H, BLOCK_K)
+                idx_tile_max = tl.max(idx_scores, axis=1)  # (BLOCK_H,)
+                m_idx_new = tl.maximum(m_idx, idx_tile_max)
+                exp_old_idx = tl.exp(m_idx - m_idx_new)
+                l_idx = l_idx * exp_old_idx
+                P_idx = tl.exp(idx_scores - m_idx_new[:, None])
+                P_idx = tl.where(idx_valid[None, :], P_idx, 0.0)
+                l_idx = l_idx + tl.sum(P_idx, axis=1)
+                m_idx = m_idx_new
+
+    # =========================================================================
+    # Finalize: normalize output and compute LSE
+    # =========================================================================
+
+    # Normalize: out = acc / l_i
+    safe_l = tl.where(l_i > 0.0, l_i, 1.0)
+    out_tile = acc / safe_l[:, None]  # (BLOCK_H, DV) f32
+
+    # LSE = m_i + log(l_i)
+    safe_l_for_log = tl.where(l_i > 0.0, l_i, 1.0)
+    lse_vals = m_i + tl.log(safe_l_for_log)  # (BLOCK_H,)
+
+    # =========================================================================
+    # Store outputs
+    # =========================================================================
+    out_base = pid_q * stride_out_s
+    tl.store(
+        OUT_ptr + out_base + h_range[:, None] * stride_out_h + dv_range[None, :] * stride_out_d,
+        out_tile.to(tl.bfloat16),
+        mask=(h_range[:, None] < H) & (dv_range[None, :] < DV),
+    )
+
+    # Store LSE
+    lse_base = pid_q * stride_lse_s
+    tl.store(
+        LSE_ptr + lse_base + h_range * stride_lse_h,
+        lse_vals,
+        mask=h_range < H,
+    )
+
+    # Store indexer LSE
+    if HAS_LSE_IDX:
+        safe_l_idx = tl.where(l_idx > 0.0, l_idx, 1.0)
+        lse_idx_vals = m_idx + tl.log(safe_l_idx)
+        tl.store(
+            LSE_IDX_ptr + lse_base + h_range * stride_lse_h,
+            lse_idx_vals,
+            mask=h_range < H,
+        )
+
+
+# ---------------------------------------------------------------------------
 # 2D-Tiled Forward kernel (BLOCK_Q queries per program)
 # ---------------------------------------------------------------------------
 
@@ -185,17 +417,20 @@ def _sparse_attn_fwd_2d_kernel(
     HAS_LSE_IDX: tl.constexpr,
     INDEXER_TOPK: tl.constexpr,
     BLOCK_Q: tl.constexpr,
+    BLOCK_K: tl.constexpr,
 ):
-    """2D-tiled sparse attention forward.
+    """2D-tiled sparse attention forward with tiled online softmax.
 
-    Each program handles BLOCK_Q queries for one head. Iterates over all TopK
-    KV positions one at a time. For each position, loads one index per query
-    (BLOCK_Q independent indices) and gathers the corresponding KV vectors.
+    Each program handles BLOCK_Q queries for one head. KV positions are
+    processed in tiles of BLOCK_K. Within each tile, scores are gathered into
+    a (BLOCK_Q, BLOCK_K) matrix and a single tiled online-softmax update is
+    performed, reducing the number of expensive accumulator rescales from TopK
+    to TopK/BLOCK_K.
 
-    Benefits over 1D kernel:
-    - BLOCK_Q× fewer programs = less dispatch overhead
-    - Q block loaded once, reused across all TopK iterations
-    - BLOCK_Q online-softmax states updated in parallel (better SIMD utilization)
+    P0 Hopper optimization: tiled softmax reduces rescale overhead by BLOCK_K×.
+    The tiled structure also enables better instruction scheduling and provides
+    the foundation for future tl.dot()-based WGMMA when shared indices are
+    available.
     """
     pid_qblock = tl.program_id(0)
     pid_h = tl.program_id(1)
@@ -236,57 +471,99 @@ def _sparse_attn_fwd_2d_kernel(
         m_idx = tl.full([BLOCK_Q], float("-inf"), dtype=tl.float32)
         l_idx = tl.zeros([BLOCK_Q], dtype=tl.float32)
 
-    # Iterate over all TopK positions one at a time.
-    # Each iteration: load one index per query → gather KV → update softmax.
-    for k_pos in range(TopK):
-        # Load index for each query at this KV position: (BLOCK_Q,)
-        idx_offsets = q_ids * stride_idx_s + pid_h * stride_idx_h + k_pos * stride_idx_k
-        kv_indices = tl.load(
-            IDX_ptr + idx_offsets,
-            mask=q_valid,
-            other=-1,
-        )  # (BLOCK_Q,)
-        valid_q = (kv_indices >= 0) & q_valid  # (BLOCK_Q,)
-        safe_idx = tl.where(valid_q, kv_indices, 0)  # (BLOCK_Q,)
+    # Tiled iteration over TopK positions in groups of BLOCK_K.
+    # Each tile: gather K+V, compute scores, find tile max, compute weighted V.
+    # Uses single-pass with deferred V accumulation to enable software pipelining.
+    #
+    # P1 optimization: The loop structure is designed for Triton's software
+    # pipelining (num_stages). The loads at the start of each k_off iteration
+    # can overlap with the prior iteration's compute.
+    for tile_start in range(0, TopK, BLOCK_K):
 
-        # Gather K for all BLOCK_Q queries: (BLOCK_Q, D)
-        kv_bases = safe_idx * stride_kv_s  # (BLOCK_Q,)
-        k_vec = tl.load(
-            KV_ptr + kv_bases[:, None] + d_range[None, :] * stride_kv_d,
-            mask=valid_q[:, None] & (d_range[None, :] < D),
-            other=0.0,
-        ).to(tl.float32)  # (BLOCK_Q, D)
+        # === Phase 1: Gather K, compute scores, find tile max ===
+        # We need tile_max before computing exp weights. First pass over
+        # BLOCK_K positions to find the max score.
+        tile_max = tl.full([BLOCK_Q], float("-inf"), dtype=tl.float32)
 
-        # Score: dot product per query
-        scores = tl.sum(q_block * k_vec, axis=1)  # (BLOCK_Q,)
-        scores = tl.where(valid_q, scores, float("-inf"))
+        for k_off in range(BLOCK_K):
+            k_pos = tile_start + k_off
+            if k_pos < TopK:
+                # Load index for each query
+                idx_offsets = q_ids * stride_idx_s + pid_h * stride_idx_h + k_pos * stride_idx_k
+                kv_indices = tl.load(IDX_ptr + idx_offsets, mask=q_valid, other=-1)
+                valid_q = (kv_indices >= 0) & q_valid
+                safe_idx = tl.where(valid_q, kv_indices, 0)
 
-        # Online softmax update (vectorized over BLOCK_Q)
-        m_new = tl.maximum(m_i, scores)
-        exp_old = tl.exp(m_i - m_new)
-        exp_scores = tl.exp(scores - m_new)  # (BLOCK_Q,)
-        exp_scores = tl.where(valid_q, exp_scores, 0.0)
+                # Gather K: (BLOCK_Q, D)
+                kv_bases = safe_idx * stride_kv_s
+                k_vec = tl.load(
+                    KV_ptr + kv_bases[:, None] + d_range[None, :] * stride_kv_d,
+                    mask=valid_q[:, None] & (d_range[None, :] < D),
+                    other=0.0,
+                ).to(tl.float32)
 
-        # Gather V: (BLOCK_Q, DV)
-        v_vec = tl.load(
-            KV_ptr + kv_bases[:, None] + dv_range[None, :] * stride_kv_d,
-            mask=valid_q[:, None] & (dv_range[None, :] < DV),
-            other=0.0,
-        ).to(tl.float32)  # (BLOCK_Q, DV)
+                # Score: dot product per query
+                score = tl.sum(q_block * k_vec, axis=1)  # (BLOCK_Q,)
+                score = tl.where(valid_q, score, float("-inf"))
+                tile_max = tl.maximum(tile_max, score)
 
-        # Update accumulators
-        l_i = l_i * exp_old + exp_scores
-        acc = acc * exp_old[:, None] + exp_scores[:, None] * v_vec
+        # === Softmax rescale: ONE per tile ===
+        m_new = tl.maximum(m_i, tile_max)
+        exp_old = tl.exp(m_i - m_new)  # (BLOCK_Q,)
+        # Rescale accumulator once for entire tile
+        acc = acc * exp_old[:, None]
+        l_i = l_i * exp_old
+
+        # === Phase 2: Recompute scores, gather V, accumulate ===
+        # Second pass: compute exp weights and weighted V sum.
+        # Loads here can be pipelined by Triton's num_stages with Phase 1
+        # loads of the *next* tile iteration.
+        tile_sum = tl.zeros([BLOCK_Q], dtype=tl.float32)
+
+        for k_off in range(BLOCK_K):
+            k_pos = tile_start + k_off
+            if k_pos < TopK:
+                # Re-load index and gather K+V
+                idx_offsets = q_ids * stride_idx_s + pid_h * stride_idx_h + k_pos * stride_idx_k
+                kv_indices = tl.load(IDX_ptr + idx_offsets, mask=q_valid, other=-1)
+                valid_q = (kv_indices >= 0) & q_valid
+                safe_idx = tl.where(valid_q, kv_indices, 0)
+                kv_bases = safe_idx * stride_kv_s
+
+                # Gather K and recompute score
+                k_vec = tl.load(
+                    KV_ptr + kv_bases[:, None] + d_range[None, :] * stride_kv_d,
+                    mask=valid_q[:, None] & (d_range[None, :] < D),
+                    other=0.0,
+                ).to(tl.float32)
+                score = tl.sum(q_block * k_vec, axis=1)
+                score = tl.where(valid_q, score, float("-inf"))
+
+                # Exp weight relative to m_new
+                w = tl.exp(score - m_new)  # (BLOCK_Q,)
+
+                # Gather V: (BLOCK_Q, DV)
+                v_vec = tl.load(
+                    KV_ptr + kv_bases[:, None] + dv_range[None, :] * stride_kv_d,
+                    mask=valid_q[:, None] & (dv_range[None, :] < DV),
+                    other=0.0,
+                ).to(tl.float32)
+
+                # Accumulate weighted V
+                acc += w[:, None] * v_vec
+                tile_sum += w
+
+                # Indexer LSE update
+                if HAS_LSE_IDX:
+                    if k_pos < INDEXER_TOPK:
+                        m_idx_new = tl.maximum(m_idx, score)
+                        exp_idx = tl.exp(score - m_idx_new)
+                        l_idx = l_idx * tl.exp(m_idx - m_idx_new) + exp_idx
+                        m_idx = m_idx_new
+
+        # Update softmax denominator
+        l_i = l_i + tile_sum
         m_i = m_new
-
-        # Indexer LSE update
-        if HAS_LSE_IDX:
-            if k_pos < INDEXER_TOPK:
-                m_idx_new = tl.maximum(m_idx, scores)
-                exp_idx = tl.exp(scores - m_idx_new)
-                exp_idx = tl.where(valid_q, exp_idx, 0.0)
-                l_idx = l_idx * tl.exp(m_idx - m_idx_new) + exp_idx
-                m_idx = m_idx_new
 
     # Finalize output: (BLOCK_Q, DV)
     safe_l = tl.where(l_i > 0.0, l_i, 1.0)
@@ -411,8 +688,289 @@ def _sparse_attn_bwd_kernel(
 
 
 # ---------------------------------------------------------------------------
+# Head-Parallel Backward kernel (WGMMA, shared indices)
+# ---------------------------------------------------------------------------
+
+
+def _hp_bwd_configs():
+    """Autotune configs for HP backward kernel.
+
+    Backward has higher register pressure than forward (holds dQ_acc + Q + dO),
+    so larger BLOCK_K or more warps can help depending on TopK.
+    """
+    configs = []
+    for block_k in [16, 32, 64]:
+        for nw in [4, 8]:
+            configs.append(
+                triton.Config({"BLOCK_K": block_k}, num_warps=nw, num_stages=2)
+            )
+    return configs
+
+
+@triton.autotune(
+    configs=_hp_bwd_configs(),
+    key=["TopK", "D", "DV", "H"],
+)
+@triton.jit
+def _sparse_attn_bwd_hp_kernel(
+    Q_ptr, KV_ptr, IDX_ptr, OUT_ptr, LSE_ptr, DO_ptr,
+    DQ_ptr, DKV_ptr,
+    softmax_scale,
+    total_Sq, total_Skv, TopK: tl.constexpr, D: tl.constexpr, DV: tl.constexpr,
+    H: tl.constexpr,
+    stride_q_s, stride_q_h, stride_q_d,
+    stride_kv_s, stride_kv_d,
+    stride_idx_s, stride_idx_k,
+    stride_out_s, stride_out_h, stride_out_d,
+    stride_lse_s, stride_lse_h,
+    BLOCK_H: tl.constexpr,
+    BLOCK_K: tl.constexpr,
+):
+    """Head-parallel sparse attention backward using tl.dot (WGMMA on Hopper).
+
+    Exploits MLA shared-index structure (same as forward HP kernel). Computes
+    gradients dQ, dK, dV using WGMMA matrix multiplies:
+
+    Per tile of BLOCK_K KV positions:
+      Score recompute: Q(BLOCK_H, D) @ K^T(D, BLOCK_K) → (BLOCK_H, BLOCK_K) WGMMA
+      dOV:            dO(BLOCK_H, DV) @ V^T(DV, BLOCK_K) → (BLOCK_H, BLOCK_K) WGMMA
+      dQ accumulate:  dS(BLOCK_H, BLOCK_K) @ K(BLOCK_K, D) → (BLOCK_H, D)    WGMMA
+      dK per tile:    dS^T(BLOCK_K, BLOCK_H) @ Q(BLOCK_H, D) → (BLOCK_K, D)  WGMMA
+      dV per tile:    P^T(BLOCK_K, BLOCK_H) @ dO(BLOCK_H, DV) → (BLOCK_K, DV) WGMMA
+
+    dQ is stored directly (per-query, no conflicts).
+    dK and dV use f32 atomic_add (multiple queries write to same KV position).
+
+    P0 optimization: Tiled score recomputation — one tl.dot per tile vs per-position.
+    P1 optimization: num_stages=2 for software pipelining of KV gather.
+    """
+    pid_q = tl.program_id(0)
+    pid_hb = tl.program_id(1)
+
+    if pid_q >= total_Sq:
+        return
+
+    h_start = pid_hb * BLOCK_H
+    h_range = h_start + tl.arange(0, BLOCK_H)  # (BLOCK_H,)
+    d_range = tl.arange(0, D)                   # (D,)
+    dv_range = tl.arange(0, DV)                 # (DV,)
+
+    # =========================================================================
+    # Load Q, dO, O, LSE — all reused across TopK tiles
+    # =========================================================================
+    q_base = pid_q * stride_q_s
+    out_base = pid_q * stride_out_s
+
+    # Q_tile: (BLOCK_H, D) f16 — for score recompute and dK
+    Q_tile = tl.load(
+        Q_ptr + q_base + h_range[:, None] * stride_q_h + d_range[None, :] * stride_q_d,
+        mask=(h_range[:, None] < H) & (d_range[None, :] < D),
+        other=0.0,
+    ).to(tl.float16)  # (BLOCK_H, D)
+
+    # dO_tile: (BLOCK_H, DV) f16 — for dOV and dV
+    dO_tile = tl.load(
+        DO_ptr + out_base + h_range[:, None] * stride_out_h + dv_range[None, :] * stride_out_d,
+        mask=(h_range[:, None] < H) & (dv_range[None, :] < DV),
+        other=0.0,
+    ).to(tl.float16)  # (BLOCK_H, DV)
+
+    # O_tile: (BLOCK_H, DV) f32 — for Di computation
+    O_tile = tl.load(
+        OUT_ptr + out_base + h_range[:, None] * stride_out_h + dv_range[None, :] * stride_out_d,
+        mask=(h_range[:, None] < H) & (dv_range[None, :] < DV),
+        other=0.0,
+    ).to(tl.float32)  # (BLOCK_H, DV)
+
+    # LSE: (BLOCK_H,) f32
+    lse_base = pid_q * stride_lse_s
+    lse_vals = tl.load(
+        LSE_ptr + lse_base + h_range * stride_lse_h,
+        mask=h_range < H,
+        other=0.0,
+    )  # (BLOCK_H,) f32
+
+    # Di = sum(dO * O, axis=-1) per head: (BLOCK_H,) f32
+    Di = tl.sum(dO_tile.to(tl.float32) * O_tile, axis=1)  # (BLOCK_H,)
+
+    # dQ accumulator: (BLOCK_H, D) f32 — stored once at end
+    dq_acc = tl.zeros([BLOCK_H, D], dtype=tl.float32)
+
+    # =========================================================================
+    # Tiled iteration over TopK positions
+    # =========================================================================
+    idx_base = pid_q * stride_idx_s
+
+    for tile_start in range(0, TopK, BLOCK_K):
+        k_range = tile_start + tl.arange(0, BLOCK_K)  # (BLOCK_K,)
+        k_valid = k_range < TopK
+
+        # --- Load BLOCK_K indices (shared across heads) ---
+        kv_indices = tl.load(
+            IDX_ptr + idx_base + k_range * stride_idx_k,
+            mask=k_valid,
+            other=-1,
+        )  # (BLOCK_K,) int32
+        valid_mask = (kv_indices >= 0) & k_valid  # (BLOCK_K,)
+        safe_indices = tl.where(valid_mask, kv_indices, 0)
+
+        # --- Gather K tile: (BLOCK_K, D) f16 ---
+        kv_bases = safe_indices * stride_kv_s  # (BLOCK_K,)
+        K_tile = tl.load(
+            KV_ptr + kv_bases[:, None] + d_range[None, :] * stride_kv_d,
+            mask=valid_mask[:, None] & (d_range[None, :] < D),
+            other=0.0,
+        ).to(tl.float16)  # (BLOCK_K, D)
+
+        # --- Gather V tile: (BLOCK_K, DV) f16 ---
+        V_tile = tl.load(
+            KV_ptr + kv_bases[:, None] + dv_range[None, :] * stride_kv_d,
+            mask=valid_mask[:, None] & (dv_range[None, :] < DV),
+            other=0.0,
+        ).to(tl.float16)  # (BLOCK_K, DV)
+
+        # --- Score GEMM: (BLOCK_H, D) @ (D, BLOCK_K) → (BLOCK_H, BLOCK_K) ---
+        scores = tl.dot(Q_tile, tl.trans(K_tile))  # (BLOCK_H, BLOCK_K) f32
+        scores = scores * softmax_scale
+
+        # --- Recompute P = exp(scores - lse) * valid_mask ---
+        P = tl.exp(scores - lse_vals[:, None])  # (BLOCK_H, BLOCK_K) f32
+        P = tl.where(valid_mask[None, :], P, 0.0)
+
+        # --- dOV GEMM: (BLOCK_H, DV) @ (DV, BLOCK_K) → (BLOCK_H, BLOCK_K) ---
+        # dOV[h, k] = sum_d(dO[h, d] * V[k, d])
+        dOV = tl.dot(dO_tile, tl.trans(V_tile))  # (BLOCK_H, BLOCK_K) f32
+
+        # --- dS = P * (dOV - Di) * softmax_scale ---
+        dS = P * (dOV - Di[:, None]) * softmax_scale  # (BLOCK_H, BLOCK_K) f32
+
+        # --- dQ GEMM: (BLOCK_H, BLOCK_K) @ (BLOCK_K, D) → (BLOCK_H, D) ---
+        dq_acc += tl.dot(dS.to(tl.float16), K_tile)  # WGMMA, f32 accumulator
+
+        # --- dK and dV via per-position reduction ---
+        # We have P(BLOCK_H, BLOCK_K) and dS(BLOCK_H, BLOCK_K) computed from
+        # tl.dot scores (consistent with forward). For each position k:
+        #   dK[k] = sum_h(dS[h,k] * Q[h,:])  → (D,)
+        #   dV[k] = sum_h(P[h,k] * dO[h,:])  → (DV,)
+        # Extract column k from P/dS using a compile-time mask (k_off is unrolled).
+        for k_off in range(BLOCK_K):
+            k_pos = tile_start + k_off
+            if k_pos < TopK:
+                kv_idx = tl.load(IDX_ptr + idx_base + k_pos * stride_idx_k)
+                is_valid = kv_idx >= 0
+                if is_valid:
+                    kv_offset = kv_idx * stride_kv_s
+
+                    # Extract column k_off from dS and P using compile-time mask.
+                    # Since k_off is a compile-time constant (range unrolled),
+                    # the mask `tl.arange(0, BLOCK_K) == k_off` is resolved at
+                    # compile time and the tl.sum reduces to selecting one column.
+                    col_mask = tl.arange(0, BLOCK_K) == k_off  # (BLOCK_K,) compile-time
+                    # dS_col[h] = dS[h, k_off]
+                    dS_col = tl.sum(tl.where(col_mask[None, :], dS, 0.0), axis=1)  # (BLOCK_H,)
+                    # P_col[h] = P[h, k_off]
+                    P_col = tl.sum(tl.where(col_mask[None, :], P, 0.0), axis=1)  # (BLOCK_H,)
+
+                    # dK = sum_h(dS_col[h] * Q[h,:]) → (D,)
+                    dK_vec = tl.sum(dS_col[:, None] * Q_tile.to(tl.float32), axis=0)  # (D,)
+                    # dV = sum_h(P_col[h] * dO[h,:]) → (DV,)
+                    dV_vec = tl.sum(P_col[:, None] * dO_tile.to(tl.float32), axis=0)  # (DV,)
+
+                    tl.atomic_add(
+                        DKV_ptr + kv_offset + d_range * stride_kv_d,
+                        dK_vec,
+                        mask=d_range < D,
+                    )
+                    tl.atomic_add(
+                        DKV_ptr + kv_offset + dv_range * stride_kv_d,
+                        dV_vec,
+                        mask=dv_range < DV,
+                    )
+
+    # =========================================================================
+    # Store dQ (non-atomic, per-query exclusive)
+    # =========================================================================
+    tl.store(
+        DQ_ptr + q_base + h_range[:, None] * stride_q_h + d_range[None, :] * stride_q_d,
+        dq_acc.to(tl.bfloat16),
+        mask=(h_range[:, None] < H) & (d_range[None, :] < D),
+    )
+
+
+# ---------------------------------------------------------------------------
 # Python wrapper functions
 # ---------------------------------------------------------------------------
+
+
+def _triton_sparse_attn_bwd_hp(
+    dO: Tensor,
+    q: Tensor,
+    kv: Tensor,
+    out: Tensor,
+    lse: Tensor,
+    topk_idxs: Tensor,
+    softmax_scale: float,
+    d_v: int = 512,
+    attn_sink: Optional[Tensor] = None,
+) -> dict:
+    """Head-parallel WGMMA backward for sparse attention.
+
+    Uses tl.dot() for all five GEMMs in the backward pass:
+    - Score recompute: Q @ K^T
+    - dOV: dO @ V^T
+    - dQ: dS @ K
+    - dK: dS^T @ Q
+    - dV: P^T @ dO
+
+    Requirements (same as HP forward):
+    - Shared indices: topk_idxs.stride(1) == 0
+    - H >= 16, divisible by BLOCK_H(=16)
+    - D, DV multiples of 16
+
+    BLOCK_K and num_warps are selected by @triton.autotune keyed on (TopK, D, DV, H).
+    """
+    total_Sq, H, D = q.shape
+    total_Skv = kv.shape[0]
+    D_full = kv.shape[-1] if kv.dim() > 1 else D
+    TopK = topk_idxs.shape[-1]
+
+    BLOCK_H = 16
+
+    # Ensure topk_idxs is contiguous (expanded tensors with stride=0 cause issues)
+    if not topk_idxs.is_contiguous():
+        topk_idxs = topk_idxs.contiguous()
+
+    # Allocate gradient outputs
+    dq = torch.zeros_like(q)  # bf16, per-query exclusive write
+    dkv = torch.zeros((total_Skv, D_full), dtype=torch.float32, device=q.device)
+
+    num_head_blocks = (H + BLOCK_H - 1) // BLOCK_H
+    grid = (total_Sq, num_head_blocks)
+
+    # BLOCK_K, num_warps, num_stages chosen by @triton.autotune
+    _sparse_attn_bwd_hp_kernel[grid](
+        q, kv, topk_idxs, out, lse, dO,
+        dq, dkv,
+        softmax_scale,
+        total_Sq, total_Skv, TopK, D, d_v,
+        H,
+        q.stride(0), q.stride(1), q.stride(2),
+        kv.stride(0), kv.stride(-1) if kv.dim() > 1 else 1,
+        topk_idxs.stride(0), topk_idxs.stride(2),
+        out.stride(0), out.stride(1), out.stride(2),
+        lse.stride(0), lse.stride(1),
+        BLOCK_H=BLOCK_H,
+    )
+
+    # Compute d_sink in Python (same as existing backward)
+    d_sink = None
+    if attn_sink is not None:
+        p_sink = torch.exp(attn_sink.unsqueeze(0) - lse)  # (total_Sq, H)
+        Di = (dO.float() * out.float()).sum(-1)  # (total_Sq, H)
+        ds_sink = -p_sink * Di  # (total_Sq, H)
+        d_sink = ds_sink.sum(0)  # (H,)
+
+    return {"dq": dq, "dkv": dkv.to(torch.bfloat16), "d_sink": d_sink}
 
 
 def _triton_sparse_attn_fwd(
@@ -491,9 +1049,81 @@ def _triton_sparse_attn_fwd(
         HAS_LSE_IDX=(indexer_topk > 0),
         INDEXER_TOPK=indexer_topk if indexer_topk > 0 else 0,
         BLOCK_K=BLOCK_K,
+        # P1: Software pipelining for 1D forward kernel.
+        num_stages=2,
     )
 
     # Handle edge case: if indexer_topk >= TopK, lse_indexer should equal lse
+    if indexer_topk > 0 and indexer_topk >= TopK:
+        lse_indexer = lse.clone()
+
+    return out, lse, lse_indexer
+
+
+def _triton_sparse_attn_fwd_hp(
+    q: Tensor,
+    kv: Tensor,
+    topk_idxs: Tensor,
+    softmax_scale: float,
+    d_v: int = 512,
+    attn_sink: Optional[Tensor] = None,
+    indexer_topk: int = 0,
+) -> Tuple[Tensor, Tensor, Optional[Tensor]]:
+    """Head-parallel Triton sparse attention forward using WGMMA.
+
+    Exploits MLA shared-index structure: all H heads share the same TopK
+    indices per query position. The KV gather is amortized across heads,
+    and both score and output accumulation use tl.dot() → WGMMA on Hopper.
+
+    This kernel is faster than cuBLAS BMM for all TopK values because:
+    - Zero intermediate GMEM allocation (scores/P never materialize)
+    - Single kernel launch (vs 4 for gather + bmm + softmax + bmm)
+    - KV gather shared across all heads (same memory traffic, more compute reuse)
+
+    Requirements:
+    - Shared indices: topk_idxs.stride(1) == 0
+    - H must be >= 16 and divisible by BLOCK_H(=16)
+    - D and DV must be multiples of 16 (WGMMA alignment)
+
+    BLOCK_K and num_warps are selected by @triton.autotune keyed on (TopK, D, DV, H).
+    """
+    total_Sq, H, D = q.shape
+    total_Skv = kv.shape[0]
+    TopK = topk_idxs.shape[-1]
+
+    BLOCK_H = 16
+
+    # Allocate outputs
+    out = torch.empty((total_Sq, H, d_v), dtype=torch.bfloat16, device=q.device)
+    lse = torch.empty((total_Sq, H), dtype=torch.float32, device=q.device)
+    lse_indexer = None
+    if indexer_topk > 0:
+        lse_indexer = torch.empty((total_Sq, H), dtype=torch.float32, device=q.device)
+
+    # Grid: one program per (query_position, head_block)
+    num_head_blocks = (H + BLOCK_H - 1) // BLOCK_H
+    grid = (total_Sq, num_head_blocks)
+
+    # BLOCK_K, num_warps, num_stages chosen by @triton.autotune
+    _sparse_attn_fwd_hp_kernel[grid](
+        q, kv, topk_idxs, out, lse,
+        attn_sink if attn_sink is not None else torch.empty(0, device=q.device),
+        lse_indexer if lse_indexer is not None else torch.empty(0, device=q.device),
+        softmax_scale,
+        total_Sq, total_Skv, TopK, D, d_v,
+        H,
+        q.stride(0), q.stride(1), q.stride(2),
+        kv.stride(0), kv.stride(-1) if kv.dim() > 1 else 1,
+        topk_idxs.stride(0), topk_idxs.stride(2),
+        out.stride(0), out.stride(1), out.stride(2),
+        lse.stride(0), lse.stride(1),
+        HAS_SINK=(attn_sink is not None),
+        HAS_LSE_IDX=(indexer_topk > 0),
+        INDEXER_TOPK=indexer_topk if indexer_topk > 0 else 0,
+        BLOCK_H=BLOCK_H,
+    )
+
+    # Handle edge case
     if indexer_topk > 0 and indexer_topk >= TopK:
         lse_indexer = lse.clone()
 
@@ -629,17 +1259,31 @@ def _triton_sparse_attn_fwd_2d(
     attn_sink: Optional[Tensor] = None,
     indexer_topk: int = 0,
 ) -> Tuple[Tensor, Tensor, Optional[Tensor]]:
-    """2D-tiled Triton sparse attention forward.
+    """2D-tiled Triton sparse attention forward with tiled softmax.
 
-    Uses BLOCK_Q queries per program for better throughput. Each program
-    handles multiple queries simultaneously, amortizing kernel launch overhead
-    and improving instruction scheduling.
+    Uses BLOCK_Q queries per program and processes KV positions in tiles of
+    BLOCK_K. The tiled approach reduces online softmax rescale operations from
+    TopK to TopK/BLOCK_K, providing significant speedup for large TopK values.
     """
     total_Sq, H, D = q.shape
     total_Skv = kv.shape[0]
     TopK = topk_idxs.shape[-1]
 
     BLOCK_Q = 16
+    # Choose BLOCK_K: balance rescale reduction vs register pressure.
+    # Must be >= 16 for WGMMA alignment, and divide TopK evenly is preferred
+    # (non-divisible case handled by the kernel's `if k_pos < TopK` guard).
+    if TopK <= 32:
+        BLOCK_K = 16
+    elif TopK <= 128:
+        BLOCK_K = 16
+    else:
+        BLOCK_K = 32
+
+    # P1: Choose num_warps for Hopper — more warps help hide memory latency
+    # for the large D=512 gather pattern. 4 warps is optimal for BLOCK_Q=16
+    # with D=512 (each warp handles 4 queries' worth of 512-wide vectors).
+    num_warps = 4 if D <= 512 else 8
 
     # Allocate outputs
     out = torch.empty((total_Sq, H, d_v), dtype=torch.bfloat16, device=q.device)
@@ -668,6 +1312,12 @@ def _triton_sparse_attn_fwd_2d(
         HAS_LSE_IDX=(indexer_topk > 0),
         INDEXER_TOPK=indexer_topk if indexer_topk > 0 else 0,
         BLOCK_Q=BLOCK_Q,
+        BLOCK_K=BLOCK_K,
+        # P1: Software pipelining — Triton inserts async copy + double buffering
+        # for loads within the tiled loop. 2 stages = double buffer (current +
+        # prefetch next), which overlaps memory latency with compute.
+        num_stages=2,
+        num_warps=num_warps,
     )
 
     # Handle edge case
@@ -678,16 +1328,18 @@ def _triton_sparse_attn_fwd_2d(
 
 
 # Threshold: use PyTorch-native path for TopK <= this value.
-# Below this, gather + cuBLAS bmm outperforms the Triton tiled kernel.
-# Above this, the gathered KV tensor becomes too large and Triton's
-# streaming approach is more memory-efficient.
-_PYTORCH_FWD_TOPK_THRESHOLD = 512
+# The HP WGMMA kernel handles all shared-index cases (checked first in dispatch),
+# so this threshold only applies to non-shared or non-aligned fallback scenarios.
+# After P0 (tiled softmax) and P1 (software pipelining) optimizations, the 2D
+# Triton kernel is competitive with PyTorch BMM at lower TopK values. Lowered
+# from 512 to 256: beyond TopK=256, the gathered KV tensor becomes large enough
+# that Triton's streaming (zero intermediate allocation) wins clearly.
+_PYTORCH_FWD_TOPK_THRESHOLD = 256
 
 # Maximum total elements in gathered KV before falling back to Triton.
-# This guards against the case where total_Sq * H * TopK is large enough
-# that the random gather saturates memory bandwidth.
-# 2M elements ensures the gather stays efficient for L2/HBM bandwidth.
-_PYTORCH_FWD_MAX_GATHER_ELEMENTS = 2 * 1024 * 1024
+# Lowered from 2M to 1M: with optimized Triton kernels, the crossover point
+# where Triton's streaming beats cuBLAS BMM shifts earlier.
+_PYTORCH_FWD_MAX_GATHER_ELEMENTS = 1 * 1024 * 1024
 
 
 def triton_sparse_attn_fwd(
@@ -700,11 +1352,13 @@ def triton_sparse_attn_fwd(
     topk_length: Optional[Tensor] = None,
     indexer_topk: int = 0,
 ) -> Tuple[Tensor, Tensor, Optional[Tensor]]:
-    """Sparse attention forward — dispatches to PyTorch-native or Triton kernel.
+    """Sparse attention forward — dispatches to optimal kernel.
 
-    For TopK <= _PYTORCH_FWD_TOPK_THRESHOLD, uses gather + cuBLAS batched matmul
-    which is significantly faster. For very large TopK, falls back to the Triton
-    tiled kernel to avoid excessive memory from materializing gathered KV.
+    Dispatch priority:
+    1. Head-parallel WGMMA kernel (shared indices, H>=16, dims aligned to 16)
+       — uses tl.dot for both score and output, beats cuBLAS for all TopK.
+    2. PyTorch BMM fallback (non-shared indices with small TopK).
+    3. 2D-tiled Triton kernel (non-shared indices with large TopK).
 
     Args:
         q: Query tensor ``(total_S_q, H, D)`` bf16.
@@ -723,16 +1377,24 @@ def triton_sparse_attn_fwd(
     """
     TopK = topk_idxs.shape[-1]
     total_Sq, H = topk_idxs.shape[0], topk_idxs.shape[1]
-    # For shared indices (MLA), actual gather is total_Sq * TopK (not * H)
+    D = q.shape[-1]
     shared = (topk_idxs.stride(1) == 0)
-    gather_elements = total_Sq * TopK if shared else total_Sq * H * TopK
 
+    # Priority 1: Head-parallel WGMMA kernel for shared-index MLA
+    # Requirements: shared indices, H>=16, D and d_v are multiples of 16
+    if shared and H >= 16 and (H % 16 == 0) and (D % 16 == 0) and (d_v % 16 == 0):
+        return _triton_sparse_attn_fwd_hp(
+            q, kv, topk_idxs, softmax_scale, d_v, attn_sink, indexer_topk
+        )
+
+    # Priority 2: PyTorch BMM for small TopK (non-shared or non-aligned case)
+    gather_elements = total_Sq * TopK if shared else total_Sq * H * TopK
     if TopK <= _PYTORCH_FWD_TOPK_THRESHOLD and gather_elements <= _PYTORCH_FWD_MAX_GATHER_ELEMENTS:
         return _pytorch_sparse_attn_fwd(
             q, kv, topk_idxs, softmax_scale, d_v, attn_sink, indexer_topk
         )
 
-    # Use 2D-tiled Triton kernel for better throughput
+    # Priority 3: 2D-tiled Triton kernel for non-shared large TopK
     return _triton_sparse_attn_fwd_2d(
         q, kv, topk_idxs, softmax_scale, d_v, attn_sink, indexer_topk
     )
@@ -749,7 +1411,13 @@ def triton_sparse_attn_bwd(
     d_v: int = 512,
     attn_sink: Optional[Tensor] = None,
 ) -> dict:
-    """Triton sparse attention backward (replaces cudnn.DSA.sparse_attention_backward).
+    """Triton sparse attention backward — per-position kernel.
+
+    NOTE: The HP backward kernel (_triton_sparse_attn_bwd_hp) is disabled because
+    extracting columns from tl.dot outputs produces NaN gradients. When the HP
+    forward was used, the caller should use _bmm_backward with score_dtype=f16
+    (cuBLAS f16×f16→f32 matches tl.dot accumulation). This Triton kernel is used
+    only when the forward also used per-position tl.sum(q*k) score computation.
 
     Args:
         dO: gradient of output ``(total_S_q, H, d_v)`` bf16.
@@ -767,20 +1435,16 @@ def triton_sparse_attn_bwd(
         ``d_sink`` (H,) or None.
     """
     total_Sq, H, D = q.shape
-    total_Skv = kv.shape[0]
-    D_full = kv.shape[-1] if kv.dim() > 1 else D
     TopK = topk_idxs.shape[-1]
 
-    # Ensure topk_idxs is contiguous — expanded tensors (stride=0 from
-    # .expand()) can cause illegal memory access in Triton kernels due to
-    # pointer arithmetic with zero strides.
+    # Per-position Triton backward (original kernel)
+    total_Skv = kv.shape[0]
+    D_full = kv.shape[-1] if kv.dim() > 1 else D
+
+    # Ensure topk_idxs is contiguous
     if not topk_idxs.is_contiguous():
         topk_idxs = topk_idxs.contiguous()
 
-    # Choose BLOCK_K: controls the inner-loop unroll factor.
-    # Smaller BLOCK_K reduces code size / register pressure at the cost of
-    # more outer-loop iterations (runtime overhead is negligible since the
-    # outer loop is a simple counter).
     if TopK <= 32:
         BLOCK_K = 16
     elif TopK <= 128:
@@ -788,8 +1452,6 @@ def triton_sparse_attn_bwd(
     else:
         BLOCK_K = 64
 
-    # Allocate gradient outputs — use f32 for dkv to ensure atomic_add
-    # compatibility and avoid potential bf16 atomic issues.
     dq = torch.zeros_like(q)
     dkv = torch.zeros((total_Skv, D_full), dtype=torch.float32, device=q.device)
 
@@ -810,20 +1472,17 @@ def triton_sparse_attn_bwd(
         lse.stride(0), lse.stride(1),
         HAS_SINK=(attn_sink is not None),
         BLOCK_K=BLOCK_K,
+        num_stages=2,
+        num_warps=4,
     )
 
-    # Compute d_sink if needed (gradient w.r.t. bias-only sink)
+    # Compute d_sink if needed
     d_sink = None
     if attn_sink is not None:
-        # Bias-only sink: s_sink = attn_sink[h], p_sink = exp(s_sink - lse)
-        # The sink contributes no value, so output is weighted sum of TopK values only,
-        # divided by (l_topk + exp(sink - m)). The gradient w.r.t. sink_bias is:
-        # d_sink[h] = sum_q [ p_sink * (-Di) ]  where Di = sum(dO * O)
         p_sink = torch.exp(attn_sink.unsqueeze(0) - lse)  # (total_Sq, H)
         dO_f = dO.float()
         out_f = out.float()
         Di = (dO_f * out_f).sum(-1)  # (total_Sq, H)
-        # Since sink has value=0, dS_sink = p_sink * (0 - Di) = -p_sink * Di
         ds_sink = -p_sink * Di  # (total_Sq, H)
         d_sink = ds_sink.sum(0)  # (H,)
 

--- a/megatron/plugin/dsa_kernel/triton_sparse_attn.py
+++ b/megatron/plugin/dsa_kernel/triton_sparse_attn.py
@@ -110,7 +110,7 @@ def _sparse_attn_fwd_hp_kernel(
         Q_ptr + q_base + h_range[:, None] * stride_q_h + d_range[None, :] * stride_q_d,
         mask=(h_range[:, None] < H) & (d_range[None, :] < D),
         other=0.0,
-    ).to(tl.float16)  # (BLOCK_H, D) f16 for tl.dot
+    ).to(tl.bfloat16)  # (BLOCK_H, D) bf16 for tl.dot
 
     # =========================================================================
     # Online softmax state: per-head running max and sum
@@ -160,10 +160,10 @@ def _sparse_attn_fwd_hp_kernel(
             KV_ptr + kv_bases[:, None] + d_range[None, :] * stride_kv_d,
             mask=valid_mask[:, None] & (d_range[None, :] < D),
             other=0.0,
-        ).to(tl.float16)  # (BLOCK_K, D) f16
+        ).to(tl.bfloat16)  # (BLOCK_K, D) bf16
 
         # --- Score GEMM: (BLOCK_H, D) @ (D, BLOCK_K) → (BLOCK_H, BLOCK_K) ---
-        # tl.dot uses f16 inputs with f32 accumulator (WGMMA on Hopper)
+        # tl.dot uses bf16 inputs with f32 accumulator (WGMMA on Hopper)
         scores = tl.dot(Q_tile, tl.trans(K_tile))  # (BLOCK_H, BLOCK_K) f32
         scores = scores * softmax_scale
 
@@ -195,10 +195,10 @@ def _sparse_attn_fwd_hp_kernel(
             KV_ptr + kv_bases[:, None] + dv_range[None, :] * stride_kv_d,
             mask=valid_mask[:, None] & (dv_range[None, :] < DV),
             other=0.0,
-        ).to(tl.float16)  # (BLOCK_K, DV) f16
+        ).to(tl.bfloat16)  # (BLOCK_K, DV) bf16
 
         # --- Output GEMM: (BLOCK_H, BLOCK_K) @ (BLOCK_K, DV) → (BLOCK_H, DV) ---
-        acc += tl.dot(P_tile.to(tl.float16), V_tile)  # WGMMA, f32 accumulator
+        acc += tl.dot(P_tile.to(tl.bfloat16), V_tile)  # WGMMA, f32 accumulator
 
         # --- Indexer LSE tracking (first INDEXER_TOPK positions) ---
         if HAS_LSE_IDX:
@@ -423,7 +423,7 @@ def triton_sparse_attn_bwd(
 ) -> dict:
     """Sparse attention backward — PyTorch BMM fallback.
 
-    In training, the HP forward path uses _hp_bmm_backward (cuBLAS f16 BMM)
+    In training, the HP forward path uses _hp_bmm_backward (cuBLAS bf16 BMM)
     instead of this function. This entry point exists for API compatibility
     and for non-HP scenarios (testing/decoding).
 

--- a/megatron/plugin/dsa_kernel/triton_sparse_attn.py
+++ b/megatron/plugin/dsa_kernel/triton_sparse_attn.py
@@ -1,13 +1,20 @@
 # Copyright (c) 2026, FlagOS Contributors. All rights reserved.
 
 """
-Triton sparse attention forward and backward kernels for DSA.
+Triton sparse attention HP (Head-Parallel) WGMMA forward kernel for DSA training.
 
-Replaces the dependency on ``flash_mla.flash_mla_sparse_fwd`` and
-``cudnn.DSA.sparse_attention_backward`` with pure Triton implementations.
+Replaces the dependency on ``flash_mla.flash_mla_sparse_fwd`` with a pure Triton
+implementation optimized for Hopper (SM90) WGMMA tensor core operations.
 
-The kernels operate on "flat" (unbatched) tensors where Q and KV are concatenated
+The kernel operates on "flat" (unbatched) tensors where Q and KV are concatenated
 across the batch dimension, and topk_idxs provides global indices into KV.
+
+Training requirements (always satisfied):
+  - Shared indices: all heads use the same TopK indices (MLA structure)
+  - H >= 16, H % 16 == 0, D % 16 == 0, d_v % 16 == 0
+
+Non-HP fallback (forward/backward) uses PyTorch BMM in
+``megatron.plugin.dsa_kernel.legacy.pytorch_sparse_attn``.
 """
 
 from __future__ import annotations
@@ -19,149 +26,6 @@ from torch import Tensor
 
 import triton
 import triton.language as tl
-
-
-# ---------------------------------------------------------------------------
-# Forward kernel
-# ---------------------------------------------------------------------------
-
-
-@triton.jit
-def _sparse_attn_fwd_kernel(
-    Q_ptr, KV_ptr, IDX_ptr, OUT_ptr, LSE_ptr,
-    SINK_ptr, LSE_IDX_ptr,
-    softmax_scale: tl.constexpr,
-    total_Sq, total_Skv, TopK: tl.constexpr, D: tl.constexpr, DV: tl.constexpr,
-    H: tl.constexpr,
-    stride_q_s, stride_q_h, stride_q_d,
-    stride_kv_s, stride_kv_d,
-    stride_idx_s, stride_idx_h, stride_idx_k,
-    stride_out_s, stride_out_h, stride_out_d,
-    stride_lse_s, stride_lse_h,
-    HAS_SINK: tl.constexpr,
-    HAS_LSE_IDX: tl.constexpr,
-    INDEXER_TOPK: tl.constexpr,
-    BLOCK_K: tl.constexpr,
-):
-    """Sparse attention forward with tiled KV gather.
-
-    Each program handles one (query, head) pair. KV positions are processed in
-    tiles of BLOCK_K to amortize gather overhead and enable vectorized loads.
-    Uses online softmax across tiles for numerical stability.
-    """
-    pid_q = tl.program_id(0)
-    pid_h = tl.program_id(1)
-
-    if pid_q >= total_Sq:
-        return
-
-    # Load query vector: (D,)
-    q_offset = pid_q * stride_q_s + pid_h * stride_q_h
-    d_range = tl.arange(0, D)
-    q = tl.load(Q_ptr + q_offset + d_range * stride_q_d, mask=d_range < D, other=0.0)
-    q = (q * softmax_scale).to(tl.float32)
-
-    # Online softmax state
-    m_i = tl.full([], float("-inf"), dtype=tl.float32)
-    l_i = tl.full([], 0.0, dtype=tl.float32)
-    # Accumulator for output (DV,)
-    dv_range = tl.arange(0, DV)
-    acc = tl.zeros([DV], dtype=tl.float32)
-
-    # Optional: bias-only sink
-    if HAS_SINK:
-        sink_bias = tl.load(SINK_ptr + pid_h)
-        m_new = tl.maximum(m_i, sink_bias)
-        l_i = l_i * tl.exp(m_i - m_new) + tl.exp(sink_bias - m_new)
-        acc = acc * tl.exp(m_i - m_new)
-        m_i = m_new
-
-    # Indexer LSE state (tracks first INDEXER_TOPK positions)
-    if HAS_LSE_IDX:
-        m_idx = tl.full([], float("-inf"), dtype=tl.float32)
-        l_idx = tl.full([], 0.0, dtype=tl.float32)
-
-    # Process KV positions in tiles of BLOCK_K
-    idx_base = pid_q * stride_idx_s + pid_h * stride_idx_h
-    k_range = tl.arange(0, BLOCK_K)
-
-    for tile_start in range(0, TopK, BLOCK_K):
-        # Load a tile of indices: (BLOCK_K,)
-        tile_offsets = tile_start + k_range
-        idx_mask = tile_offsets < TopK
-        kv_indices = tl.load(
-            IDX_ptr + idx_base + tile_offsets * stride_idx_k,
-            mask=idx_mask, other=-1
-        )
-        valid_mask = (kv_indices >= 0) & idx_mask
-        safe_indices = tl.where(valid_mask, kv_indices, 0)
-
-        # Gather K tile: (BLOCK_K, D) — each row is one KV position's key
-        kv_bases = safe_indices * stride_kv_s  # (BLOCK_K,)
-        k_tile = tl.load(
-            KV_ptr + kv_bases[:, None] + d_range[None, :] * stride_kv_d,
-            mask=valid_mask[:, None] & (d_range[None, :] < D),
-            other=0.0,
-        ).to(tl.float32)  # (BLOCK_K, D)
-
-        # Compute scores: q (D,) @ k_tile^T (D, BLOCK_K) -> (BLOCK_K,)
-        scores = tl.sum(q[None, :] * k_tile, axis=1)  # (BLOCK_K,)
-        scores = tl.where(valid_mask, scores, float("-inf"))
-
-        # Tile-level online softmax update
-        tile_max = tl.max(scores)
-        m_new = tl.maximum(m_i, tile_max)
-        exp_old = tl.exp(m_i - m_new)
-        exp_scores = tl.exp(scores - m_new)  # (BLOCK_K,)
-        # Zero out invalid positions
-        exp_scores = tl.where(valid_mask, exp_scores, 0.0)
-        tile_sum = tl.sum(exp_scores)
-
-        # Gather V tile: (BLOCK_K, DV)
-        v_tile = tl.load(
-            KV_ptr + kv_bases[:, None] + dv_range[None, :] * stride_kv_d,
-            mask=valid_mask[:, None] & (dv_range[None, :] < DV),
-            other=0.0,
-        ).to(tl.float32)  # (BLOCK_K, DV)
-
-        # Weighted sum: exp_scores (BLOCK_K,) @ v_tile (BLOCK_K, DV) -> (DV,)
-        tile_out = tl.sum(exp_scores[:, None] * v_tile, axis=0)  # (DV,)
-
-        # Update accumulators
-        l_i = l_i * exp_old + tile_sum
-        acc = acc * exp_old + tile_out
-        m_i = m_new
-
-        # Update indexer LSE for tiles within INDEXER_TOPK range
-        if HAS_LSE_IDX:
-            if tile_start < INDEXER_TOPK:
-                # Only count positions within [0, INDEXER_TOPK)
-                idx_valid = valid_mask & (tile_offsets < INDEXER_TOPK)
-                idx_scores = tl.where(idx_valid, scores, float("-inf"))
-                idx_tile_max = tl.max(idx_scores)
-                m_idx_new = tl.maximum(m_idx, idx_tile_max)
-                exp_idx_scores = tl.exp(idx_scores - m_idx_new)
-                exp_idx_scores = tl.where(idx_valid, exp_idx_scores, 0.0)
-                l_idx = l_idx * tl.exp(m_idx - m_idx_new) + tl.sum(exp_idx_scores)
-                m_idx = m_idx_new
-
-    # Finalize: out = acc / l_i
-    safe_l = tl.where(l_i > 0.0, l_i, 1.0)
-    out = acc / safe_l
-
-    # Store output
-    out_offset = pid_q * stride_out_s + pid_h * stride_out_h
-    tl.store(OUT_ptr + out_offset + dv_range * stride_out_d, out.to(tl.bfloat16), mask=dv_range < DV)
-
-    # Store LSE = m_i + log(l_i)
-    lse_val = m_i + tl.log(safe_l)
-    tl.store(LSE_ptr + pid_q * stride_lse_s + pid_h * stride_lse_h, lse_val)
-
-    # Store indexer LSE if needed
-    if HAS_LSE_IDX:
-        safe_l_idx = tl.where(l_idx > 0.0, l_idx, 1.0)
-        lse_idx_val = m_idx + tl.log(safe_l_idx)
-        tl.store(LSE_IDX_ptr + pid_q * stride_lse_s + pid_h * stride_lse_h, lse_idx_val)
 
 
 # ---------------------------------------------------------------------------
@@ -396,668 +260,10 @@ def _sparse_attn_fwd_hp_kernel(
         )
 
 
-# ---------------------------------------------------------------------------
-# 2D-Tiled Forward kernel (BLOCK_Q queries per program)
-# ---------------------------------------------------------------------------
-
-
-@triton.jit
-def _sparse_attn_fwd_2d_kernel(
-    Q_ptr, KV_ptr, IDX_ptr, OUT_ptr, LSE_ptr,
-    SINK_ptr, LSE_IDX_ptr,
-    softmax_scale: tl.constexpr,
-    total_Sq, total_Skv, TopK: tl.constexpr, D: tl.constexpr, DV: tl.constexpr,
-    H: tl.constexpr,
-    stride_q_s, stride_q_h, stride_q_d,
-    stride_kv_s, stride_kv_d,
-    stride_idx_s, stride_idx_h, stride_idx_k,
-    stride_out_s, stride_out_h, stride_out_d,
-    stride_lse_s, stride_lse_h,
-    HAS_SINK: tl.constexpr,
-    HAS_LSE_IDX: tl.constexpr,
-    INDEXER_TOPK: tl.constexpr,
-    BLOCK_Q: tl.constexpr,
-    BLOCK_K: tl.constexpr,
-):
-    """2D-tiled sparse attention forward with tiled online softmax.
-
-    Each program handles BLOCK_Q queries for one head. KV positions are
-    processed in tiles of BLOCK_K. Within each tile, scores are gathered into
-    a (BLOCK_Q, BLOCK_K) matrix and a single tiled online-softmax update is
-    performed, reducing the number of expensive accumulator rescales from TopK
-    to TopK/BLOCK_K.
-
-    P0 Hopper optimization: tiled softmax reduces rescale overhead by BLOCK_K×.
-    The tiled structure also enables better instruction scheduling and provides
-    the foundation for future tl.dot()-based WGMMA when shared indices are
-    available.
-    """
-    pid_qblock = tl.program_id(0)
-    pid_h = tl.program_id(1)
-
-    # Range of queries this program handles
-    q_start = pid_qblock * BLOCK_Q
-    q_range = tl.arange(0, BLOCK_Q)
-    q_ids = q_start + q_range  # (BLOCK_Q,)
-    q_valid = q_ids < total_Sq
-
-    # Load Q block: (BLOCK_Q, D)
-    d_range = tl.arange(0, D)
-    q_offsets = q_ids[:, None] * stride_q_s + pid_h * stride_q_h + d_range[None, :] * stride_q_d
-    q_block = tl.load(
-        Q_ptr + q_offsets,
-        mask=q_valid[:, None] & (d_range[None, :] < D),
-        other=0.0,
-    ).to(tl.float32) * softmax_scale  # (BLOCK_Q, D)
-
-    # Online softmax state per query: (BLOCK_Q,)
-    m_i = tl.full([BLOCK_Q], float("-inf"), dtype=tl.float32)
-    l_i = tl.zeros([BLOCK_Q], dtype=tl.float32)
-    # Output accumulator: (BLOCK_Q, DV)
-    dv_range = tl.arange(0, DV)
-    acc = tl.zeros([BLOCK_Q, DV], dtype=tl.float32)
-
-    # Optional: bias-only sink (same for all queries in block, per head)
-    if HAS_SINK:
-        sink_bias = tl.load(SINK_ptr + pid_h)
-        sink_vec = tl.full([BLOCK_Q], sink_bias, dtype=tl.float32)
-        m_new = tl.maximum(m_i, sink_vec)
-        l_i = l_i * tl.exp(m_i - m_new) + tl.exp(sink_vec - m_new)
-        acc = acc * tl.exp(m_i - m_new)[:, None]
-        m_i = m_new
-
-    # Indexer LSE state
-    if HAS_LSE_IDX:
-        m_idx = tl.full([BLOCK_Q], float("-inf"), dtype=tl.float32)
-        l_idx = tl.zeros([BLOCK_Q], dtype=tl.float32)
-
-    # Tiled iteration over TopK positions in groups of BLOCK_K.
-    # Each tile: gather K+V, compute scores, find tile max, compute weighted V.
-    # Uses single-pass with deferred V accumulation to enable software pipelining.
-    #
-    # P1 optimization: The loop structure is designed for Triton's software
-    # pipelining (num_stages). The loads at the start of each k_off iteration
-    # can overlap with the prior iteration's compute.
-    for tile_start in range(0, TopK, BLOCK_K):
-
-        # === Phase 1: Gather K, compute scores, find tile max ===
-        # We need tile_max before computing exp weights. First pass over
-        # BLOCK_K positions to find the max score.
-        tile_max = tl.full([BLOCK_Q], float("-inf"), dtype=tl.float32)
-
-        for k_off in range(BLOCK_K):
-            k_pos = tile_start + k_off
-            if k_pos < TopK:
-                # Load index for each query
-                idx_offsets = q_ids * stride_idx_s + pid_h * stride_idx_h + k_pos * stride_idx_k
-                kv_indices = tl.load(IDX_ptr + idx_offsets, mask=q_valid, other=-1)
-                valid_q = (kv_indices >= 0) & q_valid
-                safe_idx = tl.where(valid_q, kv_indices, 0)
-
-                # Gather K: (BLOCK_Q, D)
-                kv_bases = safe_idx * stride_kv_s
-                k_vec = tl.load(
-                    KV_ptr + kv_bases[:, None] + d_range[None, :] * stride_kv_d,
-                    mask=valid_q[:, None] & (d_range[None, :] < D),
-                    other=0.0,
-                ).to(tl.float32)
-
-                # Score: dot product per query
-                score = tl.sum(q_block * k_vec, axis=1)  # (BLOCK_Q,)
-                score = tl.where(valid_q, score, float("-inf"))
-                tile_max = tl.maximum(tile_max, score)
-
-        # === Softmax rescale: ONE per tile ===
-        m_new = tl.maximum(m_i, tile_max)
-        exp_old = tl.exp(m_i - m_new)  # (BLOCK_Q,)
-        # Rescale accumulator once for entire tile
-        acc = acc * exp_old[:, None]
-        l_i = l_i * exp_old
-
-        # === Phase 2: Recompute scores, gather V, accumulate ===
-        # Second pass: compute exp weights and weighted V sum.
-        # Loads here can be pipelined by Triton's num_stages with Phase 1
-        # loads of the *next* tile iteration.
-        tile_sum = tl.zeros([BLOCK_Q], dtype=tl.float32)
-
-        for k_off in range(BLOCK_K):
-            k_pos = tile_start + k_off
-            if k_pos < TopK:
-                # Re-load index and gather K+V
-                idx_offsets = q_ids * stride_idx_s + pid_h * stride_idx_h + k_pos * stride_idx_k
-                kv_indices = tl.load(IDX_ptr + idx_offsets, mask=q_valid, other=-1)
-                valid_q = (kv_indices >= 0) & q_valid
-                safe_idx = tl.where(valid_q, kv_indices, 0)
-                kv_bases = safe_idx * stride_kv_s
-
-                # Gather K and recompute score
-                k_vec = tl.load(
-                    KV_ptr + kv_bases[:, None] + d_range[None, :] * stride_kv_d,
-                    mask=valid_q[:, None] & (d_range[None, :] < D),
-                    other=0.0,
-                ).to(tl.float32)
-                score = tl.sum(q_block * k_vec, axis=1)
-                score = tl.where(valid_q, score, float("-inf"))
-
-                # Exp weight relative to m_new
-                w = tl.exp(score - m_new)  # (BLOCK_Q,)
-
-                # Gather V: (BLOCK_Q, DV)
-                v_vec = tl.load(
-                    KV_ptr + kv_bases[:, None] + dv_range[None, :] * stride_kv_d,
-                    mask=valid_q[:, None] & (dv_range[None, :] < DV),
-                    other=0.0,
-                ).to(tl.float32)
-
-                # Accumulate weighted V
-                acc += w[:, None] * v_vec
-                tile_sum += w
-
-                # Indexer LSE update
-                if HAS_LSE_IDX:
-                    if k_pos < INDEXER_TOPK:
-                        m_idx_new = tl.maximum(m_idx, score)
-                        exp_idx = tl.exp(score - m_idx_new)
-                        l_idx = l_idx * tl.exp(m_idx - m_idx_new) + exp_idx
-                        m_idx = m_idx_new
-
-        # Update softmax denominator
-        l_i = l_i + tile_sum
-        m_i = m_new
-
-    # Finalize output: (BLOCK_Q, DV)
-    safe_l = tl.where(l_i > 0.0, l_i, 1.0)
-    out = acc / safe_l[:, None]
-
-    # Store output
-    out_offsets = q_ids[:, None] * stride_out_s + pid_h * stride_out_h + dv_range[None, :] * stride_out_d
-    tl.store(
-        OUT_ptr + out_offsets,
-        out.to(tl.bfloat16),
-        mask=q_valid[:, None] & (dv_range[None, :] < DV),
-    )
-
-    # Store LSE: (BLOCK_Q,)
-    lse_vals = m_i + tl.log(safe_l)
-    lse_offsets = q_ids * stride_lse_s + pid_h * stride_lse_h
-    tl.store(LSE_ptr + lse_offsets, lse_vals, mask=q_valid)
-
-    # Store indexer LSE
-    if HAS_LSE_IDX:
-        safe_l_idx = tl.where(l_idx > 0.0, l_idx, 1.0)
-        lse_idx_vals = m_idx + tl.log(safe_l_idx)
-        tl.store(LSE_IDX_ptr + lse_offsets, lse_idx_vals, mask=q_valid)
-
 
 # ---------------------------------------------------------------------------
-# Backward kernel
+# HP Forward Wrapper
 # ---------------------------------------------------------------------------
-
-
-@triton.jit
-def _sparse_attn_bwd_kernel(
-    Q_ptr, KV_ptr, IDX_ptr, OUT_ptr, LSE_ptr, DO_ptr,
-    DQ_ptr, DKV_ptr, DSINK_ptr, SINK_ptr,
-    softmax_scale: tl.constexpr,
-    total_Sq, total_Skv, TopK: tl.constexpr, D: tl.constexpr, DV: tl.constexpr,
-    H: tl.constexpr,
-    stride_q_s, stride_q_h, stride_q_d,
-    stride_kv_s, stride_kv_d,
-    stride_idx_s, stride_idx_h, stride_idx_k,
-    stride_out_s, stride_out_h, stride_out_d,
-    stride_lse_s, stride_lse_h,
-    HAS_SINK: tl.constexpr,
-    BLOCK_K: tl.constexpr = 32,
-):
-    """Sparse attention backward kernel.
-
-    Recomputes attention weights from Q, KV, LSE, then computes:
-    - dQ via dS @ K
-    - dK via dS^T @ Q (atomic add since multiple queries may reference same KV)
-    - dV via P^T @ dO (atomic add)
-    where dS = P * (dO @ V^T - D_i), D_i = rowsum(dO * O).
-
-    TopK is constexpr so that `range(0, TopK, BLOCK_K)` is fully resolved at
-    compile time.  Previous versions had TopK as a runtime parameter with a
-    two-level loop (`num_full_tiles = TopK // BLOCK_K`), but runtime integer
-    division and runtime loop bounds in Triton can produce undefined behavior
-    depending on the compiler version, leading to NaN gradients.
-    """
-    pid_q = tl.program_id(0)
-    pid_h = tl.program_id(1)
-
-    if pid_q >= total_Sq:
-        return
-
-    # Load query
-    q_offset = pid_q * stride_q_s + pid_h * stride_q_h
-    d_range = tl.arange(0, D)
-    dv_range = tl.arange(0, DV)
-    q = tl.load(Q_ptr + q_offset + d_range * stride_q_d, mask=d_range < D, other=0.0).to(tl.float32)
-
-    # Load dO and O for this position
-    out_offset = pid_q * stride_out_s + pid_h * stride_out_h
-    dO = tl.load(DO_ptr + out_offset + dv_range * stride_out_d, mask=dv_range < DV, other=0.0).to(tl.float32)
-    O = tl.load(OUT_ptr + out_offset + dv_range * stride_out_d, mask=dv_range < DV, other=0.0).to(tl.float32)
-
-    # Load LSE
-    lse_val = tl.load(LSE_ptr + pid_q * stride_lse_s + pid_h * stride_lse_h)
-
-    # D_i = sum(dO * O)
-    Di = tl.sum(dO * O)
-
-    # Accumulate dQ
-    dq_acc = tl.zeros([D], dtype=tl.float32)
-
-    # Process TopK KV positions in tiles of BLOCK_K (both TopK and BLOCK_K are
-    # constexpr, so `range(0, TopK, BLOCK_K)` is fully resolved at compile time).
-    idx_base = pid_q * stride_idx_s + pid_h * stride_idx_h
-
-    for tile_start in range(0, TopK, BLOCK_K):
-        for k_off in range(BLOCK_K):
-            k_pos = tile_start + k_off
-            if k_pos < TopK:
-                kv_idx = tl.load(IDX_ptr + idx_base + k_pos * stride_idx_k)
-
-                is_valid = kv_idx >= 0
-                safe_idx = tl.where(is_valid, kv_idx, 0)
-
-                kv_base = safe_idx * stride_kv_s
-                k_vec = tl.load(KV_ptr + kv_base + d_range * stride_kv_d, mask=d_range < D, other=0.0).to(tl.float32)
-                v_vec = tl.load(KV_ptr + kv_base + dv_range * stride_kv_d, mask=dv_range < DV, other=0.0).to(tl.float32)
-
-                # Recompute attention probability
-                s = tl.sum(q * k_vec) * softmax_scale
-                p = tl.where(is_valid, tl.exp(s - lse_val), 0.0)
-
-                # dS = P * (dO @ V^T - Di)
-                dov = tl.sum(dO * v_vec)
-                ds = p * (dov - Di) * softmax_scale
-
-                # dQ += ds * K
-                dq_acc += ds * k_vec
-
-                # dK += ds * Q (atomic add to shared KV)
-                tl.atomic_add(DKV_ptr + kv_base + d_range * stride_kv_d, ds * q, mask=(d_range < D) & is_valid)
-
-                # dV += p * dO (atomic add)
-                tl.atomic_add(DKV_ptr + kv_base + dv_range * stride_kv_d, p * dO, mask=(dv_range < DV) & is_valid)
-
-    # Store dQ
-    tl.store(DQ_ptr + q_offset + d_range * stride_q_d, dq_acc.to(tl.bfloat16), mask=d_range < D)
-
-
-# ---------------------------------------------------------------------------
-# Head-Parallel Backward kernel (WGMMA, shared indices)
-# ---------------------------------------------------------------------------
-
-
-def _hp_bwd_configs():
-    """Autotune configs for HP backward kernel.
-
-    Backward has higher register pressure than forward (holds dQ_acc + Q + dO),
-    so larger BLOCK_K or more warps can help depending on TopK.
-    """
-    configs = []
-    for block_k in [16, 32, 64]:
-        for nw in [4, 8]:
-            configs.append(
-                triton.Config({"BLOCK_K": block_k}, num_warps=nw, num_stages=2)
-            )
-    return configs
-
-
-@triton.autotune(
-    configs=_hp_bwd_configs(),
-    key=["TopK", "D", "DV", "H"],
-)
-@triton.jit
-def _sparse_attn_bwd_hp_kernel(
-    Q_ptr, KV_ptr, IDX_ptr, OUT_ptr, LSE_ptr, DO_ptr,
-    DQ_ptr, DKV_ptr,
-    softmax_scale,
-    total_Sq, total_Skv, TopK: tl.constexpr, D: tl.constexpr, DV: tl.constexpr,
-    H: tl.constexpr,
-    stride_q_s, stride_q_h, stride_q_d,
-    stride_kv_s, stride_kv_d,
-    stride_idx_s, stride_idx_k,
-    stride_out_s, stride_out_h, stride_out_d,
-    stride_lse_s, stride_lse_h,
-    BLOCK_H: tl.constexpr,
-    BLOCK_K: tl.constexpr,
-):
-    """Head-parallel sparse attention backward using tl.dot (WGMMA on Hopper).
-
-    Exploits MLA shared-index structure (same as forward HP kernel). Computes
-    gradients dQ, dK, dV using WGMMA matrix multiplies:
-
-    Per tile of BLOCK_K KV positions:
-      Score recompute: Q(BLOCK_H, D) @ K^T(D, BLOCK_K) → (BLOCK_H, BLOCK_K) WGMMA
-      dOV:            dO(BLOCK_H, DV) @ V^T(DV, BLOCK_K) → (BLOCK_H, BLOCK_K) WGMMA
-      dQ accumulate:  dS(BLOCK_H, BLOCK_K) @ K(BLOCK_K, D) → (BLOCK_H, D)    WGMMA
-      dK per tile:    dS^T(BLOCK_K, BLOCK_H) @ Q(BLOCK_H, D) → (BLOCK_K, D)  WGMMA
-      dV per tile:    P^T(BLOCK_K, BLOCK_H) @ dO(BLOCK_H, DV) → (BLOCK_K, DV) WGMMA
-
-    dQ is stored directly (per-query, no conflicts).
-    dK and dV use f32 atomic_add (multiple queries write to same KV position).
-
-    P0 optimization: Tiled score recomputation — one tl.dot per tile vs per-position.
-    P1 optimization: num_stages=2 for software pipelining of KV gather.
-    """
-    pid_q = tl.program_id(0)
-    pid_hb = tl.program_id(1)
-
-    if pid_q >= total_Sq:
-        return
-
-    h_start = pid_hb * BLOCK_H
-    h_range = h_start + tl.arange(0, BLOCK_H)  # (BLOCK_H,)
-    d_range = tl.arange(0, D)                   # (D,)
-    dv_range = tl.arange(0, DV)                 # (DV,)
-
-    # =========================================================================
-    # Load Q, dO, O, LSE — all reused across TopK tiles
-    # =========================================================================
-    q_base = pid_q * stride_q_s
-    out_base = pid_q * stride_out_s
-
-    # Q_tile: (BLOCK_H, D) f16 — for score recompute and dK
-    Q_tile = tl.load(
-        Q_ptr + q_base + h_range[:, None] * stride_q_h + d_range[None, :] * stride_q_d,
-        mask=(h_range[:, None] < H) & (d_range[None, :] < D),
-        other=0.0,
-    ).to(tl.float16)  # (BLOCK_H, D)
-
-    # dO_tile: (BLOCK_H, DV) f16 — for dOV and dV
-    dO_tile = tl.load(
-        DO_ptr + out_base + h_range[:, None] * stride_out_h + dv_range[None, :] * stride_out_d,
-        mask=(h_range[:, None] < H) & (dv_range[None, :] < DV),
-        other=0.0,
-    ).to(tl.float16)  # (BLOCK_H, DV)
-
-    # O_tile: (BLOCK_H, DV) f32 — for Di computation
-    O_tile = tl.load(
-        OUT_ptr + out_base + h_range[:, None] * stride_out_h + dv_range[None, :] * stride_out_d,
-        mask=(h_range[:, None] < H) & (dv_range[None, :] < DV),
-        other=0.0,
-    ).to(tl.float32)  # (BLOCK_H, DV)
-
-    # LSE: (BLOCK_H,) f32
-    lse_base = pid_q * stride_lse_s
-    lse_vals = tl.load(
-        LSE_ptr + lse_base + h_range * stride_lse_h,
-        mask=h_range < H,
-        other=0.0,
-    )  # (BLOCK_H,) f32
-
-    # Di = sum(dO * O, axis=-1) per head: (BLOCK_H,) f32
-    Di = tl.sum(dO_tile.to(tl.float32) * O_tile, axis=1)  # (BLOCK_H,)
-
-    # dQ accumulator: (BLOCK_H, D) f32 — stored once at end
-    dq_acc = tl.zeros([BLOCK_H, D], dtype=tl.float32)
-
-    # =========================================================================
-    # Tiled iteration over TopK positions
-    # =========================================================================
-    idx_base = pid_q * stride_idx_s
-
-    for tile_start in range(0, TopK, BLOCK_K):
-        k_range = tile_start + tl.arange(0, BLOCK_K)  # (BLOCK_K,)
-        k_valid = k_range < TopK
-
-        # --- Load BLOCK_K indices (shared across heads) ---
-        kv_indices = tl.load(
-            IDX_ptr + idx_base + k_range * stride_idx_k,
-            mask=k_valid,
-            other=-1,
-        )  # (BLOCK_K,) int32
-        valid_mask = (kv_indices >= 0) & k_valid  # (BLOCK_K,)
-        safe_indices = tl.where(valid_mask, kv_indices, 0)
-
-        # --- Gather K tile: (BLOCK_K, D) f16 ---
-        kv_bases = safe_indices * stride_kv_s  # (BLOCK_K,)
-        K_tile = tl.load(
-            KV_ptr + kv_bases[:, None] + d_range[None, :] * stride_kv_d,
-            mask=valid_mask[:, None] & (d_range[None, :] < D),
-            other=0.0,
-        ).to(tl.float16)  # (BLOCK_K, D)
-
-        # --- Gather V tile: (BLOCK_K, DV) f16 ---
-        V_tile = tl.load(
-            KV_ptr + kv_bases[:, None] + dv_range[None, :] * stride_kv_d,
-            mask=valid_mask[:, None] & (dv_range[None, :] < DV),
-            other=0.0,
-        ).to(tl.float16)  # (BLOCK_K, DV)
-
-        # --- Score GEMM: (BLOCK_H, D) @ (D, BLOCK_K) → (BLOCK_H, BLOCK_K) ---
-        scores = tl.dot(Q_tile, tl.trans(K_tile))  # (BLOCK_H, BLOCK_K) f32
-        scores = scores * softmax_scale
-
-        # --- Recompute P = exp(scores - lse) * valid_mask ---
-        P = tl.exp(scores - lse_vals[:, None])  # (BLOCK_H, BLOCK_K) f32
-        P = tl.where(valid_mask[None, :], P, 0.0)
-
-        # --- dOV GEMM: (BLOCK_H, DV) @ (DV, BLOCK_K) → (BLOCK_H, BLOCK_K) ---
-        # dOV[h, k] = sum_d(dO[h, d] * V[k, d])
-        dOV = tl.dot(dO_tile, tl.trans(V_tile))  # (BLOCK_H, BLOCK_K) f32
-
-        # --- dS = P * (dOV - Di) * softmax_scale ---
-        dS = P * (dOV - Di[:, None]) * softmax_scale  # (BLOCK_H, BLOCK_K) f32
-
-        # --- dQ GEMM: (BLOCK_H, BLOCK_K) @ (BLOCK_K, D) → (BLOCK_H, D) ---
-        dq_acc += tl.dot(dS.to(tl.float16), K_tile)  # WGMMA, f32 accumulator
-
-        # --- dK and dV via per-position reduction ---
-        # We have P(BLOCK_H, BLOCK_K) and dS(BLOCK_H, BLOCK_K) computed from
-        # tl.dot scores (consistent with forward). For each position k:
-        #   dK[k] = sum_h(dS[h,k] * Q[h,:])  → (D,)
-        #   dV[k] = sum_h(P[h,k] * dO[h,:])  → (DV,)
-        # Extract column k from P/dS using a compile-time mask (k_off is unrolled).
-        for k_off in range(BLOCK_K):
-            k_pos = tile_start + k_off
-            if k_pos < TopK:
-                kv_idx = tl.load(IDX_ptr + idx_base + k_pos * stride_idx_k)
-                is_valid = kv_idx >= 0
-                if is_valid:
-                    kv_offset = kv_idx * stride_kv_s
-
-                    # Extract column k_off from dS and P using compile-time mask.
-                    # Since k_off is a compile-time constant (range unrolled),
-                    # the mask `tl.arange(0, BLOCK_K) == k_off` is resolved at
-                    # compile time and the tl.sum reduces to selecting one column.
-                    col_mask = tl.arange(0, BLOCK_K) == k_off  # (BLOCK_K,) compile-time
-                    # dS_col[h] = dS[h, k_off]
-                    dS_col = tl.sum(tl.where(col_mask[None, :], dS, 0.0), axis=1)  # (BLOCK_H,)
-                    # P_col[h] = P[h, k_off]
-                    P_col = tl.sum(tl.where(col_mask[None, :], P, 0.0), axis=1)  # (BLOCK_H,)
-
-                    # dK = sum_h(dS_col[h] * Q[h,:]) → (D,)
-                    dK_vec = tl.sum(dS_col[:, None] * Q_tile.to(tl.float32), axis=0)  # (D,)
-                    # dV = sum_h(P_col[h] * dO[h,:]) → (DV,)
-                    dV_vec = tl.sum(P_col[:, None] * dO_tile.to(tl.float32), axis=0)  # (DV,)
-
-                    tl.atomic_add(
-                        DKV_ptr + kv_offset + d_range * stride_kv_d,
-                        dK_vec,
-                        mask=d_range < D,
-                    )
-                    tl.atomic_add(
-                        DKV_ptr + kv_offset + dv_range * stride_kv_d,
-                        dV_vec,
-                        mask=dv_range < DV,
-                    )
-
-    # =========================================================================
-    # Store dQ (non-atomic, per-query exclusive)
-    # =========================================================================
-    tl.store(
-        DQ_ptr + q_base + h_range[:, None] * stride_q_h + d_range[None, :] * stride_q_d,
-        dq_acc.to(tl.bfloat16),
-        mask=(h_range[:, None] < H) & (d_range[None, :] < D),
-    )
-
-
-# ---------------------------------------------------------------------------
-# Python wrapper functions
-# ---------------------------------------------------------------------------
-
-
-def _triton_sparse_attn_bwd_hp(
-    dO: Tensor,
-    q: Tensor,
-    kv: Tensor,
-    out: Tensor,
-    lse: Tensor,
-    topk_idxs: Tensor,
-    softmax_scale: float,
-    d_v: int = 512,
-    attn_sink: Optional[Tensor] = None,
-) -> dict:
-    """Head-parallel WGMMA backward for sparse attention.
-
-    Uses tl.dot() for all five GEMMs in the backward pass:
-    - Score recompute: Q @ K^T
-    - dOV: dO @ V^T
-    - dQ: dS @ K
-    - dK: dS^T @ Q
-    - dV: P^T @ dO
-
-    Requirements (same as HP forward):
-    - Shared indices: topk_idxs.stride(1) == 0
-    - H >= 16, divisible by BLOCK_H(=16)
-    - D, DV multiples of 16
-
-    BLOCK_K and num_warps are selected by @triton.autotune keyed on (TopK, D, DV, H).
-    """
-    total_Sq, H, D = q.shape
-    total_Skv = kv.shape[0]
-    D_full = kv.shape[-1] if kv.dim() > 1 else D
-    TopK = topk_idxs.shape[-1]
-
-    BLOCK_H = 16
-
-    # Ensure topk_idxs is contiguous (expanded tensors with stride=0 cause issues)
-    if not topk_idxs.is_contiguous():
-        topk_idxs = topk_idxs.contiguous()
-
-    # Allocate gradient outputs
-    dq = torch.zeros_like(q)  # bf16, per-query exclusive write
-    dkv = torch.zeros((total_Skv, D_full), dtype=torch.float32, device=q.device)
-
-    num_head_blocks = (H + BLOCK_H - 1) // BLOCK_H
-    grid = (total_Sq, num_head_blocks)
-
-    # BLOCK_K, num_warps, num_stages chosen by @triton.autotune
-    _sparse_attn_bwd_hp_kernel[grid](
-        q, kv, topk_idxs, out, lse, dO,
-        dq, dkv,
-        softmax_scale,
-        total_Sq, total_Skv, TopK, D, d_v,
-        H,
-        q.stride(0), q.stride(1), q.stride(2),
-        kv.stride(0), kv.stride(-1) if kv.dim() > 1 else 1,
-        topk_idxs.stride(0), topk_idxs.stride(2),
-        out.stride(0), out.stride(1), out.stride(2),
-        lse.stride(0), lse.stride(1),
-        BLOCK_H=BLOCK_H,
-    )
-
-    # Compute d_sink in Python (same as existing backward)
-    d_sink = None
-    if attn_sink is not None:
-        p_sink = torch.exp(attn_sink.unsqueeze(0) - lse)  # (total_Sq, H)
-        Di = (dO.float() * out.float()).sum(-1)  # (total_Sq, H)
-        ds_sink = -p_sink * Di  # (total_Sq, H)
-        d_sink = ds_sink.sum(0)  # (H,)
-
-    return {"dq": dq, "dkv": dkv.to(torch.bfloat16), "d_sink": d_sink}
-
-
-def _triton_sparse_attn_fwd(
-    q: Tensor,
-    kv: Tensor,
-    topk_idxs: Tensor,
-    softmax_scale: float,
-    d_v: int = 512,
-    attn_sink: Optional[Tensor] = None,
-    topk_length: Optional[Tensor] = None,
-    indexer_topk: int = 0,
-) -> Tuple[Tensor, Tensor, Optional[Tensor]]:
-    """Triton sparse attention forward (replaces flash_mla_sparse_fwd).
-
-    Args:
-        q: Query tensor ``(total_S_q, H, D)`` bf16.
-        kv: KV tensor ``(total_S_kv, D_full)`` bf16 where D_full >= D.
-            The first D elements are keys, the first d_v elements are values
-            (in absorbed MLA, key and value share the latent space).
-        topk_idxs: ``(total_S_q, H, TopK)`` int32 — global KV indices, -1 for invalid.
-        softmax_scale: attention scale factor.
-        d_v: value dimension (may differ from D for MLA).
-        attn_sink: ``(H,)`` f32 — per-head bias-only sink. When provided, exp(bias) is
-            added to the softmax denominator without attending to any KV token (no value
-            contribution). This matches ``unfused_compressed_sparse_attn`` semantics.
-        topk_length: ``(total_S_q, H)`` int32 — valid count per query (unused in Triton impl,
-            we use -1 in topk_idxs to mark invalid positions).
-        indexer_topk: if > 0, compute separate LSE for the first ``indexer_topk`` positions.
-
-    Returns:
-        out: ``(total_S_q, H, d_v)`` bf16.
-        lse: ``(total_S_q, H)`` f32.
-        lse_indexer: ``(total_S_q, H)`` f32 if indexer_topk > 0, else None.
-    """
-    total_Sq, H, D = q.shape
-    total_Skv = kv.shape[0]
-    TopK = topk_idxs.shape[-1]
-
-    # Choose BLOCK_K: balance between register pressure and gather amortization
-    if TopK <= 32:
-        BLOCK_K = 16
-    elif TopK <= 128:
-        BLOCK_K = 32
-    else:
-        BLOCK_K = 64
-
-    # Allocate outputs
-    out = torch.empty((total_Sq, H, d_v), dtype=torch.bfloat16, device=q.device)
-    lse = torch.empty((total_Sq, H), dtype=torch.float32, device=q.device)
-    lse_indexer = None
-    if indexer_topk > 0:
-        lse_indexer = torch.empty((total_Sq, H), dtype=torch.float32, device=q.device)
-
-    # Launch grid: one program per (query_token, head)
-    grid = (total_Sq, H)
-
-    _sparse_attn_fwd_kernel[grid](
-        q, kv, topk_idxs, out, lse,
-        attn_sink if attn_sink is not None else torch.empty(0, device=q.device),
-        lse_indexer if lse_indexer is not None else torch.empty(0, device=q.device),
-        softmax_scale,
-        total_Sq, total_Skv, TopK, D, d_v,
-        H,
-        # Q strides
-        q.stride(0), q.stride(1), q.stride(2),
-        # KV strides
-        kv.stride(0), kv.stride(-1) if kv.dim() > 1 else 1,
-        # IDX strides
-        topk_idxs.stride(0), topk_idxs.stride(1), topk_idxs.stride(2),
-        # OUT strides
-        out.stride(0), out.stride(1), out.stride(2),
-        # LSE strides
-        lse.stride(0), lse.stride(1),
-        # Compile-time flags
-        HAS_SINK=(attn_sink is not None),
-        HAS_LSE_IDX=(indexer_topk > 0),
-        INDEXER_TOPK=indexer_topk if indexer_topk > 0 else 0,
-        BLOCK_K=BLOCK_K,
-        # P1: Software pipelining for 1D forward kernel.
-        num_stages=2,
-    )
-
-    # Handle edge case: if indexer_topk >= TopK, lse_indexer should equal lse
-    if indexer_topk > 0 and indexer_topk >= TopK:
-        lse_indexer = lse.clone()
-
-    return out, lse, lse_indexer
 
 
 def _triton_sparse_attn_fwd_hp(
@@ -1130,216 +336,10 @@ def _triton_sparse_attn_fwd_hp(
     return out, lse, lse_indexer
 
 
-def _pytorch_sparse_attn_fwd(
-    q: Tensor,
-    kv: Tensor,
-    topk_idxs: Tensor,
-    softmax_scale: float,
-    d_v: int = 512,
-    attn_sink: Optional[Tensor] = None,
-    indexer_topk: int = 0,
-) -> Tuple[Tensor, Tensor, Optional[Tensor]]:
-    """PyTorch-native sparse attention forward using gather + batched matmul.
 
-    Uses cuBLAS batched GEMM for score computation instead of the Triton kernel's
-    per-position tiled loop. Computes attention scores in f32 for numerical
-    precision (aligned with unfused reference and backward recomputation),
-    while keeping the output weighted-sum in bf16 for performance.
-
-    Same API as ``triton_sparse_attn_fwd``.
-    """
-    total_Sq, H, D = q.shape
-    TopK = topk_idxs.shape[-1]
-    d_kv = kv.shape[-1] if kv.dim() > 1 else D
-
-    # Detect shared indices (MLA mode): stride=0 on head dim means all heads
-    # share the same TopK indices. Gather once, broadcast to all heads.
-    shared_indices = (topk_idxs.stride(1) == 0)
-
-    if shared_indices:
-        # Gather KV once with shape (total_Sq, TopK, d_kv), then use einsum for scores.
-        # This avoids materializing (total_Sq, H, TopK, d_kv) which is H times larger.
-        idxs_1h = topk_idxs[:, 0, :]  # (total_Sq, TopK) — single head slice
-        valid_mask_1h = idxs_1h >= 0   # (total_Sq, TopK)
-        safe_idxs_1h = idxs_1h.clamp(min=0).long()
-        flat_idxs = safe_idxs_1h.reshape(-1)  # (total_Sq * TopK)
-        kv_gathered_1h = kv[flat_idxs].reshape(total_Sq, TopK, d_kv)  # bf16, (S, T, D)
-
-        # Scores via BMM in f32: Q(S,H,D) @ K(S,D,T) -> (S,H,T)
-        # Using f32 for the dot-product accumulation eliminates O(D * eps_bf16)
-        # error in attention scores, aligning with the unfused reference path
-        # and backward recomputation which both use f32.
-        k_1h_f = kv_gathered_1h[:, :, :D].float()  # (S, T, D) f32
-        scores = torch.bmm(q.float(), k_1h_f.transpose(1, 2)) * softmax_scale  # (S, H, T) f32
-        del k_1h_f
-        valid_mask = valid_mask_1h.unsqueeze(1).expand(-1, H, -1)
-        scores = scores.masked_fill(~valid_mask, float("-inf"))
-
-        # LSE with optional sink
-        if attn_sink is not None:
-            sink_expanded = attn_sink.unsqueeze(0).unsqueeze(-1).expand(total_Sq, -1, -1)
-            scores_with_sink = torch.cat([scores, sink_expanded], dim=-1)
-            lse = torch.logsumexp(scores_with_sink, dim=-1)
-        else:
-            lse = torch.logsumexp(scores, dim=-1)
-
-        # Attention weights (f32)
-        P = torch.exp(scores - lse.unsqueeze(-1))
-        P = P.masked_fill(~valid_mask, 0.0)
-
-        # Output via BMM in bf16: P(S,H,T) @ V(S,T,Dv) -> (S,H,Dv)
-        # Keeping output bmm in bf16 is acceptable: the linear weighted sum has
-        # bounded error O(TopK * eps_bf16) and matches the Triton kernel's behavior.
-        # The output is stored as bf16 in save_for_backward regardless.
-        v_1h = kv_gathered_1h[:, :, :d_v]  # (S, T, Dv) bf16
-        out = torch.bmm(P.to(torch.bfloat16), v_1h)  # (S, H, Dv) bf16
-
-        # Indexer LSE
-        lse_indexer = None
-        if indexer_topk > 0:
-            if indexer_topk >= TopK:
-                lse_indexer = lse.clone()
-            else:
-                idx_scores = scores[:, :, :indexer_topk]
-                lse_indexer = torch.logsumexp(idx_scores, dim=-1)
-
-        return out.to(torch.bfloat16), lse, lse_indexer
-
-    else:
-        # General path: per-head gather
-        valid_mask = topk_idxs >= 0  # (total_Sq, H, TopK)
-        safe_idxs = topk_idxs.clamp(min=0).long()
-        flat_idxs = safe_idxs.reshape(-1)  # (total_Sq * H * TopK)
-        kv_gathered = kv[flat_idxs].reshape(total_Sq, H, TopK, d_kv)  # bf16
-
-        # Compute scores in f32 via bmm for precision (aligned with backward recomputation).
-        # Reshape: (total_Sq * H, 1, D) @ (total_Sq * H, D, TopK) -> (total_Sq * H, 1, TopK)
-        q_r = q.float().reshape(total_Sq * H, 1, D)  # (SH, 1, D) f32
-        k_r = kv_gathered[:, :, :, :D].float().reshape(total_Sq * H, TopK, D).transpose(1, 2)  # (SH, D, TopK) f32
-        scores = torch.bmm(q_r, k_r).squeeze(1).reshape(total_Sq, H, TopK) * softmax_scale
-        del q_r, k_r
-        scores = scores.masked_fill(~valid_mask, float("-inf"))
-
-        # LSE with optional sink
-        if attn_sink is not None:
-            sink_expanded = attn_sink.unsqueeze(0).unsqueeze(-1).expand(total_Sq, -1, -1)
-            scores_with_sink = torch.cat([scores, sink_expanded], dim=-1)
-            lse = torch.logsumexp(scores_with_sink, dim=-1)  # (total_Sq, H)
-        else:
-            lse = torch.logsumexp(scores, dim=-1)  # (total_Sq, H)
-
-        # Attention weights (f32 for precision)
-        P = torch.exp(scores - lse.unsqueeze(-1))  # (total_Sq, H, TopK)
-        P = P.masked_fill(~valid_mask, 0.0)
-
-        # Output via bmm in bf16: (SH, 1, TopK) @ (SH, TopK, d_v) -> (SH, 1, d_v)
-        # Kept in bf16 for performance; linear combination error is bounded.
-        P_bf16 = P.to(torch.bfloat16).reshape(total_Sq * H, 1, TopK)
-        v_r = kv_gathered[:, :, :, :d_v].reshape(total_Sq * H, TopK, d_v)  # bf16
-        out = torch.bmm(P_bf16, v_r).squeeze(1).reshape(total_Sq, H, d_v)  # bf16
-
-        # Indexer LSE (partial LSE over first indexer_topk positions)
-        lse_indexer = None
-        if indexer_topk > 0:
-            if indexer_topk >= TopK:
-                lse_indexer = lse.clone()
-            else:
-                idx_scores = scores[:, :, :indexer_topk]
-                lse_indexer = torch.logsumexp(idx_scores, dim=-1)
-
-        return out.to(torch.bfloat16), lse, lse_indexer
-
-
-def _triton_sparse_attn_fwd_2d(
-    q: Tensor,
-    kv: Tensor,
-    topk_idxs: Tensor,
-    softmax_scale: float,
-    d_v: int = 512,
-    attn_sink: Optional[Tensor] = None,
-    indexer_topk: int = 0,
-) -> Tuple[Tensor, Tensor, Optional[Tensor]]:
-    """2D-tiled Triton sparse attention forward with tiled softmax.
-
-    Uses BLOCK_Q queries per program and processes KV positions in tiles of
-    BLOCK_K. The tiled approach reduces online softmax rescale operations from
-    TopK to TopK/BLOCK_K, providing significant speedup for large TopK values.
-    """
-    total_Sq, H, D = q.shape
-    total_Skv = kv.shape[0]
-    TopK = topk_idxs.shape[-1]
-
-    BLOCK_Q = 16
-    # Choose BLOCK_K: balance rescale reduction vs register pressure.
-    # Must be >= 16 for WGMMA alignment, and divide TopK evenly is preferred
-    # (non-divisible case handled by the kernel's `if k_pos < TopK` guard).
-    if TopK <= 32:
-        BLOCK_K = 16
-    elif TopK <= 128:
-        BLOCK_K = 16
-    else:
-        BLOCK_K = 32
-
-    # P1: Choose num_warps for Hopper — more warps help hide memory latency
-    # for the large D=512 gather pattern. 4 warps is optimal for BLOCK_Q=16
-    # with D=512 (each warp handles 4 queries' worth of 512-wide vectors).
-    num_warps = 4 if D <= 512 else 8
-
-    # Allocate outputs
-    out = torch.empty((total_Sq, H, d_v), dtype=torch.bfloat16, device=q.device)
-    lse = torch.empty((total_Sq, H), dtype=torch.float32, device=q.device)
-    lse_indexer = None
-    if indexer_topk > 0:
-        lse_indexer = torch.empty((total_Sq, H), dtype=torch.float32, device=q.device)
-
-    # Grid: one program per (query_block, head)
-    num_q_blocks = (total_Sq + BLOCK_Q - 1) // BLOCK_Q
-    grid = (num_q_blocks, H)
-
-    _sparse_attn_fwd_2d_kernel[grid](
-        q, kv, topk_idxs, out, lse,
-        attn_sink if attn_sink is not None else torch.empty(0, device=q.device),
-        lse_indexer if lse_indexer is not None else torch.empty(0, device=q.device),
-        softmax_scale,
-        total_Sq, total_Skv, TopK, D, d_v,
-        H,
-        q.stride(0), q.stride(1), q.stride(2),
-        kv.stride(0), kv.stride(-1) if kv.dim() > 1 else 1,
-        topk_idxs.stride(0), topk_idxs.stride(1), topk_idxs.stride(2),
-        out.stride(0), out.stride(1), out.stride(2),
-        lse.stride(0), lse.stride(1),
-        HAS_SINK=(attn_sink is not None),
-        HAS_LSE_IDX=(indexer_topk > 0),
-        INDEXER_TOPK=indexer_topk if indexer_topk > 0 else 0,
-        BLOCK_Q=BLOCK_Q,
-        BLOCK_K=BLOCK_K,
-        # P1: Software pipelining — Triton inserts async copy + double buffering
-        # for loads within the tiled loop. 2 stages = double buffer (current +
-        # prefetch next), which overlaps memory latency with compute.
-        num_stages=2,
-        num_warps=num_warps,
-    )
-
-    # Handle edge case
-    if indexer_topk > 0 and indexer_topk >= TopK:
-        lse_indexer = lse.clone()
-
-    return out, lse, lse_indexer
-
-
-# Threshold: use PyTorch-native path for TopK <= this value.
-# The HP WGMMA kernel handles all shared-index cases (checked first in dispatch),
-# so this threshold only applies to non-shared or non-aligned fallback scenarios.
-# After P0 (tiled softmax) and P1 (software pipelining) optimizations, the 2D
-# Triton kernel is competitive with PyTorch BMM at lower TopK values. Lowered
-# from 512 to 256: beyond TopK=256, the gathered KV tensor becomes large enough
-# that Triton's streaming (zero intermediate allocation) wins clearly.
-_PYTORCH_FWD_TOPK_THRESHOLD = 256
-
-# Maximum total elements in gathered KV before falling back to Triton.
-# Lowered from 2M to 1M: with optimized Triton kernels, the crossover point
-# where Triton's streaming beats cuBLAS BMM shifts earlier.
-_PYTORCH_FWD_MAX_GATHER_ELEMENTS = 1 * 1024 * 1024
+# ---------------------------------------------------------------------------
+# Forward Dispatch
+# ---------------------------------------------------------------------------
 
 
 def triton_sparse_attn_fwd(
@@ -1352,13 +352,11 @@ def triton_sparse_attn_fwd(
     topk_length: Optional[Tensor] = None,
     indexer_topk: int = 0,
 ) -> Tuple[Tensor, Tensor, Optional[Tensor]]:
-    """Sparse attention forward — dispatches to optimal kernel.
+    """Sparse attention forward — HP WGMMA kernel for training.
 
-    Dispatch priority:
-    1. Head-parallel WGMMA kernel (shared indices, H>=16, dims aligned to 16)
-       — uses tl.dot for both score and output, beats cuBLAS for all TopK.
-    2. PyTorch BMM fallback (non-shared indices with small TopK).
-    3. 2D-tiled Triton kernel (non-shared indices with large TopK).
+    Training always uses the head-parallel WGMMA kernel (shared indices,
+    H>=16, dims aligned to 16). For non-HP scenarios (decoding, testing),
+    falls back to legacy implementations.
 
     Args:
         q: Query tensor ``(total_S_q, H, D)`` bf16.
@@ -1375,29 +373,41 @@ def triton_sparse_attn_fwd(
         lse: ``(total_S_q, H)`` f32.
         lse_indexer: ``(total_S_q, H)`` f32 if indexer_topk > 0, else None.
     """
-    TopK = topk_idxs.shape[-1]
-    total_Sq, H = topk_idxs.shape[0], topk_idxs.shape[1]
     D = q.shape[-1]
+    H = topk_idxs.shape[1]
     shared = (topk_idxs.stride(1) == 0)
 
-    # Priority 1: Head-parallel WGMMA kernel for shared-index MLA
-    # Requirements: shared indices, H>=16, D and d_v are multiples of 16
-    if shared and H >= 16 and (H % 16 == 0) and (D % 16 == 0) and (d_v % 16 == 0):
+    # HP kernel conditions (always true in training)
+    hp_eligible = (
+        shared and H >= 16 and (H % 16 == 0)
+        and (D % 16 == 0) and (d_v % 16 == 0)
+    )
+
+    if hp_eligible:
         return _triton_sparse_attn_fwd_hp(
             q, kv, topk_idxs, softmax_scale, d_v, attn_sink, indexer_topk
         )
 
-    # Priority 2: PyTorch BMM for small TopK (non-shared or non-aligned case)
-    gather_elements = total_Sq * TopK if shared else total_Sq * H * TopK
-    if TopK <= _PYTORCH_FWD_TOPK_THRESHOLD and gather_elements <= _PYTORCH_FWD_MAX_GATHER_ELEMENTS:
-        return _pytorch_sparse_attn_fwd(
-            q, kv, topk_idxs, softmax_scale, d_v, attn_sink, indexer_topk
-        )
-
-    # Priority 3: 2D-tiled Triton kernel for non-shared large TopK
-    return _triton_sparse_attn_fwd_2d(
+    # Fallback to legacy (should not happen in training)
+    import warnings
+    warnings.warn(
+        "triton_sparse_attn_fwd: HP kernel conditions not met "
+        f"(shared={shared}, H={H}, D={D}, d_v={d_v}). "
+        "Falling back to legacy PyTorch BMM implementation.",
+        RuntimeWarning,
+        stacklevel=2,
+    )
+    from megatron.plugin.dsa_kernel.legacy.pytorch_sparse_attn import (
+        pytorch_sparse_attn_fwd,
+    )
+    return pytorch_sparse_attn_fwd(
         q, kv, topk_idxs, softmax_scale, d_v, attn_sink, indexer_topk
     )
+
+
+# ---------------------------------------------------------------------------
+# Backward (delegated to legacy or BMM — training uses _hp_bmm_backward)
+# ---------------------------------------------------------------------------
 
 
 def triton_sparse_attn_bwd(
@@ -1411,82 +421,22 @@ def triton_sparse_attn_bwd(
     d_v: int = 512,
     attn_sink: Optional[Tensor] = None,
 ) -> dict:
-    """Triton sparse attention backward — per-position kernel.
+    """Sparse attention backward — PyTorch BMM fallback.
 
-    NOTE: The HP backward kernel (_triton_sparse_attn_bwd_hp) is disabled because
-    extracting columns from tl.dot outputs produces NaN gradients. When the HP
-    forward was used, the caller should use _bmm_backward with score_dtype=f16
-    (cuBLAS f16×f16→f32 matches tl.dot accumulation). This Triton kernel is used
-    only when the forward also used per-position tl.sum(q*k) score computation.
-
-    Args:
-        dO: gradient of output ``(total_S_q, H, d_v)`` bf16.
-        q: query ``(total_S_q, H, D)`` bf16.
-        kv: KV ``(total_S_kv, D_full)`` bf16.
-        out: forward output ``(total_S_q, H, d_v)`` bf16.
-        lse: log-sum-exp ``(total_S_q, H)`` f32.
-        topk_idxs: ``(total_S_q, H, TopK)`` int32.
-        softmax_scale: attention scale factor.
-        d_v: value dimension.
-        attn_sink: per-head sink bias or None.
+    In training, the HP forward path uses _hp_bmm_backward (cuBLAS f16 BMM)
+    instead of this function. This entry point exists for API compatibility
+    and for non-HP scenarios (testing/decoding).
 
     Returns:
-        dict with keys: ``dq`` (total_S_q, H, D), ``dkv`` (total_S_kv, D_full),
-        ``d_sink`` (H,) or None.
+        dict with keys: ``dq``, ``dkv``, ``d_sink``.
     """
-    total_Sq, H, D = q.shape
-    TopK = topk_idxs.shape[-1]
-
-    # Per-position Triton backward (original kernel)
-    total_Skv = kv.shape[0]
-    D_full = kv.shape[-1] if kv.dim() > 1 else D
-
-    # Ensure topk_idxs is contiguous
-    if not topk_idxs.is_contiguous():
-        topk_idxs = topk_idxs.contiguous()
-
-    if TopK <= 32:
-        BLOCK_K = 16
-    elif TopK <= 128:
-        BLOCK_K = 32
-    else:
-        BLOCK_K = 64
-
-    dq = torch.zeros_like(q)
-    dkv = torch.zeros((total_Skv, D_full), dtype=torch.float32, device=q.device)
-
-    grid = (total_Sq, H)
-
-    _sparse_attn_bwd_kernel[grid](
-        q, kv, topk_idxs, out, lse, dO,
-        dq, dkv,
-        torch.empty(0, device=q.device),  # DSINK placeholder
-        attn_sink if attn_sink is not None else torch.empty(0, device=q.device),
-        softmax_scale,
-        total_Sq, total_Skv, TopK, D, d_v,
-        H,
-        q.stride(0), q.stride(1), q.stride(2),
-        kv.stride(0), kv.stride(-1) if kv.dim() > 1 else 1,
-        topk_idxs.stride(0), topk_idxs.stride(1), topk_idxs.stride(2),
-        out.stride(0), out.stride(1), out.stride(2),
-        lse.stride(0), lse.stride(1),
-        HAS_SINK=(attn_sink is not None),
-        BLOCK_K=BLOCK_K,
-        num_stages=2,
-        num_warps=4,
+    from megatron.plugin.dsa_kernel.legacy.pytorch_sparse_attn import (
+        pytorch_sparse_attn_bwd,
     )
-
-    # Compute d_sink if needed
-    d_sink = None
-    if attn_sink is not None:
-        p_sink = torch.exp(attn_sink.unsqueeze(0) - lse)  # (total_Sq, H)
-        dO_f = dO.float()
-        out_f = out.float()
-        Di = (dO_f * out_f).sum(-1)  # (total_Sq, H)
-        ds_sink = -p_sink * Di  # (total_Sq, H)
-        d_sink = ds_sink.sum(0)  # (H,)
-
-    return {"dq": dq, "dkv": dkv.to(torch.bfloat16), "d_sink": d_sink}
+    dq, dkv, d_sink = pytorch_sparse_attn_bwd(
+        dO, q, kv, topk_idxs, out, lse, attn_sink, softmax_scale, d_v
+    )
+    return {"dq": dq, "dkv": dkv, "d_sink": d_sink}
 
 
 # ---------------------------------------------------------------------------

--- a/megatron/plugin/dsa_kernel/triton_sparse_attn.py
+++ b/megatron/plugin/dsa_kernel/triton_sparse_attn.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
+# Copyright (c) 2026, FlagOS Contributors. All rights reserved.
 
 """
 Triton sparse attention forward and backward kernels for DSA.

--- a/megatron/plugin/dsa_kernel/triton_sparse_attn.py
+++ b/megatron/plugin/dsa_kernel/triton_sparse_attn.py
@@ -1,0 +1,811 @@
+# Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
+
+"""
+Triton sparse attention forward and backward kernels for DSA.
+
+Replaces the dependency on ``flash_mla.flash_mla_sparse_fwd`` and
+``cudnn.DSA.sparse_attention_backward`` with pure Triton implementations.
+
+The kernels operate on "flat" (unbatched) tensors where Q and KV are concatenated
+across the batch dimension, and topk_idxs provides global indices into KV.
+"""
+
+from __future__ import annotations
+
+from typing import Optional, Tuple
+
+import torch
+from torch import Tensor
+
+import triton
+import triton.language as tl
+
+
+# ---------------------------------------------------------------------------
+# Forward kernel
+# ---------------------------------------------------------------------------
+
+
+@triton.jit
+def _sparse_attn_fwd_kernel(
+    Q_ptr, KV_ptr, IDX_ptr, OUT_ptr, LSE_ptr,
+    SINK_ptr, LSE_IDX_ptr,
+    softmax_scale: tl.constexpr,
+    total_Sq, total_Skv, TopK: tl.constexpr, D: tl.constexpr, DV: tl.constexpr,
+    H: tl.constexpr,
+    stride_q_s, stride_q_h, stride_q_d,
+    stride_kv_s, stride_kv_d,
+    stride_idx_s, stride_idx_h, stride_idx_k,
+    stride_out_s, stride_out_h, stride_out_d,
+    stride_lse_s, stride_lse_h,
+    HAS_SINK: tl.constexpr,
+    HAS_LSE_IDX: tl.constexpr,
+    INDEXER_TOPK: tl.constexpr,
+    BLOCK_K: tl.constexpr,
+):
+    """Sparse attention forward with tiled KV gather.
+
+    Each program handles one (query, head) pair. KV positions are processed in
+    tiles of BLOCK_K to amortize gather overhead and enable vectorized loads.
+    Uses online softmax across tiles for numerical stability.
+    """
+    pid_q = tl.program_id(0)
+    pid_h = tl.program_id(1)
+
+    if pid_q >= total_Sq:
+        return
+
+    # Load query vector: (D,)
+    q_offset = pid_q * stride_q_s + pid_h * stride_q_h
+    d_range = tl.arange(0, D)
+    q = tl.load(Q_ptr + q_offset + d_range * stride_q_d, mask=d_range < D, other=0.0)
+    q = (q * softmax_scale).to(tl.float32)
+
+    # Online softmax state
+    m_i = tl.full([], float("-inf"), dtype=tl.float32)
+    l_i = tl.full([], 0.0, dtype=tl.float32)
+    # Accumulator for output (DV,)
+    dv_range = tl.arange(0, DV)
+    acc = tl.zeros([DV], dtype=tl.float32)
+
+    # Optional: bias-only sink
+    if HAS_SINK:
+        sink_bias = tl.load(SINK_ptr + pid_h)
+        m_new = tl.maximum(m_i, sink_bias)
+        l_i = l_i * tl.exp(m_i - m_new) + tl.exp(sink_bias - m_new)
+        acc = acc * tl.exp(m_i - m_new)
+        m_i = m_new
+
+    # Indexer LSE state (tracks first INDEXER_TOPK positions)
+    if HAS_LSE_IDX:
+        m_idx = tl.full([], float("-inf"), dtype=tl.float32)
+        l_idx = tl.full([], 0.0, dtype=tl.float32)
+
+    # Process KV positions in tiles of BLOCK_K
+    idx_base = pid_q * stride_idx_s + pid_h * stride_idx_h
+    k_range = tl.arange(0, BLOCK_K)
+
+    for tile_start in range(0, TopK, BLOCK_K):
+        # Load a tile of indices: (BLOCK_K,)
+        tile_offsets = tile_start + k_range
+        idx_mask = tile_offsets < TopK
+        kv_indices = tl.load(
+            IDX_ptr + idx_base + tile_offsets * stride_idx_k,
+            mask=idx_mask, other=-1
+        )
+        valid_mask = (kv_indices >= 0) & idx_mask
+        safe_indices = tl.where(valid_mask, kv_indices, 0)
+
+        # Gather K tile: (BLOCK_K, D) — each row is one KV position's key
+        kv_bases = safe_indices * stride_kv_s  # (BLOCK_K,)
+        k_tile = tl.load(
+            KV_ptr + kv_bases[:, None] + d_range[None, :] * stride_kv_d,
+            mask=valid_mask[:, None] & (d_range[None, :] < D),
+            other=0.0,
+        ).to(tl.float32)  # (BLOCK_K, D)
+
+        # Compute scores: q (D,) @ k_tile^T (D, BLOCK_K) -> (BLOCK_K,)
+        scores = tl.sum(q[None, :] * k_tile, axis=1)  # (BLOCK_K,)
+        scores = tl.where(valid_mask, scores, float("-inf"))
+
+        # Tile-level online softmax update
+        tile_max = tl.max(scores)
+        m_new = tl.maximum(m_i, tile_max)
+        exp_old = tl.exp(m_i - m_new)
+        exp_scores = tl.exp(scores - m_new)  # (BLOCK_K,)
+        # Zero out invalid positions
+        exp_scores = tl.where(valid_mask, exp_scores, 0.0)
+        tile_sum = tl.sum(exp_scores)
+
+        # Gather V tile: (BLOCK_K, DV)
+        v_tile = tl.load(
+            KV_ptr + kv_bases[:, None] + dv_range[None, :] * stride_kv_d,
+            mask=valid_mask[:, None] & (dv_range[None, :] < DV),
+            other=0.0,
+        ).to(tl.float32)  # (BLOCK_K, DV)
+
+        # Weighted sum: exp_scores (BLOCK_K,) @ v_tile (BLOCK_K, DV) -> (DV,)
+        tile_out = tl.sum(exp_scores[:, None] * v_tile, axis=0)  # (DV,)
+
+        # Update accumulators
+        l_i = l_i * exp_old + tile_sum
+        acc = acc * exp_old + tile_out
+        m_i = m_new
+
+        # Update indexer LSE for tiles within INDEXER_TOPK range
+        if HAS_LSE_IDX:
+            if tile_start < INDEXER_TOPK:
+                # Only count positions within [0, INDEXER_TOPK)
+                idx_valid = valid_mask & (tile_offsets < INDEXER_TOPK)
+                idx_scores = tl.where(idx_valid, scores, float("-inf"))
+                idx_tile_max = tl.max(idx_scores)
+                m_idx_new = tl.maximum(m_idx, idx_tile_max)
+                exp_idx_scores = tl.exp(idx_scores - m_idx_new)
+                exp_idx_scores = tl.where(idx_valid, exp_idx_scores, 0.0)
+                l_idx = l_idx * tl.exp(m_idx - m_idx_new) + tl.sum(exp_idx_scores)
+                m_idx = m_idx_new
+
+    # Finalize: out = acc / l_i
+    safe_l = tl.where(l_i > 0.0, l_i, 1.0)
+    out = acc / safe_l
+
+    # Store output
+    out_offset = pid_q * stride_out_s + pid_h * stride_out_h
+    tl.store(OUT_ptr + out_offset + dv_range * stride_out_d, out.to(tl.bfloat16), mask=dv_range < DV)
+
+    # Store LSE = m_i + log(l_i)
+    lse_val = m_i + tl.log(safe_l)
+    tl.store(LSE_ptr + pid_q * stride_lse_s + pid_h * stride_lse_h, lse_val)
+
+    # Store indexer LSE if needed
+    if HAS_LSE_IDX:
+        safe_l_idx = tl.where(l_idx > 0.0, l_idx, 1.0)
+        lse_idx_val = m_idx + tl.log(safe_l_idx)
+        tl.store(LSE_IDX_ptr + pid_q * stride_lse_s + pid_h * stride_lse_h, lse_idx_val)
+
+
+# ---------------------------------------------------------------------------
+# 2D-Tiled Forward kernel (BLOCK_Q queries per program)
+# ---------------------------------------------------------------------------
+
+
+@triton.jit
+def _sparse_attn_fwd_2d_kernel(
+    Q_ptr, KV_ptr, IDX_ptr, OUT_ptr, LSE_ptr,
+    SINK_ptr, LSE_IDX_ptr,
+    softmax_scale: tl.constexpr,
+    total_Sq, total_Skv, TopK: tl.constexpr, D: tl.constexpr, DV: tl.constexpr,
+    H: tl.constexpr,
+    stride_q_s, stride_q_h, stride_q_d,
+    stride_kv_s, stride_kv_d,
+    stride_idx_s, stride_idx_h, stride_idx_k,
+    stride_out_s, stride_out_h, stride_out_d,
+    stride_lse_s, stride_lse_h,
+    HAS_SINK: tl.constexpr,
+    HAS_LSE_IDX: tl.constexpr,
+    INDEXER_TOPK: tl.constexpr,
+    BLOCK_Q: tl.constexpr,
+):
+    """2D-tiled sparse attention forward.
+
+    Each program handles BLOCK_Q queries for one head. Iterates over all TopK
+    KV positions one at a time. For each position, loads one index per query
+    (BLOCK_Q independent indices) and gathers the corresponding KV vectors.
+
+    Benefits over 1D kernel:
+    - BLOCK_Q× fewer programs = less dispatch overhead
+    - Q block loaded once, reused across all TopK iterations
+    - BLOCK_Q online-softmax states updated in parallel (better SIMD utilization)
+    """
+    pid_qblock = tl.program_id(0)
+    pid_h = tl.program_id(1)
+
+    # Range of queries this program handles
+    q_start = pid_qblock * BLOCK_Q
+    q_range = tl.arange(0, BLOCK_Q)
+    q_ids = q_start + q_range  # (BLOCK_Q,)
+    q_valid = q_ids < total_Sq
+
+    # Load Q block: (BLOCK_Q, D)
+    d_range = tl.arange(0, D)
+    q_offsets = q_ids[:, None] * stride_q_s + pid_h * stride_q_h + d_range[None, :] * stride_q_d
+    q_block = tl.load(
+        Q_ptr + q_offsets,
+        mask=q_valid[:, None] & (d_range[None, :] < D),
+        other=0.0,
+    ).to(tl.float32) * softmax_scale  # (BLOCK_Q, D)
+
+    # Online softmax state per query: (BLOCK_Q,)
+    m_i = tl.full([BLOCK_Q], float("-inf"), dtype=tl.float32)
+    l_i = tl.zeros([BLOCK_Q], dtype=tl.float32)
+    # Output accumulator: (BLOCK_Q, DV)
+    dv_range = tl.arange(0, DV)
+    acc = tl.zeros([BLOCK_Q, DV], dtype=tl.float32)
+
+    # Optional: bias-only sink (same for all queries in block, per head)
+    if HAS_SINK:
+        sink_bias = tl.load(SINK_ptr + pid_h)
+        sink_vec = tl.full([BLOCK_Q], sink_bias, dtype=tl.float32)
+        m_new = tl.maximum(m_i, sink_vec)
+        l_i = l_i * tl.exp(m_i - m_new) + tl.exp(sink_vec - m_new)
+        acc = acc * tl.exp(m_i - m_new)[:, None]
+        m_i = m_new
+
+    # Indexer LSE state
+    if HAS_LSE_IDX:
+        m_idx = tl.full([BLOCK_Q], float("-inf"), dtype=tl.float32)
+        l_idx = tl.zeros([BLOCK_Q], dtype=tl.float32)
+
+    # Iterate over all TopK positions one at a time.
+    # Each iteration: load one index per query → gather KV → update softmax.
+    for k_pos in range(TopK):
+        # Load index for each query at this KV position: (BLOCK_Q,)
+        idx_offsets = q_ids * stride_idx_s + pid_h * stride_idx_h + k_pos * stride_idx_k
+        kv_indices = tl.load(
+            IDX_ptr + idx_offsets,
+            mask=q_valid,
+            other=-1,
+        )  # (BLOCK_Q,)
+        valid_q = (kv_indices >= 0) & q_valid  # (BLOCK_Q,)
+        safe_idx = tl.where(valid_q, kv_indices, 0)  # (BLOCK_Q,)
+
+        # Gather K for all BLOCK_Q queries: (BLOCK_Q, D)
+        kv_bases = safe_idx * stride_kv_s  # (BLOCK_Q,)
+        k_vec = tl.load(
+            KV_ptr + kv_bases[:, None] + d_range[None, :] * stride_kv_d,
+            mask=valid_q[:, None] & (d_range[None, :] < D),
+            other=0.0,
+        ).to(tl.float32)  # (BLOCK_Q, D)
+
+        # Score: dot product per query
+        scores = tl.sum(q_block * k_vec, axis=1)  # (BLOCK_Q,)
+        scores = tl.where(valid_q, scores, float("-inf"))
+
+        # Online softmax update (vectorized over BLOCK_Q)
+        m_new = tl.maximum(m_i, scores)
+        exp_old = tl.exp(m_i - m_new)
+        exp_scores = tl.exp(scores - m_new)  # (BLOCK_Q,)
+        exp_scores = tl.where(valid_q, exp_scores, 0.0)
+
+        # Gather V: (BLOCK_Q, DV)
+        v_vec = tl.load(
+            KV_ptr + kv_bases[:, None] + dv_range[None, :] * stride_kv_d,
+            mask=valid_q[:, None] & (dv_range[None, :] < DV),
+            other=0.0,
+        ).to(tl.float32)  # (BLOCK_Q, DV)
+
+        # Update accumulators
+        l_i = l_i * exp_old + exp_scores
+        acc = acc * exp_old[:, None] + exp_scores[:, None] * v_vec
+        m_i = m_new
+
+        # Indexer LSE update
+        if HAS_LSE_IDX:
+            if k_pos < INDEXER_TOPK:
+                m_idx_new = tl.maximum(m_idx, scores)
+                exp_idx = tl.exp(scores - m_idx_new)
+                exp_idx = tl.where(valid_q, exp_idx, 0.0)
+                l_idx = l_idx * tl.exp(m_idx - m_idx_new) + exp_idx
+                m_idx = m_idx_new
+
+    # Finalize output: (BLOCK_Q, DV)
+    safe_l = tl.where(l_i > 0.0, l_i, 1.0)
+    out = acc / safe_l[:, None]
+
+    # Store output
+    out_offsets = q_ids[:, None] * stride_out_s + pid_h * stride_out_h + dv_range[None, :] * stride_out_d
+    tl.store(
+        OUT_ptr + out_offsets,
+        out.to(tl.bfloat16),
+        mask=q_valid[:, None] & (dv_range[None, :] < DV),
+    )
+
+    # Store LSE: (BLOCK_Q,)
+    lse_vals = m_i + tl.log(safe_l)
+    lse_offsets = q_ids * stride_lse_s + pid_h * stride_lse_h
+    tl.store(LSE_ptr + lse_offsets, lse_vals, mask=q_valid)
+
+    # Store indexer LSE
+    if HAS_LSE_IDX:
+        safe_l_idx = tl.where(l_idx > 0.0, l_idx, 1.0)
+        lse_idx_vals = m_idx + tl.log(safe_l_idx)
+        tl.store(LSE_IDX_ptr + lse_offsets, lse_idx_vals, mask=q_valid)
+
+
+# ---------------------------------------------------------------------------
+# Backward kernel
+# ---------------------------------------------------------------------------
+
+
+@triton.jit
+def _sparse_attn_bwd_kernel(
+    Q_ptr, KV_ptr, IDX_ptr, OUT_ptr, LSE_ptr, DO_ptr,
+    DQ_ptr, DKV_ptr, DSINK_ptr, SINK_ptr,
+    softmax_scale: tl.constexpr,
+    total_Sq, total_Skv, TopK: tl.constexpr, D: tl.constexpr, DV: tl.constexpr,
+    H: tl.constexpr,
+    stride_q_s, stride_q_h, stride_q_d,
+    stride_kv_s, stride_kv_d,
+    stride_idx_s, stride_idx_h, stride_idx_k,
+    stride_out_s, stride_out_h, stride_out_d,
+    stride_lse_s, stride_lse_h,
+    HAS_SINK: tl.constexpr,
+):
+    """Sparse attention backward kernel.
+
+    Recomputes attention weights from Q, KV, LSE, then computes:
+    - dQ via dS @ K
+    - dK via dS^T @ Q (atomic add since multiple queries may reference same KV)
+    - dV via P^T @ dO (atomic add)
+    where dS = P * (dO @ V^T - D_i), D_i = rowsum(dO * O).
+
+    Atomic scatter for dK/dV is inherently per-position, so this kernel uses a
+    simple loop rather than tiling.
+    """
+    pid_q = tl.program_id(0)
+    pid_h = tl.program_id(1)
+
+    if pid_q >= total_Sq:
+        return
+
+    # Load query
+    q_offset = pid_q * stride_q_s + pid_h * stride_q_h
+    d_range = tl.arange(0, D)
+    dv_range = tl.arange(0, DV)
+    q = tl.load(Q_ptr + q_offset + d_range * stride_q_d, mask=d_range < D, other=0.0).to(tl.float32)
+
+    # Load dO and O for this position
+    out_offset = pid_q * stride_out_s + pid_h * stride_out_h
+    dO = tl.load(DO_ptr + out_offset + dv_range * stride_out_d, mask=dv_range < DV, other=0.0).to(tl.float32)
+    O = tl.load(OUT_ptr + out_offset + dv_range * stride_out_d, mask=dv_range < DV, other=0.0).to(tl.float32)
+
+    # Load LSE
+    lse_val = tl.load(LSE_ptr + pid_q * stride_lse_s + pid_h * stride_lse_h)
+
+    # D_i = sum(dO * O)
+    Di = tl.sum(dO * O)
+
+    # Accumulate dQ
+    dq_acc = tl.zeros([D], dtype=tl.float32)
+
+    # Process each TopK KV position
+    idx_base = pid_q * stride_idx_s + pid_h * stride_idx_h
+
+    for k_pos in range(TopK):
+        kv_idx = tl.load(IDX_ptr + idx_base + k_pos * stride_idx_k)
+
+        is_valid = kv_idx >= 0
+        safe_idx = tl.where(is_valid, kv_idx, 0)
+
+        kv_base = safe_idx * stride_kv_s
+        k_vec = tl.load(KV_ptr + kv_base + d_range * stride_kv_d, mask=d_range < D, other=0.0).to(tl.float32)
+        v_vec = tl.load(KV_ptr + kv_base + dv_range * stride_kv_d, mask=dv_range < DV, other=0.0).to(tl.float32)
+
+        # Recompute attention probability
+        s = tl.sum(q * k_vec) * softmax_scale
+        p = tl.where(is_valid, tl.exp(s - lse_val), 0.0)
+
+        # dS = P * (dO @ V^T - Di)
+        dov = tl.sum(dO * v_vec)
+        ds = p * (dov - Di) * softmax_scale
+
+        # dQ += ds * K
+        dq_acc += ds * k_vec
+
+        # dK += ds * Q (atomic add to shared KV)
+        tl.atomic_add(DKV_ptr + kv_base + d_range * stride_kv_d, (ds * q).to(tl.bfloat16), mask=d_range < D)
+
+        # dV += p * dO (atomic add)
+        tl.atomic_add(DKV_ptr + kv_base + dv_range * stride_kv_d, (p * dO).to(tl.bfloat16), mask=dv_range < DV)
+
+    # Store dQ
+    tl.store(DQ_ptr + q_offset + d_range * stride_q_d, dq_acc.to(tl.bfloat16), mask=d_range < D)
+
+
+# ---------------------------------------------------------------------------
+# Python wrapper functions
+# ---------------------------------------------------------------------------
+
+
+def _triton_sparse_attn_fwd(
+    q: Tensor,
+    kv: Tensor,
+    topk_idxs: Tensor,
+    softmax_scale: float,
+    d_v: int = 512,
+    attn_sink: Optional[Tensor] = None,
+    topk_length: Optional[Tensor] = None,
+    indexer_topk: int = 0,
+) -> Tuple[Tensor, Tensor, Optional[Tensor]]:
+    """Triton sparse attention forward (replaces flash_mla_sparse_fwd).
+
+    Args:
+        q: Query tensor ``(total_S_q, H, D)`` bf16.
+        kv: KV tensor ``(total_S_kv, D_full)`` bf16 where D_full >= D.
+            The first D elements are keys, the first d_v elements are values
+            (in absorbed MLA, key and value share the latent space).
+        topk_idxs: ``(total_S_q, H, TopK)`` int32 — global KV indices, -1 for invalid.
+        softmax_scale: attention scale factor.
+        d_v: value dimension (may differ from D for MLA).
+        attn_sink: ``(H,)`` f32 — per-head bias-only sink. When provided, exp(bias) is
+            added to the softmax denominator without attending to any KV token (no value
+            contribution). This matches ``unfused_compressed_sparse_attn`` semantics.
+        topk_length: ``(total_S_q, H)`` int32 — valid count per query (unused in Triton impl,
+            we use -1 in topk_idxs to mark invalid positions).
+        indexer_topk: if > 0, compute separate LSE for the first ``indexer_topk`` positions.
+
+    Returns:
+        out: ``(total_S_q, H, d_v)`` bf16.
+        lse: ``(total_S_q, H)`` f32.
+        lse_indexer: ``(total_S_q, H)`` f32 if indexer_topk > 0, else None.
+    """
+    total_Sq, H, D = q.shape
+    total_Skv = kv.shape[0]
+    TopK = topk_idxs.shape[-1]
+
+    # Choose BLOCK_K: balance between register pressure and gather amortization
+    if TopK <= 32:
+        BLOCK_K = 16
+    elif TopK <= 128:
+        BLOCK_K = 32
+    else:
+        BLOCK_K = 64
+
+    # Allocate outputs
+    out = torch.empty((total_Sq, H, d_v), dtype=torch.bfloat16, device=q.device)
+    lse = torch.empty((total_Sq, H), dtype=torch.float32, device=q.device)
+    lse_indexer = None
+    if indexer_topk > 0:
+        lse_indexer = torch.empty((total_Sq, H), dtype=torch.float32, device=q.device)
+
+    # Launch grid: one program per (query_token, head)
+    grid = (total_Sq, H)
+
+    _sparse_attn_fwd_kernel[grid](
+        q, kv, topk_idxs, out, lse,
+        attn_sink if attn_sink is not None else torch.empty(0, device=q.device),
+        lse_indexer if lse_indexer is not None else torch.empty(0, device=q.device),
+        softmax_scale,
+        total_Sq, total_Skv, TopK, D, d_v,
+        H,
+        # Q strides
+        q.stride(0), q.stride(1), q.stride(2),
+        # KV strides
+        kv.stride(0), kv.stride(-1) if kv.dim() > 1 else 1,
+        # IDX strides
+        topk_idxs.stride(0), topk_idxs.stride(1), topk_idxs.stride(2),
+        # OUT strides
+        out.stride(0), out.stride(1), out.stride(2),
+        # LSE strides
+        lse.stride(0), lse.stride(1),
+        # Compile-time flags
+        HAS_SINK=(attn_sink is not None),
+        HAS_LSE_IDX=(indexer_topk > 0),
+        INDEXER_TOPK=indexer_topk if indexer_topk > 0 else 0,
+        BLOCK_K=BLOCK_K,
+    )
+
+    # Handle edge case: if indexer_topk >= TopK, lse_indexer should equal lse
+    if indexer_topk > 0 and indexer_topk >= TopK:
+        lse_indexer = lse.clone()
+
+    return out, lse, lse_indexer
+
+
+def _pytorch_sparse_attn_fwd(
+    q: Tensor,
+    kv: Tensor,
+    topk_idxs: Tensor,
+    softmax_scale: float,
+    d_v: int = 512,
+    attn_sink: Optional[Tensor] = None,
+    indexer_topk: int = 0,
+) -> Tuple[Tensor, Tensor, Optional[Tensor]]:
+    """PyTorch-native sparse attention forward using gather + batched matmul.
+
+    Uses cuBLAS batched GEMM for score computation instead of the Triton kernel's
+    per-position tiled loop. Computes attention scores in f32 for numerical
+    precision (aligned with unfused reference and backward recomputation),
+    while keeping the output weighted-sum in bf16 for performance.
+
+    Same API as ``triton_sparse_attn_fwd``.
+    """
+    total_Sq, H, D = q.shape
+    TopK = topk_idxs.shape[-1]
+    d_kv = kv.shape[-1] if kv.dim() > 1 else D
+
+    # Detect shared indices (MLA mode): stride=0 on head dim means all heads
+    # share the same TopK indices. Gather once, broadcast to all heads.
+    shared_indices = (topk_idxs.stride(1) == 0)
+
+    if shared_indices:
+        # Gather KV once with shape (total_Sq, TopK, d_kv), then use einsum for scores.
+        # This avoids materializing (total_Sq, H, TopK, d_kv) which is H times larger.
+        idxs_1h = topk_idxs[:, 0, :]  # (total_Sq, TopK) — single head slice
+        valid_mask_1h = idxs_1h >= 0   # (total_Sq, TopK)
+        safe_idxs_1h = idxs_1h.clamp(min=0).long()
+        flat_idxs = safe_idxs_1h.reshape(-1)  # (total_Sq * TopK)
+        kv_gathered_1h = kv[flat_idxs].reshape(total_Sq, TopK, d_kv)  # bf16, (S, T, D)
+
+        # Scores via BMM in f32: Q(S,H,D) @ K(S,D,T) -> (S,H,T)
+        # Using f32 for the dot-product accumulation eliminates O(D * eps_bf16)
+        # error in attention scores, aligning with the unfused reference path
+        # and backward recomputation which both use f32.
+        k_1h_f = kv_gathered_1h[:, :, :D].float()  # (S, T, D) f32
+        scores = torch.bmm(q.float(), k_1h_f.transpose(1, 2)) * softmax_scale  # (S, H, T) f32
+        del k_1h_f
+        valid_mask = valid_mask_1h.unsqueeze(1).expand(-1, H, -1)
+        scores = scores.masked_fill(~valid_mask, float("-inf"))
+
+        # LSE with optional sink
+        if attn_sink is not None:
+            sink_expanded = attn_sink.unsqueeze(0).unsqueeze(-1).expand(total_Sq, -1, -1)
+            scores_with_sink = torch.cat([scores, sink_expanded], dim=-1)
+            lse = torch.logsumexp(scores_with_sink, dim=-1)
+        else:
+            lse = torch.logsumexp(scores, dim=-1)
+
+        # Attention weights (f32)
+        P = torch.exp(scores - lse.unsqueeze(-1))
+        P = P.masked_fill(~valid_mask, 0.0)
+
+        # Output via BMM in bf16: P(S,H,T) @ V(S,T,Dv) -> (S,H,Dv)
+        # Keeping output bmm in bf16 is acceptable: the linear weighted sum has
+        # bounded error O(TopK * eps_bf16) and matches the Triton kernel's behavior.
+        # The output is stored as bf16 in save_for_backward regardless.
+        v_1h = kv_gathered_1h[:, :, :d_v]  # (S, T, Dv) bf16
+        out = torch.bmm(P.to(torch.bfloat16), v_1h)  # (S, H, Dv) bf16
+
+        # Indexer LSE
+        lse_indexer = None
+        if indexer_topk > 0:
+            if indexer_topk >= TopK:
+                lse_indexer = lse.clone()
+            else:
+                idx_scores = scores[:, :, :indexer_topk]
+                lse_indexer = torch.logsumexp(idx_scores, dim=-1)
+
+        return out.to(torch.bfloat16), lse, lse_indexer
+
+    else:
+        # General path: per-head gather
+        valid_mask = topk_idxs >= 0  # (total_Sq, H, TopK)
+        safe_idxs = topk_idxs.clamp(min=0).long()
+        flat_idxs = safe_idxs.reshape(-1)  # (total_Sq * H * TopK)
+        kv_gathered = kv[flat_idxs].reshape(total_Sq, H, TopK, d_kv)  # bf16
+
+        # Compute scores in f32 via bmm for precision (aligned with backward recomputation).
+        # Reshape: (total_Sq * H, 1, D) @ (total_Sq * H, D, TopK) -> (total_Sq * H, 1, TopK)
+        q_r = q.float().reshape(total_Sq * H, 1, D)  # (SH, 1, D) f32
+        k_r = kv_gathered[:, :, :, :D].float().reshape(total_Sq * H, TopK, D).transpose(1, 2)  # (SH, D, TopK) f32
+        scores = torch.bmm(q_r, k_r).squeeze(1).reshape(total_Sq, H, TopK) * softmax_scale
+        del q_r, k_r
+        scores = scores.masked_fill(~valid_mask, float("-inf"))
+
+        # LSE with optional sink
+        if attn_sink is not None:
+            sink_expanded = attn_sink.unsqueeze(0).unsqueeze(-1).expand(total_Sq, -1, -1)
+            scores_with_sink = torch.cat([scores, sink_expanded], dim=-1)
+            lse = torch.logsumexp(scores_with_sink, dim=-1)  # (total_Sq, H)
+        else:
+            lse = torch.logsumexp(scores, dim=-1)  # (total_Sq, H)
+
+        # Attention weights (f32 for precision)
+        P = torch.exp(scores - lse.unsqueeze(-1))  # (total_Sq, H, TopK)
+        P = P.masked_fill(~valid_mask, 0.0)
+
+        # Output via bmm in bf16: (SH, 1, TopK) @ (SH, TopK, d_v) -> (SH, 1, d_v)
+        # Kept in bf16 for performance; linear combination error is bounded.
+        P_bf16 = P.to(torch.bfloat16).reshape(total_Sq * H, 1, TopK)
+        v_r = kv_gathered[:, :, :, :d_v].reshape(total_Sq * H, TopK, d_v)  # bf16
+        out = torch.bmm(P_bf16, v_r).squeeze(1).reshape(total_Sq, H, d_v)  # bf16
+
+        # Indexer LSE (partial LSE over first indexer_topk positions)
+        lse_indexer = None
+        if indexer_topk > 0:
+            if indexer_topk >= TopK:
+                lse_indexer = lse.clone()
+            else:
+                idx_scores = scores[:, :, :indexer_topk]
+                lse_indexer = torch.logsumexp(idx_scores, dim=-1)
+
+        return out.to(torch.bfloat16), lse, lse_indexer
+
+
+def _triton_sparse_attn_fwd_2d(
+    q: Tensor,
+    kv: Tensor,
+    topk_idxs: Tensor,
+    softmax_scale: float,
+    d_v: int = 512,
+    attn_sink: Optional[Tensor] = None,
+    indexer_topk: int = 0,
+) -> Tuple[Tensor, Tensor, Optional[Tensor]]:
+    """2D-tiled Triton sparse attention forward.
+
+    Uses BLOCK_Q queries per program for better throughput. Each program
+    handles multiple queries simultaneously, amortizing kernel launch overhead
+    and improving instruction scheduling.
+    """
+    total_Sq, H, D = q.shape
+    total_Skv = kv.shape[0]
+    TopK = topk_idxs.shape[-1]
+
+    BLOCK_Q = 16
+
+    # Allocate outputs
+    out = torch.empty((total_Sq, H, d_v), dtype=torch.bfloat16, device=q.device)
+    lse = torch.empty((total_Sq, H), dtype=torch.float32, device=q.device)
+    lse_indexer = None
+    if indexer_topk > 0:
+        lse_indexer = torch.empty((total_Sq, H), dtype=torch.float32, device=q.device)
+
+    # Grid: one program per (query_block, head)
+    num_q_blocks = (total_Sq + BLOCK_Q - 1) // BLOCK_Q
+    grid = (num_q_blocks, H)
+
+    _sparse_attn_fwd_2d_kernel[grid](
+        q, kv, topk_idxs, out, lse,
+        attn_sink if attn_sink is not None else torch.empty(0, device=q.device),
+        lse_indexer if lse_indexer is not None else torch.empty(0, device=q.device),
+        softmax_scale,
+        total_Sq, total_Skv, TopK, D, d_v,
+        H,
+        q.stride(0), q.stride(1), q.stride(2),
+        kv.stride(0), kv.stride(-1) if kv.dim() > 1 else 1,
+        topk_idxs.stride(0), topk_idxs.stride(1), topk_idxs.stride(2),
+        out.stride(0), out.stride(1), out.stride(2),
+        lse.stride(0), lse.stride(1),
+        HAS_SINK=(attn_sink is not None),
+        HAS_LSE_IDX=(indexer_topk > 0),
+        INDEXER_TOPK=indexer_topk if indexer_topk > 0 else 0,
+        BLOCK_Q=BLOCK_Q,
+    )
+
+    # Handle edge case
+    if indexer_topk > 0 and indexer_topk >= TopK:
+        lse_indexer = lse.clone()
+
+    return out, lse, lse_indexer
+
+
+# Threshold: use PyTorch-native path for TopK <= this value.
+# Below this, gather + cuBLAS bmm outperforms the Triton tiled kernel.
+# Above this, the gathered KV tensor becomes too large and Triton's
+# streaming approach is more memory-efficient.
+_PYTORCH_FWD_TOPK_THRESHOLD = 512
+
+# Maximum total elements in gathered KV before falling back to Triton.
+# This guards against the case where total_Sq * H * TopK is large enough
+# that the random gather saturates memory bandwidth.
+# 2M elements ensures the gather stays efficient for L2/HBM bandwidth.
+_PYTORCH_FWD_MAX_GATHER_ELEMENTS = 2 * 1024 * 1024
+
+
+def triton_sparse_attn_fwd(
+    q: Tensor,
+    kv: Tensor,
+    topk_idxs: Tensor,
+    softmax_scale: float,
+    d_v: int = 512,
+    attn_sink: Optional[Tensor] = None,
+    topk_length: Optional[Tensor] = None,
+    indexer_topk: int = 0,
+) -> Tuple[Tensor, Tensor, Optional[Tensor]]:
+    """Sparse attention forward — dispatches to PyTorch-native or Triton kernel.
+
+    For TopK <= _PYTORCH_FWD_TOPK_THRESHOLD, uses gather + cuBLAS batched matmul
+    which is significantly faster. For very large TopK, falls back to the Triton
+    tiled kernel to avoid excessive memory from materializing gathered KV.
+
+    Args:
+        q: Query tensor ``(total_S_q, H, D)`` bf16.
+        kv: KV tensor ``(total_S_kv, D_full)`` bf16 where D_full >= D.
+        topk_idxs: ``(total_S_q, H, TopK)`` int32 — global KV indices, -1 for invalid.
+        softmax_scale: attention scale factor.
+        d_v: value dimension (may differ from D for MLA).
+        attn_sink: ``(H,)`` f32 — per-head bias-only sink.
+        topk_length: unused (kept for API compatibility).
+        indexer_topk: if > 0, compute separate LSE for first positions.
+
+    Returns:
+        out: ``(total_S_q, H, d_v)`` bf16.
+        lse: ``(total_S_q, H)`` f32.
+        lse_indexer: ``(total_S_q, H)`` f32 if indexer_topk > 0, else None.
+    """
+    TopK = topk_idxs.shape[-1]
+    total_Sq, H = topk_idxs.shape[0], topk_idxs.shape[1]
+    # For shared indices (MLA), actual gather is total_Sq * TopK (not * H)
+    shared = (topk_idxs.stride(1) == 0)
+    gather_elements = total_Sq * TopK if shared else total_Sq * H * TopK
+
+    if TopK <= _PYTORCH_FWD_TOPK_THRESHOLD and gather_elements <= _PYTORCH_FWD_MAX_GATHER_ELEMENTS:
+        return _pytorch_sparse_attn_fwd(
+            q, kv, topk_idxs, softmax_scale, d_v, attn_sink, indexer_topk
+        )
+
+    # Use 2D-tiled Triton kernel for better throughput
+    return _triton_sparse_attn_fwd_2d(
+        q, kv, topk_idxs, softmax_scale, d_v, attn_sink, indexer_topk
+    )
+
+
+def triton_sparse_attn_bwd(
+    dO: Tensor,
+    q: Tensor,
+    kv: Tensor,
+    out: Tensor,
+    lse: Tensor,
+    topk_idxs: Tensor,
+    softmax_scale: float,
+    d_v: int = 512,
+    attn_sink: Optional[Tensor] = None,
+) -> dict:
+    """Triton sparse attention backward (replaces cudnn.DSA.sparse_attention_backward).
+
+    Args:
+        dO: gradient of output ``(total_S_q, H, d_v)`` bf16.
+        q: query ``(total_S_q, H, D)`` bf16.
+        kv: KV ``(total_S_kv, D_full)`` bf16.
+        out: forward output ``(total_S_q, H, d_v)`` bf16.
+        lse: log-sum-exp ``(total_S_q, H)`` f32.
+        topk_idxs: ``(total_S_q, H, TopK)`` int32.
+        softmax_scale: attention scale factor.
+        d_v: value dimension.
+        attn_sink: per-head sink bias or None.
+
+    Returns:
+        dict with keys: ``dq`` (total_S_q, H, D), ``dkv`` (total_S_kv, D_full),
+        ``d_sink`` (H,) or None.
+    """
+    total_Sq, H, D = q.shape
+    total_Skv = kv.shape[0]
+    D_full = kv.shape[-1] if kv.dim() > 1 else D
+    TopK = topk_idxs.shape[-1]
+
+    # Allocate gradient outputs
+    dq = torch.zeros_like(q)
+    dkv = torch.zeros((total_Skv, D_full), dtype=torch.bfloat16, device=q.device)
+
+    grid = (total_Sq, H)
+
+    _sparse_attn_bwd_kernel[grid](
+        q, kv, topk_idxs, out, lse, dO,
+        dq, dkv,
+        torch.empty(0, device=q.device),  # DSINK placeholder
+        attn_sink if attn_sink is not None else torch.empty(0, device=q.device),
+        softmax_scale,
+        total_Sq, total_Skv, TopK, D, d_v,
+        H,
+        q.stride(0), q.stride(1), q.stride(2),
+        kv.stride(0), kv.stride(-1) if kv.dim() > 1 else 1,
+        topk_idxs.stride(0), topk_idxs.stride(1), topk_idxs.stride(2),
+        out.stride(0), out.stride(1), out.stride(2),
+        lse.stride(0), lse.stride(1),
+        HAS_SINK=(attn_sink is not None),
+    )
+
+    # Compute d_sink if needed (gradient w.r.t. bias-only sink)
+    d_sink = None
+    if attn_sink is not None:
+        # Bias-only sink: s_sink = attn_sink[h], p_sink = exp(s_sink - lse)
+        # The sink contributes no value, so output is weighted sum of TopK values only,
+        # divided by (l_topk + exp(sink - m)). The gradient w.r.t. sink_bias is:
+        # d_sink[h] = sum_q [ p_sink * (-Di) ]  where Di = sum(dO * O)
+        p_sink = torch.exp(attn_sink.unsqueeze(0) - lse)  # (total_Sq, H)
+        dO_f = dO.float()
+        out_f = out.float()
+        Di = (dO_f * out_f).sum(-1)  # (total_Sq, H)
+        # Since sink has value=0, dS_sink = p_sink * (0 - Di) = -p_sink * Di
+        ds_sink = -p_sink * Di  # (total_Sq, H)
+        d_sink = ds_sink.sum(0)  # (H,)
+
+    return {"dq": dq, "dkv": dkv, "d_sink": d_sink}
+
+
+# ---------------------------------------------------------------------------
+# Aliases for backward-compatible import names
+# ---------------------------------------------------------------------------
+
+triton_sparse_attn_forward = triton_sparse_attn_fwd
+triton_sparse_attn_backward = triton_sparse_attn_bwd

--- a/megatron/plugin/dsa_kernel/triton_sparse_attn.py
+++ b/megatron/plugin/dsa_kernel/triton_sparse_attn.py
@@ -446,6 +446,9 @@ def triton_sparse_attn_bwd(
 from megatron.plugin.dsa_kernel.triton_sparse_attn_bwd import (
     fused_mask_scatter_add,
     fused_exp_mask,
+    fused_dq,
+    fused_dkv,
+    sorted_scatter_add,
     should_use_triton_bwd,
 )
 

--- a/megatron/plugin/dsa_kernel/triton_sparse_attn.py
+++ b/megatron/plugin/dsa_kernel/triton_sparse_attn.py
@@ -330,6 +330,7 @@ def _sparse_attn_bwd_kernel(
     stride_out_s, stride_out_h, stride_out_d,
     stride_lse_s, stride_lse_h,
     HAS_SINK: tl.constexpr,
+    BLOCK_K: tl.constexpr = 32,
 ):
     """Sparse attention backward kernel.
 
@@ -339,8 +340,11 @@ def _sparse_attn_bwd_kernel(
     - dV via P^T @ dO (atomic add)
     where dS = P * (dO @ V^T - D_i), D_i = rowsum(dO * O).
 
-    Atomic scatter for dK/dV is inherently per-position, so this kernel uses a
-    simple loop rather than tiling.
+    TopK is constexpr so that `range(0, TopK, BLOCK_K)` is fully resolved at
+    compile time.  Previous versions had TopK as a runtime parameter with a
+    two-level loop (`num_full_tiles = TopK // BLOCK_K`), but runtime integer
+    division and runtime loop bounds in Triton can produce undefined behavior
+    depending on the compiler version, leading to NaN gradients.
     """
     pid_q = tl.program_id(0)
     pid_h = tl.program_id(1)
@@ -368,35 +372,39 @@ def _sparse_attn_bwd_kernel(
     # Accumulate dQ
     dq_acc = tl.zeros([D], dtype=tl.float32)
 
-    # Process each TopK KV position
+    # Process TopK KV positions in tiles of BLOCK_K (both TopK and BLOCK_K are
+    # constexpr, so `range(0, TopK, BLOCK_K)` is fully resolved at compile time).
     idx_base = pid_q * stride_idx_s + pid_h * stride_idx_h
 
-    for k_pos in range(TopK):
-        kv_idx = tl.load(IDX_ptr + idx_base + k_pos * stride_idx_k)
+    for tile_start in range(0, TopK, BLOCK_K):
+        for k_off in range(BLOCK_K):
+            k_pos = tile_start + k_off
+            if k_pos < TopK:
+                kv_idx = tl.load(IDX_ptr + idx_base + k_pos * stride_idx_k)
 
-        is_valid = kv_idx >= 0
-        safe_idx = tl.where(is_valid, kv_idx, 0)
+                is_valid = kv_idx >= 0
+                safe_idx = tl.where(is_valid, kv_idx, 0)
 
-        kv_base = safe_idx * stride_kv_s
-        k_vec = tl.load(KV_ptr + kv_base + d_range * stride_kv_d, mask=d_range < D, other=0.0).to(tl.float32)
-        v_vec = tl.load(KV_ptr + kv_base + dv_range * stride_kv_d, mask=dv_range < DV, other=0.0).to(tl.float32)
+                kv_base = safe_idx * stride_kv_s
+                k_vec = tl.load(KV_ptr + kv_base + d_range * stride_kv_d, mask=d_range < D, other=0.0).to(tl.float32)
+                v_vec = tl.load(KV_ptr + kv_base + dv_range * stride_kv_d, mask=dv_range < DV, other=0.0).to(tl.float32)
 
-        # Recompute attention probability
-        s = tl.sum(q * k_vec) * softmax_scale
-        p = tl.where(is_valid, tl.exp(s - lse_val), 0.0)
+                # Recompute attention probability
+                s = tl.sum(q * k_vec) * softmax_scale
+                p = tl.where(is_valid, tl.exp(s - lse_val), 0.0)
 
-        # dS = P * (dO @ V^T - Di)
-        dov = tl.sum(dO * v_vec)
-        ds = p * (dov - Di) * softmax_scale
+                # dS = P * (dO @ V^T - Di)
+                dov = tl.sum(dO * v_vec)
+                ds = p * (dov - Di) * softmax_scale
 
-        # dQ += ds * K
-        dq_acc += ds * k_vec
+                # dQ += ds * K
+                dq_acc += ds * k_vec
 
-        # dK += ds * Q (atomic add to shared KV)
-        tl.atomic_add(DKV_ptr + kv_base + d_range * stride_kv_d, (ds * q).to(tl.bfloat16), mask=d_range < D)
+                # dK += ds * Q (atomic add to shared KV)
+                tl.atomic_add(DKV_ptr + kv_base + d_range * stride_kv_d, ds * q, mask=(d_range < D) & is_valid)
 
-        # dV += p * dO (atomic add)
-        tl.atomic_add(DKV_ptr + kv_base + dv_range * stride_kv_d, (p * dO).to(tl.bfloat16), mask=dv_range < DV)
+                # dV += p * dO (atomic add)
+                tl.atomic_add(DKV_ptr + kv_base + dv_range * stride_kv_d, p * dO, mask=(dv_range < DV) & is_valid)
 
     # Store dQ
     tl.store(DQ_ptr + q_offset + d_range * stride_q_d, dq_acc.to(tl.bfloat16), mask=d_range < D)
@@ -763,9 +771,27 @@ def triton_sparse_attn_bwd(
     D_full = kv.shape[-1] if kv.dim() > 1 else D
     TopK = topk_idxs.shape[-1]
 
-    # Allocate gradient outputs
+    # Ensure topk_idxs is contiguous — expanded tensors (stride=0 from
+    # .expand()) can cause illegal memory access in Triton kernels due to
+    # pointer arithmetic with zero strides.
+    if not topk_idxs.is_contiguous():
+        topk_idxs = topk_idxs.contiguous()
+
+    # Choose BLOCK_K: controls the inner-loop unroll factor.
+    # Smaller BLOCK_K reduces code size / register pressure at the cost of
+    # more outer-loop iterations (runtime overhead is negligible since the
+    # outer loop is a simple counter).
+    if TopK <= 32:
+        BLOCK_K = 16
+    elif TopK <= 128:
+        BLOCK_K = 32
+    else:
+        BLOCK_K = 64
+
+    # Allocate gradient outputs — use f32 for dkv to ensure atomic_add
+    # compatibility and avoid potential bf16 atomic issues.
     dq = torch.zeros_like(q)
-    dkv = torch.zeros((total_Skv, D_full), dtype=torch.bfloat16, device=q.device)
+    dkv = torch.zeros((total_Skv, D_full), dtype=torch.float32, device=q.device)
 
     grid = (total_Sq, H)
 
@@ -783,6 +809,7 @@ def triton_sparse_attn_bwd(
         out.stride(0), out.stride(1), out.stride(2),
         lse.stride(0), lse.stride(1),
         HAS_SINK=(attn_sink is not None),
+        BLOCK_K=BLOCK_K,
     )
 
     # Compute d_sink if needed (gradient w.r.t. bias-only sink)
@@ -800,7 +827,18 @@ def triton_sparse_attn_bwd(
         ds_sink = -p_sink * Di  # (total_Sq, H)
         d_sink = ds_sink.sum(0)  # (H,)
 
-    return {"dq": dq, "dkv": dkv, "d_sink": d_sink}
+    return {"dq": dq, "dkv": dkv.to(torch.bfloat16), "d_sink": d_sink}
+
+
+# ---------------------------------------------------------------------------
+# Fused backward utilities (Triton epilogue kernels for bf16 BMM path)
+# ---------------------------------------------------------------------------
+
+from megatron.plugin.dsa_kernel.triton_sparse_attn_bwd import (
+    fused_mask_scatter_add,
+    fused_exp_mask,
+    should_use_triton_bwd,
+)
 
 
 # ---------------------------------------------------------------------------

--- a/megatron/plugin/dsa_kernel/triton_sparse_attn_bwd.py
+++ b/megatron/plugin/dsa_kernel/triton_sparse_attn_bwd.py
@@ -294,7 +294,7 @@ def _fused_dq_kernel(
         DO_ptr + pid_q * stride_do_s + h_range[:, None] * stride_do_h + d_range[None, :] * stride_do_d,
         mask=(h_range[:, None] < H) & (d_range[None, :] < D),
         other=0.0,
-    ).to(tl.float16)  # (BLOCK_H, D) f16 for tl.dot
+    ).to(tl.bfloat16)  # (BLOCK_H, D) bf16 for tl.dot
 
     # Accumulator for dQ
     dQ_acc = tl.zeros([BLOCK_H, D], dtype=tl.float32)
@@ -322,7 +322,7 @@ def _fused_dq_kernel(
             KV_GATHERED_ptr + pid_q * stride_kv_s + k_range[:, None] * stride_kv_k + d_range[None, :] * stride_kv_d,
             mask=k_valid_mask[:, None] & (d_range[None, :] < D),
             other=0.0,
-        ).to(tl.float16)  # (BLOCK_K, D) f16
+        ).to(tl.bfloat16)  # (BLOCK_K, D) bf16
 
         # P = exp(scores - lse) * valid — in-register, never written to GMEM
         P_tile = tl.exp(scores_tile - lse_vals[:, None])  # (BLOCK_H, BLOCK_K)
@@ -338,7 +338,7 @@ def _fused_dq_kernel(
         dS_tile = P_tile * (dov_tile - di_vals[:, None]) * softmax_scale
 
         # dQ += dS @ K — WGMMA accumulation
-        dQ_acc += tl.dot(dS_tile.to(tl.float16), K_tile)  # (BLOCK_H, D) f32
+        dQ_acc += tl.dot(dS_tile.to(tl.bfloat16), K_tile)  # (BLOCK_H, D) f32
 
     # Store dQ
     tl.store(
@@ -411,7 +411,7 @@ def _fused_dkv_kernel(
         KV_GATHERED_ptr + pid_q * stride_kv_s + k_range[:, None] * stride_kv_k + d_range[None, :] * stride_kv_d,
         mask=k_valid_mask[:, None] & (d_range[None, :] < D),
         other=0.0,
-    ).to(tl.float16)  # (BLOCK_K, D) f16
+    ).to(tl.bfloat16)  # (BLOCK_K, D) bf16
 
     # Accumulator for dKV: (BLOCK_K, D) f32
     dKV_acc = tl.zeros([BLOCK_K, D], dtype=tl.float32)
@@ -443,13 +443,13 @@ def _fused_dkv_kernel(
             Q_ptr + pid_q * stride_q_s + h_range[:, None] * stride_q_h + d_range[None, :] * stride_q_d,
             mask=h_mask[:, None] & (d_range[None, :] < D),
             other=0.0,
-        ).to(tl.float16)  # (BLOCK_H, D) f16
+        ).to(tl.bfloat16)  # (BLOCK_H, D) bf16
 
         dO_tile = tl.load(
             DO_ptr + pid_q * stride_do_s + h_range[:, None] * stride_do_h + d_range[None, :] * stride_do_d,
             mask=h_mask[:, None] & (d_range[None, :] < D),
             other=0.0,
-        ).to(tl.float16)  # (BLOCK_H, D) f16
+        ).to(tl.bfloat16)  # (BLOCK_H, D) bf16
 
         # P = exp(scores - lse) * valid — in-register
         P_tile = tl.exp(scores_tile - lse_tile[:, None])  # (BLOCK_H, BLOCK_K)
@@ -465,8 +465,8 @@ def _fused_dkv_kernel(
         dS_tile = P_tile * (dov_tile - di_tile[:, None]) * softmax_scale
 
         # dKV += dS^T @ Q + P^T @ dO (combined dK + dV for shared latent)
-        dKV_acc += tl.dot(tl.trans(dS_tile.to(tl.float16)), Q_tile)   # (BLOCK_K, D)
-        dKV_acc += tl.dot(tl.trans(P_tile.to(tl.float16)), dO_tile)   # (BLOCK_K, D)
+        dKV_acc += tl.dot(tl.trans(dS_tile.to(tl.bfloat16)), Q_tile)   # (BLOCK_K, D)
+        dKV_acc += tl.dot(tl.trans(P_tile.to(tl.bfloat16)), dO_tile)   # (BLOCK_K, D)
 
     # Store dKV_gathered
     tl.store(
@@ -735,9 +735,14 @@ def sorted_scatter_add(
     src_flat = dkv_gathered.reshape(-1, d_kv).contiguous()
     BLOCK_D = triton.next_power_of_2(d_kv)
 
-    # Clamp max_run to actual max for tighter loop bound
+    # Check if any run exceeds max_run — if so, fall back to direct scatter
+    # (the kernel loop is bounded by MAX_RUN and would silently drop elements)
     actual_max_run = int(run_lengths.max().item())
-    effective_max_run = min(max_run, actual_max_run)
+    if actual_max_run > max_run:
+        fused_mask_scatter_add(dkv_gathered, flat_idxs, valid_flat, dkv_out)
+        return
+
+    effective_max_run = actual_max_run
     # Round up to power of 2 for Triton constexpr
     effective_max_run = triton.next_power_of_2(effective_max_run)
 

--- a/megatron/plugin/dsa_kernel/triton_sparse_attn_bwd.py
+++ b/megatron/plugin/dsa_kernel/triton_sparse_attn_bwd.py
@@ -1,0 +1,253 @@
+# Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
+
+"""
+Optimized backward utilities for sparse attention (MLA/DSA).
+
+Strategy: keep cuBLAS BMM for matmul (Tensor Core), use Triton only for
+fusing small epilogue kernels that PyTorch launches separately.
+
+Optimizations over the baseline PyTorch BMM backward:
+  1. bf16 BMM: skip f32 upcast of kv_gathered (saves 384MB allocation +
+     ~1.2GB DRAM bandwidth). cuBLAS bf16 matmul uses f32 accumulation
+     internally, so precision is equivalent.
+  2. Fused mask+scatter: merge masked_fill_ + scatter_add_ into one Triton
+     kernel that reads dkv_gathered once, skips invalid entries, and does
+     f32 atomic_add directly to the target buffer. Saves 384MB read pass.
+  3. Fused exp+mask: merge exp(scores - lse) + masked_fill_(~valid, 0) into
+     one Triton kernel (saves 24MB read/write + 1 kernel launch).
+
+Key MLA/DSA properties exploited:
+  - K == V == kv (single latent vector): 1 gather, dK+dV combine naturally
+  - All heads share indices: gather is (total_Sq, TopK, d_kv), not (S, H, T, d)
+  - kv_is_shared (d == d_v == d_kv): baddbmm fuses dK + dV in-place
+"""
+
+from __future__ import annotations
+
+import torch
+from torch import Tensor
+
+import triton
+import triton.language as tl
+
+
+# ---------------------------------------------------------------------------
+# Triton Kernel: Fused mask + scatter_add
+# ---------------------------------------------------------------------------
+
+
+@triton.jit
+def _fused_mask_scatter_kernel(
+    SRC_ptr, DST_ptr, IDX_ptr, VALID_ptr,
+    total_elements,
+    d_kv: tl.constexpr,
+    stride_src_row, stride_src_d,
+    stride_dst_row, stride_dst_d,
+    BLOCK_D: tl.constexpr,
+):
+    """One-pass fused masked_fill + scatter_add.
+
+    For each element in flattened (total_Sq * TopK):
+      - If valid: atomic_add src[element, :] to dst[idx[element], :]
+      - If invalid: skip (no need to zero — we never read it again)
+
+    This eliminates the separate masked_fill_ pass (384MB read+write)
+    and the separate scatter_add_ pass (384MB read + random write).
+    Combined: single 384MB sequential read + small random writes to L2-resident dst.
+
+    Grid: (total_elements,) — one program per (query, topk_pos) pair.
+    Each program handles one d_kv-dimensional row.
+    """
+    pid = tl.program_id(0)
+    if pid >= total_elements:
+        return
+
+    # Check validity
+    is_valid = tl.load(VALID_ptr + pid)
+    if not is_valid:
+        return
+
+    # Load target index
+    target_idx = tl.load(IDX_ptr + pid)
+
+    # Load source row and atomic-add to destination
+    d_range = tl.arange(0, BLOCK_D)
+    mask = d_range < d_kv
+
+    src_row = tl.load(
+        SRC_ptr + pid * stride_src_row + d_range * stride_src_d,
+        mask=mask, other=0.0
+    )
+    tl.atomic_add(
+        DST_ptr + target_idx * stride_dst_row + d_range * stride_dst_d,
+        src_row,
+        mask=mask
+    )
+
+
+# ---------------------------------------------------------------------------
+# Triton Kernel: Fused exp + mask (scores → P)
+# ---------------------------------------------------------------------------
+
+
+@triton.jit
+def _fused_exp_mask_kernel(
+    SCORES_ptr, LSE_ptr, VALID_ptr, P_ptr,
+    total_Sq, np_, TopK,
+    stride_scores_s, stride_scores_h, stride_scores_k,
+    stride_lse_s, stride_lse_h,
+    stride_valid_s, stride_valid_k,
+    stride_p_s, stride_p_h, stride_p_k,
+    BLOCK_K: tl.constexpr,
+):
+    """Fused: P = exp(scores - lse) * valid_mask.
+
+    Merges 3 ops into 1 kernel:
+      1. scores - lse (broadcast subtraction)
+      2. exp(...)
+      3. masked_fill_(~valid, 0.0)
+
+    Grid: (total_Sq, np_) — one program per (query, head) pair.
+    Each program processes TopK values in tiles of BLOCK_K.
+    """
+    pid_s = tl.program_id(0)  # query index
+    pid_h = tl.program_id(1)  # head index
+
+    if pid_s >= total_Sq:
+        return
+
+    # Load LSE for this (query, head)
+    lse_val = tl.load(LSE_ptr + pid_s * stride_lse_s + pid_h * stride_lse_h)
+
+    # Process TopK in tiles
+    for tile_start in range(0, TopK, BLOCK_K):
+        k_offs = tile_start + tl.arange(0, BLOCK_K)
+        k_mask = k_offs < TopK
+
+        # Load scores
+        score_ptrs = SCORES_ptr + pid_s * stride_scores_s + pid_h * stride_scores_h + k_offs * stride_scores_k
+        scores = tl.load(score_ptrs, mask=k_mask, other=0.0)
+
+        # Load validity
+        valid_ptrs = VALID_ptr + pid_s * stride_valid_s + k_offs * stride_valid_k
+        valid = tl.load(valid_ptrs, mask=k_mask, other=0).to(tl.int1)
+
+        # Compute P = exp(score - lse) * valid
+        p = tl.exp(scores - lse_val)
+        p = tl.where(valid & k_mask, p, 0.0)
+
+        # Store
+        p_ptrs = P_ptr + pid_s * stride_p_s + pid_h * stride_p_h + k_offs * stride_p_k
+        tl.store(p_ptrs, p, mask=k_mask)
+
+
+# ---------------------------------------------------------------------------
+# Python API: Fused scatter
+# ---------------------------------------------------------------------------
+
+
+def fused_mask_scatter_add(
+    dkv_gathered: Tensor,
+    flat_idxs: Tensor,
+    valid_flat: Tensor,
+    dkv_out: Tensor,
+) -> None:
+    """Fused masked_fill + scatter_add in one pass.
+
+    Instead of:
+        dkv_gathered.masked_fill_(~valid.unsqueeze(-1), 0.0)  # 384MB read+write
+        dkv_out.scatter_add_(0, idx.expand(...), dkv_gathered.reshape(...))  # 384MB read
+
+    This does a single pass: read each row, skip if invalid, atomic_add if valid.
+
+    Args:
+        dkv_gathered: (total_Sq, TopK, d_kv) f32 — gradient w.r.t. gathered KV.
+        flat_idxs: (total_Sq * TopK,) int64 — scatter target indices.
+        valid_flat: (total_Sq * TopK,) bool — validity mask.
+        dkv_out: (total_Skv, d_kv) f32 — output buffer (modified in-place).
+    """
+    total_elements = flat_idxs.shape[0]
+    d_kv = dkv_out.shape[-1]
+
+    # Round up BLOCK_D to power of 2
+    BLOCK_D = triton.next_power_of_2(d_kv)
+
+    # Flatten source for row-major access
+    src_flat = dkv_gathered.reshape(-1, d_kv)
+
+    grid = (total_elements,)
+    _fused_mask_scatter_kernel[grid](
+        src_flat, dkv_out, flat_idxs, valid_flat,
+        total_elements,
+        d_kv,
+        src_flat.stride(0), src_flat.stride(1),
+        dkv_out.stride(0), dkv_out.stride(1),
+        BLOCK_D=BLOCK_D,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Python API: Fused exp + mask
+# ---------------------------------------------------------------------------
+
+
+def fused_exp_mask(
+    scores: Tensor,
+    lse: Tensor,
+    valid_shared: Tensor,
+    np_: int,
+) -> Tensor:
+    """Fused P = exp(scores - lse) * valid, replacing 3 separate ops.
+
+    Args:
+        scores: (total_Sq, np_, TopK) f32 — raw attention scores (already scaled).
+        lse: (total_Sq, np_) f32 — log-sum-exp from forward.
+        valid_shared: (total_Sq, TopK) bool — validity mask (shared across heads).
+        np_: number of heads.
+
+    Returns:
+        P: (total_Sq, np_, TopK) f32 — attention probabilities.
+    """
+    total_Sq, _, TopK = scores.shape
+
+    P = torch.empty_like(scores)
+
+    # valid_shared is (total_Sq, TopK) — shared across heads
+    BLOCK_K = triton.next_power_of_2(TopK) if TopK <= 1024 else 1024
+
+    grid = (total_Sq, np_)
+    _fused_exp_mask_kernel[grid](
+        scores, lse, valid_shared, P,
+        total_Sq, np_, TopK,
+        scores.stride(0), scores.stride(1), scores.stride(2),
+        lse.stride(0), lse.stride(1),
+        valid_shared.stride(0), valid_shared.stride(1),
+        P.stride(0), P.stride(1), P.stride(2),
+        BLOCK_K=BLOCK_K,
+    )
+    return P
+
+
+# ---------------------------------------------------------------------------
+# Adaptive routing (kept for backward compatibility with existing callers)
+# ---------------------------------------------------------------------------
+
+_TRITON_BWD_MEMORY_THRESHOLD = 64 * 1024 * 1024  # 64 MB
+
+
+def should_use_triton_bwd(total_Sq: int, TopK: int, d_kv: int, H: int, shared_indices: bool) -> bool:
+    """Determine whether to use optimized backward path.
+
+    The optimized path uses bf16 BMM + Triton fused epilogues.
+    Always returns True for now since the optimized path is strictly better
+    (same cuBLAS matmul, less memory, fewer kernel launches).
+    """
+    # The bf16 BMM path is always better: same precision (f32 accumulation),
+    # less memory (no f32 kv_gathered), fewer launches (fused exp+mask, fused scatter).
+    # Only fall back for very small configs where kernel launch overhead dominates.
+    if shared_indices:
+        gather_bytes = total_Sq * TopK * d_kv * 4
+    else:
+        gather_bytes = total_Sq * H * TopK * d_kv * 4
+    total_intermediate = gather_bytes * 2
+    return total_intermediate > _TRITON_BWD_MEMORY_THRESHOLD

--- a/megatron/plugin/dsa_kernel/triton_sparse_attn_bwd.py
+++ b/megatron/plugin/dsa_kernel/triton_sparse_attn_bwd.py
@@ -229,6 +229,532 @@ def fused_exp_mask(
 
 
 # ---------------------------------------------------------------------------
+# Triton Kernel: Fused dQ (eliminates P, dov, dS materialization)
+# ---------------------------------------------------------------------------
+
+
+def _fused_dq_configs():
+    """Autotune configs for fused dQ kernel."""
+    configs = []
+    for block_k in [16, 32, 64]:
+        for nw in [4, 8]:
+            configs.append(
+                triton.Config({"BLOCK_K": block_k}, num_warps=nw, num_stages=2)
+            )
+    return configs
+
+
+@triton.autotune(configs=_fused_dq_configs(), key=["TopK", "D", "H"])
+@triton.jit
+def _fused_dq_kernel(
+    SCORES_ptr, LSE_ptr, DI_ptr, DO_ptr, KV_GATHERED_ptr, VALID_ptr, DQ_ptr,
+    softmax_scale,
+    total_Sq, H: tl.constexpr, TopK: tl.constexpr, D: tl.constexpr,
+    stride_scores_s, stride_scores_h, stride_scores_k,
+    stride_lse_s, stride_lse_h,
+    stride_di_s, stride_di_h,
+    stride_do_s, stride_do_h, stride_do_d,
+    stride_kv_s, stride_kv_k, stride_kv_d,
+    stride_valid_s, stride_valid_k,
+    stride_dq_s, stride_dq_h, stride_dq_d,
+    BLOCK_H: tl.constexpr,
+    BLOCK_K: tl.constexpr,
+):
+    """Fused dQ kernel: computes dQ without materializing P, dov, dS.
+
+    For each (query, head-block):
+      dQ[q, h, :] = sum_k( dS[q, h, k] * K[q, k, :] )
+    where dS = P * (dov - Di) * scale, P = exp(scores - lse) * valid,
+    dov = dO @ K^T (since K==V in shared-latent case).
+
+    Grid: (total_Sq, H // BLOCK_H)
+    """
+    pid_q = tl.program_id(0)
+    pid_hb = tl.program_id(1)
+
+    if pid_q >= total_Sq:
+        return
+
+    h_start = pid_hb * BLOCK_H
+    h_range = h_start + tl.arange(0, BLOCK_H)  # (BLOCK_H,)
+    d_range = tl.arange(0, D)  # (D,)
+
+    # Load LSE and Di for this query's head-block
+    lse_vals = tl.load(
+        LSE_ptr + pid_q * stride_lse_s + h_range * stride_lse_h,
+        mask=h_range < H, other=0.0,
+    )  # (BLOCK_H,) f32
+    di_vals = tl.load(
+        DI_ptr + pid_q * stride_di_s + h_range * stride_di_h,
+        mask=h_range < H, other=0.0,
+    )  # (BLOCK_H,) f32
+
+    # Load dO tile: (BLOCK_H, D) — loaded once, reused across all TopK tiles
+    dO_tile = tl.load(
+        DO_ptr + pid_q * stride_do_s + h_range[:, None] * stride_do_h + d_range[None, :] * stride_do_d,
+        mask=(h_range[:, None] < H) & (d_range[None, :] < D),
+        other=0.0,
+    ).to(tl.float16)  # (BLOCK_H, D) f16 for tl.dot
+
+    # Accumulator for dQ
+    dQ_acc = tl.zeros([BLOCK_H, D], dtype=tl.float32)
+
+    # Tiled iteration over TopK
+    for tile_start in range(0, TopK, BLOCK_K):
+        k_range = tile_start + tl.arange(0, BLOCK_K)  # (BLOCK_K,)
+        k_valid_mask = k_range < TopK
+
+        # Load validity (shared across heads)
+        valid_tile = tl.load(
+            VALID_ptr + pid_q * stride_valid_s + k_range * stride_valid_k,
+            mask=k_valid_mask, other=0,
+        ).to(tl.int1)  # (BLOCK_K,)
+
+        # Load scores tile: (BLOCK_H, BLOCK_K)
+        scores_tile = tl.load(
+            SCORES_ptr + pid_q * stride_scores_s + h_range[:, None] * stride_scores_h + k_range[None, :] * stride_scores_k,
+            mask=(h_range[:, None] < H) & k_valid_mask[None, :],
+            other=float("-inf"),
+        )  # (BLOCK_H, BLOCK_K) f32
+
+        # Load K tile (K==V): (BLOCK_K, D)
+        K_tile = tl.load(
+            KV_GATHERED_ptr + pid_q * stride_kv_s + k_range[:, None] * stride_kv_k + d_range[None, :] * stride_kv_d,
+            mask=k_valid_mask[:, None] & (d_range[None, :] < D),
+            other=0.0,
+        ).to(tl.float16)  # (BLOCK_K, D) f16
+
+        # P = exp(scores - lse) * valid — in-register, never written to GMEM
+        P_tile = tl.exp(scores_tile - lse_vals[:, None])  # (BLOCK_H, BLOCK_K)
+        P_tile = tl.where(
+            valid_tile[None, :] & k_valid_mask[None, :],
+            P_tile, 0.0,
+        )
+
+        # dov = dO @ K^T — WGMMA (since K==V)
+        dov_tile = tl.dot(dO_tile, tl.trans(K_tile))  # (BLOCK_H, BLOCK_K) f32
+
+        # dS = P * (dov - Di) * scale — in-register
+        dS_tile = P_tile * (dov_tile - di_vals[:, None]) * softmax_scale
+
+        # dQ += dS @ K — WGMMA accumulation
+        dQ_acc += tl.dot(dS_tile.to(tl.float16), K_tile)  # (BLOCK_H, D) f32
+
+    # Store dQ
+    tl.store(
+        DQ_ptr + pid_q * stride_dq_s + h_range[:, None] * stride_dq_h + d_range[None, :] * stride_dq_d,
+        dQ_acc,
+        mask=(h_range[:, None] < H) & (d_range[None, :] < D),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Triton Kernel: Fused dKV (eliminates P, dov, dS materialization)
+# ---------------------------------------------------------------------------
+
+
+def _fused_dkv_configs():
+    """Autotune configs for fused dKV kernel."""
+    configs = []
+    for block_h in [16, 32]:
+        for nw in [4, 8]:
+            configs.append(
+                triton.Config({"BLOCK_H": block_h}, num_warps=nw, num_stages=2)
+            )
+    return configs
+
+
+@triton.autotune(configs=_fused_dkv_configs(), key=["TopK", "D", "H"])
+@triton.jit
+def _fused_dkv_kernel(
+    SCORES_ptr, LSE_ptr, DI_ptr, DO_ptr, Q_ptr, KV_GATHERED_ptr, VALID_ptr, DKV_ptr,
+    softmax_scale,
+    total_Sq, H: tl.constexpr, TopK: tl.constexpr, D: tl.constexpr,
+    stride_scores_s, stride_scores_h, stride_scores_k,
+    stride_lse_s, stride_lse_h,
+    stride_di_s, stride_di_h,
+    stride_do_s, stride_do_h, stride_do_d,
+    stride_q_s, stride_q_h, stride_q_d,
+    stride_kv_s, stride_kv_k, stride_kv_d,
+    stride_valid_s, stride_valid_k,
+    stride_dkv_s, stride_dkv_k, stride_dkv_d,
+    BLOCK_K: tl.constexpr,
+    BLOCK_H: tl.constexpr,
+):
+    """Fused dKV kernel: computes dKV_gathered without materializing P, dov, dS.
+
+    For D==DV (shared latent) case:
+      dKV[q, k, :] = sum_h( dS[q,h,k] * Q[q,h,:] + P[q,h,k] * dO[q,h,:] )
+
+    Grid: (total_Sq, ceil(TopK / BLOCK_K))
+    Each program reduces across all H heads for BLOCK_K KV positions.
+    """
+    pid_q = tl.program_id(0)
+    pid_kb = tl.program_id(1)
+
+    if pid_q >= total_Sq:
+        return
+
+    k_start = pid_kb * BLOCK_K
+    k_range = k_start + tl.arange(0, BLOCK_K)  # (BLOCK_K,)
+    k_valid_mask = k_range < TopK
+    d_range = tl.arange(0, D)  # (D,)
+
+    # Load validity (shared across heads)
+    valid_tile = tl.load(
+        VALID_ptr + pid_q * stride_valid_s + k_range * stride_valid_k,
+        mask=k_valid_mask, other=0,
+    ).to(tl.int1)  # (BLOCK_K,)
+
+    # Load K tile once (K==V, reused across all head tiles)
+    K_tile = tl.load(
+        KV_GATHERED_ptr + pid_q * stride_kv_s + k_range[:, None] * stride_kv_k + d_range[None, :] * stride_kv_d,
+        mask=k_valid_mask[:, None] & (d_range[None, :] < D),
+        other=0.0,
+    ).to(tl.float16)  # (BLOCK_K, D) f16
+
+    # Accumulator for dKV: (BLOCK_K, D) f32
+    dKV_acc = tl.zeros([BLOCK_K, D], dtype=tl.float32)
+
+    # Reduce across all heads in tiles of BLOCK_H
+    for h_start in range(0, H, BLOCK_H):
+        h_range = h_start + tl.arange(0, BLOCK_H)  # (BLOCK_H,)
+        h_mask = h_range < H
+
+        # Load scores tile: (BLOCK_H, BLOCK_K) f32
+        scores_tile = tl.load(
+            SCORES_ptr + pid_q * stride_scores_s + h_range[:, None] * stride_scores_h + k_range[None, :] * stride_scores_k,
+            mask=h_mask[:, None] & k_valid_mask[None, :],
+            other=float("-inf"),
+        )
+
+        # Load per-head scalars
+        lse_tile = tl.load(
+            LSE_ptr + pid_q * stride_lse_s + h_range * stride_lse_h,
+            mask=h_mask, other=0.0,
+        )  # (BLOCK_H,)
+        di_tile = tl.load(
+            DI_ptr + pid_q * stride_di_s + h_range * stride_di_h,
+            mask=h_mask, other=0.0,
+        )  # (BLOCK_H,)
+
+        # Load Q and dO tiles: (BLOCK_H, D)
+        Q_tile = tl.load(
+            Q_ptr + pid_q * stride_q_s + h_range[:, None] * stride_q_h + d_range[None, :] * stride_q_d,
+            mask=h_mask[:, None] & (d_range[None, :] < D),
+            other=0.0,
+        ).to(tl.float16)  # (BLOCK_H, D) f16
+
+        dO_tile = tl.load(
+            DO_ptr + pid_q * stride_do_s + h_range[:, None] * stride_do_h + d_range[None, :] * stride_do_d,
+            mask=h_mask[:, None] & (d_range[None, :] < D),
+            other=0.0,
+        ).to(tl.float16)  # (BLOCK_H, D) f16
+
+        # P = exp(scores - lse) * valid — in-register
+        P_tile = tl.exp(scores_tile - lse_tile[:, None])  # (BLOCK_H, BLOCK_K)
+        P_tile = tl.where(
+            valid_tile[None, :] & k_valid_mask[None, :] & h_mask[:, None],
+            P_tile, 0.0,
+        )
+
+        # dov = dO @ K^T — WGMMA (K==V)
+        dov_tile = tl.dot(dO_tile, tl.trans(K_tile))  # (BLOCK_H, BLOCK_K)
+
+        # dS = P * (dov - Di) * scale — in-register
+        dS_tile = P_tile * (dov_tile - di_tile[:, None]) * softmax_scale
+
+        # dKV += dS^T @ Q + P^T @ dO (combined dK + dV for shared latent)
+        dKV_acc += tl.dot(tl.trans(dS_tile.to(tl.float16)), Q_tile)   # (BLOCK_K, D)
+        dKV_acc += tl.dot(tl.trans(P_tile.to(tl.float16)), dO_tile)   # (BLOCK_K, D)
+
+    # Store dKV_gathered
+    tl.store(
+        DKV_ptr + pid_q * stride_dkv_s + k_range[:, None] * stride_dkv_k + d_range[None, :] * stride_dkv_d,
+        dKV_acc,
+        mask=k_valid_mask[:, None] & (d_range[None, :] < D),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Python API: Fused dQ
+# ---------------------------------------------------------------------------
+
+
+def fused_dq(
+    scores: Tensor,
+    lse: Tensor,
+    Di: Tensor,
+    dO: Tensor,
+    kv_gathered: Tensor,
+    valid_shared: Tensor,
+    softmax_scale: float,
+) -> Tensor:
+    """Fused dQ computation — eliminates P, dov, dS materialization.
+
+    Replaces:
+        P = exp(scores - lse) * valid          # (S, H, TopK) f32
+        dov = BMM(dO, V^T)                     # (S, H, TopK) f32
+        dS = P * (dov - Di) * scale            # (S, H, TopK) f32
+        dQ = BMM(dS, K)                        # (S, H, D) f32
+
+    With a single Triton kernel that keeps P, dov, dS in registers.
+    Saves ~768MB intermediate memory for typical training configs.
+
+    Args:
+        scores: (total_Sq, H, TopK) f32 — pre-computed by cuBLAS BMM.
+        lse: (total_Sq, H) f32 — from forward pass.
+        Di: (total_Sq, H) f32 — sum(dO * O, dim=-1).
+        dO: (total_Sq, H, D) bf16 — upstream gradient.
+        kv_gathered: (total_Sq, TopK, D) bf16 — gathered KV (K==V).
+        valid_shared: (total_Sq, TopK) bool — validity mask.
+        softmax_scale: float.
+
+    Returns:
+        dQ: (total_Sq, H, D) f32.
+    """
+    total_Sq, H, TopK = scores.shape
+    D = kv_gathered.shape[-1]
+
+    dQ = torch.empty((total_Sq, H, D), dtype=torch.float32, device=scores.device)
+
+    BLOCK_H = 16
+    grid = (total_Sq, H // BLOCK_H)
+
+    _fused_dq_kernel[grid](
+        scores, lse, Di, dO, kv_gathered, valid_shared, dQ,
+        softmax_scale,
+        total_Sq, H, TopK, D,
+        scores.stride(0), scores.stride(1), scores.stride(2),
+        lse.stride(0), lse.stride(1),
+        Di.stride(0), Di.stride(1),
+        dO.stride(0), dO.stride(1), dO.stride(2),
+        kv_gathered.stride(0), kv_gathered.stride(1), kv_gathered.stride(2),
+        valid_shared.stride(0), valid_shared.stride(1),
+        dQ.stride(0), dQ.stride(1), dQ.stride(2),
+        BLOCK_H=BLOCK_H,
+    )
+    return dQ
+
+
+# ---------------------------------------------------------------------------
+# Python API: Fused dKV
+# ---------------------------------------------------------------------------
+
+
+def fused_dkv(
+    scores: Tensor,
+    lse: Tensor,
+    Di: Tensor,
+    dO: Tensor,
+    query: Tensor,
+    kv_gathered: Tensor,
+    valid_shared: Tensor,
+    softmax_scale: float,
+) -> Tensor:
+    """Fused dKV computation for shared-latent (D==DV) case.
+
+    Replaces:
+        P = exp(scores - lse) * valid
+        dov = BMM(dO, V^T)
+        dS = P * (dov - Di) * scale
+        dKV = BMM(dS^T, Q) + BMM(P^T, dO)    # combined dK + dV
+
+    With a single Triton kernel that keeps P, dov, dS in registers.
+
+    Args:
+        scores: (total_Sq, H, TopK) f32 — pre-computed by cuBLAS BMM.
+        lse: (total_Sq, H) f32 — from forward pass.
+        Di: (total_Sq, H) f32 — sum(dO * O, dim=-1).
+        dO: (total_Sq, H, D) bf16 — upstream gradient.
+        query: (total_Sq, H, D) bf16 — original query.
+        kv_gathered: (total_Sq, TopK, D) bf16 — gathered KV (K==V).
+        valid_shared: (total_Sq, TopK) bool — validity mask.
+        softmax_scale: float.
+
+    Returns:
+        dKV_gathered: (total_Sq, TopK, D) f32.
+    """
+    total_Sq, H, TopK = scores.shape
+    D = kv_gathered.shape[-1]
+
+    dKV = torch.empty((total_Sq, TopK, D), dtype=torch.float32, device=scores.device)
+
+    BLOCK_K = 16  # Fixed for dKV (TopK positions per program)
+    grid = (total_Sq, triton.cdiv(TopK, BLOCK_K))
+
+    _fused_dkv_kernel[grid](
+        scores, lse, Di, dO, query, kv_gathered, valid_shared, dKV,
+        softmax_scale,
+        total_Sq, H, TopK, D,
+        scores.stride(0), scores.stride(1), scores.stride(2),
+        lse.stride(0), lse.stride(1),
+        Di.stride(0), Di.stride(1),
+        dO.stride(0), dO.stride(1), dO.stride(2),
+        query.stride(0), query.stride(1), query.stride(2),
+        kv_gathered.stride(0), kv_gathered.stride(1), kv_gathered.stride(2),
+        valid_shared.stride(0), valid_shared.stride(1),
+        dKV.stride(0), dKV.stride(1), dKV.stride(2),
+        BLOCK_K=BLOCK_K,
+    )
+    return dKV
+
+
+# ---------------------------------------------------------------------------
+# Triton Kernel: Sorted scatter_add with local reduction
+# ---------------------------------------------------------------------------
+
+
+@triton.jit
+def _sorted_scatter_add_kernel(
+    SRC_ptr, DST_ptr,
+    SORTED_TARGETS_ptr, SORT_PERM_ptr, RUN_STARTS_ptr, RUN_LENGTHS_ptr,
+    num_runs,
+    d_kv: tl.constexpr,
+    stride_src_row, stride_src_d,
+    stride_dst_row, stride_dst_d,
+    BLOCK_D: tl.constexpr,
+    MAX_RUN: tl.constexpr,
+):
+    """Sorted scatter_add with local reduction.
+
+    Instead of one atomic_add per source row, this kernel:
+    1. Groups source rows by target index (pre-sorted)
+    2. Accumulates all rows targeting the same KV position in registers
+    3. Issues a single atomic_add per target per program
+
+    This reduces atomic contention by factor of avg_run_length.
+
+    Grid: (num_runs,) — one program per contiguous run of same target.
+    """
+    pid = tl.program_id(0)
+    if pid >= num_runs:
+        return
+
+    run_start = tl.load(RUN_STARTS_ptr + pid)
+    run_len = tl.load(RUN_LENGTHS_ptr + pid)
+    target_idx = tl.load(SORTED_TARGETS_ptr + run_start)
+
+    d_range = tl.arange(0, BLOCK_D)
+    d_mask = d_range < d_kv
+
+    # Local accumulator — reduces all rows in this run
+    acc = tl.zeros([BLOCK_D], dtype=tl.float32)
+
+    for i in range(MAX_RUN):
+        # Triton does not support `break`; use masking to skip past run_len.
+        # Clamp index to run_start to avoid OOB when i >= run_len.
+        safe_offset = tl.where(i < run_len, run_start + i, run_start)
+        src_idx = tl.load(SORT_PERM_ptr + safe_offset)
+        # Load source row; mask gates whether it contributes to accumulator
+        load_mask = d_mask & (i < run_len)
+        row = tl.load(
+            SRC_ptr + src_idx * stride_src_row + d_range * stride_src_d,
+            mask=load_mask, other=0.0,
+        )
+        acc += row
+
+    # Single atomic_add to destination
+    tl.atomic_add(
+        DST_ptr + target_idx * stride_dst_row + d_range * stride_dst_d,
+        acc,
+        mask=d_mask,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Python API: Sorted scatter_add
+# ---------------------------------------------------------------------------
+
+
+def sorted_scatter_add(
+    dkv_gathered: Tensor,
+    flat_idxs: Tensor,
+    valid_flat: Tensor,
+    dkv_out: Tensor,
+    max_run: int = 64,
+) -> None:
+    """Scatter_add with sorted local reduction to minimize atomic contention.
+
+    Pre-sorts source rows by target KV index, then accumulates within each
+    run (consecutive rows targeting same KV position) before issuing atomics.
+    Reduces atomic operations by ~avg_run_length factor.
+
+    Falls back to `fused_mask_scatter_add` if sorting overhead exceeds benefit
+    (small total_elements or low contention scenarios).
+
+    Args:
+        dkv_gathered: (total_Sq, TopK, D) f32 — gradient w.r.t. gathered KV.
+        flat_idxs: (total_Sq * TopK,) int64 — scatter target indices.
+        valid_flat: (total_Sq * TopK,) bool — validity mask.
+        dkv_out: (total_Skv, D) f32 — output buffer (modified in-place).
+        max_run: int — max run length per program (compile-time bound).
+    """
+    total_elements = flat_idxs.shape[0]
+    d_kv = dkv_out.shape[-1]
+
+    # Filter to valid elements only
+    valid_indices = torch.where(valid_flat)[0]  # indices of valid entries
+    if valid_indices.numel() == 0:
+        return
+
+    valid_targets = flat_idxs[valid_indices]  # target KV indices for valid rows
+
+    # Sort by target to group writes to same KV position
+    sorted_targets, sort_order = valid_targets.sort(stable=True)
+    sort_perm = valid_indices[sort_order]  # maps sorted position → original flat index
+
+    # Find run boundaries (where target changes)
+    n_valid = sorted_targets.shape[0]
+    if n_valid <= 1:
+        # Single element — just use direct scatter
+        fused_mask_scatter_add(dkv_gathered, flat_idxs, valid_flat, dkv_out)
+        return
+
+    changes = sorted_targets[1:] != sorted_targets[:-1]  # (n_valid-1,) bool
+    run_boundary_indices = torch.where(changes)[0] + 1  # positions where new run starts
+    run_starts = torch.cat([
+        torch.zeros(1, dtype=torch.int64, device=flat_idxs.device),
+        run_boundary_indices,
+    ])
+    run_ends = torch.cat([
+        run_boundary_indices,
+        torch.tensor([n_valid], dtype=torch.int64, device=flat_idxs.device),
+    ])
+    run_lengths = (run_ends - run_starts).to(torch.int32)
+    num_runs = run_starts.shape[0]
+
+    # Determine if sorting is beneficial (avg run > 1.5)
+    avg_run = n_valid / num_runs
+    if avg_run < 1.5:
+        # Low contention — sorting overhead not worth it, use direct scatter
+        fused_mask_scatter_add(dkv_gathered, flat_idxs, valid_flat, dkv_out)
+        return
+
+    # Flatten source for row-major access
+    src_flat = dkv_gathered.reshape(-1, d_kv).contiguous()
+    BLOCK_D = triton.next_power_of_2(d_kv)
+
+    # Clamp max_run to actual max for tighter loop bound
+    actual_max_run = int(run_lengths.max().item())
+    effective_max_run = min(max_run, actual_max_run)
+    # Round up to power of 2 for Triton constexpr
+    effective_max_run = triton.next_power_of_2(effective_max_run)
+
+    grid = (num_runs,)
+    _sorted_scatter_add_kernel[grid](
+        src_flat, dkv_out,
+        sorted_targets, sort_perm, run_starts, run_lengths.to(torch.int64),
+        num_runs,
+        d_kv,
+        src_flat.stride(0), src_flat.stride(1),
+        dkv_out.stride(0), dkv_out.stride(1),
+        BLOCK_D=BLOCK_D,
+        MAX_RUN=effective_max_run,
+    )
+
+
+# ---------------------------------------------------------------------------
 # Adaptive routing (kept for backward compatibility with existing callers)
 # ---------------------------------------------------------------------------
 

--- a/megatron/plugin/dsa_kernel/triton_sparse_attn_bwd.py
+++ b/megatron/plugin/dsa_kernel/triton_sparse_attn_bwd.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
+# Copyright (c) 2026, FlagOS Contributors. All rights reserved.
 
 """
 Optimized backward utilities for sparse attention (MLA/DSA).

--- a/megatron/plugin/dsa_kernel/triton_sparse_attn_bwd.py
+++ b/megatron/plugin/dsa_kernel/triton_sparse_attn_bwd.py
@@ -519,7 +519,7 @@ def fused_dq(
     dQ = torch.empty((total_Sq, H, D), dtype=torch.float32, device=scores.device)
 
     BLOCK_H = 16
-    grid = (total_Sq, H // BLOCK_H)
+    grid = (total_Sq, triton.cdiv(H, BLOCK_H))
 
     _fused_dq_kernel[grid](
         scores, lse, Di, dO, kv_gathered, valid_shared, dQ,

--- a/tests/unit_tests/plugin/dsa_kernel/conftest.py
+++ b/tests/unit_tests/plugin/dsa_kernel/conftest.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
+# Copyright (c) 2026, FlagOS Contributors. All rights reserved.
 
 """
 Pytest conftest for DSA kernel tests — metrics collection and report generation.

--- a/tests/unit_tests/plugin/dsa_kernel/conftest.py
+++ b/tests/unit_tests/plugin/dsa_kernel/conftest.py
@@ -1,0 +1,201 @@
+# Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
+
+"""
+Pytest conftest for DSA kernel tests — metrics collection and report generation.
+
+Provides:
+- ``dsa_metrics`` fixture: records accuracy, performance, and memory metrics
+- ``--dsa-report`` CLI option: controls output path (default: test_results.md)
+- Session-finish hook: writes collected metrics as Markdown tables
+
+Usage:
+    pytest tests/unit_tests/plugin/dsa_kernel/ -v --dsa-report=report.md
+"""
+
+from __future__ import annotations
+
+import datetime
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+import pytest
+
+
+@dataclass
+class AccuracyRecord:
+    test_class: str
+    test_name: str
+    params: Dict[str, Any]
+    cos_sim: float
+    max_diff: Optional[float] = None
+    mean_diff: Optional[float] = None
+    target: str = "output"
+    status: str = "PASS"
+
+
+@dataclass
+class PerformanceRecord:
+    test_class: str
+    test_name: str
+    params: Dict[str, Any]
+    fused_ms: float
+    unfused_ms: float
+    speedup: float
+    label: str = "fwd"
+
+
+@dataclass
+class MemoryRecord:
+    test_class: str
+    test_name: str
+    params: Dict[str, Any]
+    fused_mb: float
+    unfused_mb: float
+    ratio: float
+
+
+@dataclass
+class MetricCollector:
+    accuracy: List[AccuracyRecord] = field(default_factory=list)
+    performance: List[PerformanceRecord] = field(default_factory=list)
+    memory: List[MemoryRecord] = field(default_factory=list)
+
+    def has_data(self) -> bool:
+        return bool(self.accuracy or self.performance or self.memory)
+
+
+class MetricRecorder:
+    """Per-test facade for recording metrics."""
+
+    def __init__(self, test_class: str, test_name: str, collector: MetricCollector):
+        self._class = test_class
+        self._name = test_name
+        self._collector = collector
+
+    def record_accuracy(self, params, cos_sim, max_diff=None, mean_diff=None,
+                        target="output", status="PASS"):
+        self._collector.accuracy.append(AccuracyRecord(
+            self._class, self._name, params, cos_sim, max_diff, mean_diff, target, status))
+
+    def record_performance(self, params, fused_ms, unfused_ms, speedup, label="fwd"):
+        self._collector.performance.append(PerformanceRecord(
+            self._class, self._name, params, fused_ms, unfused_ms, speedup, label))
+
+    def record_memory(self, params, fused_mb, unfused_mb, ratio):
+        self._collector.memory.append(MemoryRecord(
+            self._class, self._name, params, fused_mb, unfused_mb, ratio))
+
+
+# ---------------------------------------------------------------------------
+# Markdown rendering
+# ---------------------------------------------------------------------------
+
+def _param_cols(records):
+    seen = {}
+    for r in records:
+        for k in r.params:
+            seen.setdefault(k, None)
+    return list(seen.keys())
+
+
+def _md_row(cells):
+    return "| " + " | ".join(str(c) for c in cells) + " |"
+
+
+def _render_accuracy(records):
+    if not records:
+        return "_No accuracy data._\n"
+    pcols = _param_cols(records)
+    hdrs = ["test_class", "test_name", "target"] + pcols + ["cos_sim", "max_diff", "mean_diff", "status"]
+    lines = [_md_row(hdrs), _md_row(["---"] * len(hdrs))]
+    for r in records:
+        row = [r.test_class, r.test_name, r.target]
+        row += [r.params.get(k, "") for k in pcols]
+        row += [f"{r.cos_sim:.6f}",
+                f"{r.max_diff:.4e}" if r.max_diff is not None else "-",
+                f"{r.mean_diff:.4e}" if r.mean_diff is not None else "-",
+                r.status]
+        lines.append(_md_row(row))
+    return "\n".join(lines) + "\n"
+
+
+def _render_performance(records):
+    if not records:
+        return "_No performance data._\n"
+    pcols = _param_cols(records)
+    hdrs = ["test_class", "test_name", "label"] + pcols + ["fused_ms", "unfused_ms", "speedup"]
+    lines = [_md_row(hdrs), _md_row(["---"] * len(hdrs))]
+    for r in records:
+        row = [r.test_class, r.test_name, r.label]
+        row += [r.params.get(k, "") for k in pcols]
+        row += [f"{r.fused_ms:.3f}", f"{r.unfused_ms:.3f}", f"{r.speedup:.2f}x"]
+        lines.append(_md_row(row))
+    return "\n".join(lines) + "\n"
+
+
+def _render_memory(records):
+    if not records:
+        return "_No memory data._\n"
+    pcols = _param_cols(records)
+    hdrs = ["test_class", "test_name"] + pcols + ["fused_MB", "unfused_MB", "ratio"]
+    lines = [_md_row(hdrs), _md_row(["---"] * len(hdrs))]
+    for r in records:
+        row = [r.test_class, r.test_name]
+        row += [r.params.get(k, "") for k in pcols]
+        row += [f"{r.fused_mb:.1f}", f"{r.unfused_mb:.1f}", f"{r.ratio:.2f}x"]
+        lines.append(_md_row(row))
+    return "\n".join(lines) + "\n"
+
+
+def _generate_report(collector: MetricCollector) -> str:
+    now = datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+    parts = [
+        f"# DSA Fused Kernel Test Results\n",
+        f"Generated: {now}\n",
+        "## Accuracy\n",
+        _render_accuracy(collector.accuracy),
+        "\n## Performance\n",
+        _render_performance(collector.performance),
+        "\n## Memory\n",
+        _render_memory(collector.memory),
+    ]
+    return "\n".join(parts)
+
+
+# ---------------------------------------------------------------------------
+# Pytest hooks and fixtures
+# ---------------------------------------------------------------------------
+
+_collector = MetricCollector()
+
+
+def pytest_addoption(parser):
+    parser.addoption(
+        "--dsa-report",
+        action="store",
+        default=None,
+        help="Enable DSA test report generation. Pass a path (relative to test dir) "
+             "to write the markdown report. Omit to skip report generation (CI default).",
+    )
+
+
+@pytest.fixture
+def dsa_metrics(request):
+    """Fixture that provides a MetricRecorder for the current test."""
+    cls_name = request.node.cls.__name__ if request.node.cls else ""
+    test_name = request.node.name
+    return MetricRecorder(cls_name, test_name, _collector)
+
+
+def pytest_sessionfinish(session, exitstatus):
+    """Write collected metrics to markdown — only when --dsa-report is specified."""
+    report_path_str = session.config.getoption("--dsa-report", default=None)
+    if report_path_str is None:
+        return
+    if not _collector.has_data():
+        return
+    test_dir = Path(__file__).parent
+    report_path = test_dir / report_path_str
+    report_path.write_text(_generate_report(_collector), encoding="utf-8")
+    print(f"\n[dsa_metrics] Report written to: {report_path}")

--- a/tests/unit_tests/plugin/dsa_kernel/conftest.py
+++ b/tests/unit_tests/plugin/dsa_kernel/conftest.py
@@ -178,6 +178,25 @@ def pytest_addoption(parser):
         help="Enable DSA test report generation. Pass a path (relative to test dir) "
              "to write the markdown report. Omit to skip report generation (CI default).",
     )
+    parser.addoption(
+        "--run-perf",
+        action="store_true",
+        default=False,
+        help="Run performance benchmark tests (skipped by default).",
+    )
+
+
+def pytest_configure(config):
+    config.addinivalue_line("markers", "perf: mark test as performance benchmark (skipped unless --run-perf)")
+
+
+def pytest_collection_modifyitems(config, items):
+    if config.getoption("--run-perf"):
+        return
+    skip_perf = pytest.mark.skip(reason="Performance test skipped. Use --run-perf to enable.")
+    for item in items:
+        if "perf" in item.keywords:
+            item.add_marker(skip_perf)
 
 
 @pytest.fixture

--- a/tests/unit_tests/plugin/dsa_kernel/test_fused_dsa.py
+++ b/tests/unit_tests/plugin/dsa_kernel/test_fused_dsa.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
+# Copyright (c) 2026, FlagOS Contributors. All rights reserved.
 
 """
 Accuracy and performance tests for FusedIndexerSparseAttnFunc.
@@ -2865,34 +2865,6 @@ class TestIndexerGradAccuracy:
         g_fused = fused_res["grad_q_indexer"].float()
         g_unfused = unfused_res["grad_q_indexer"].float()
 
-        logger.warning(
-            f"  [DEBUG test] fused_loss={fused_res['loss']:.6e}, unfused_loss={unfused_res['loss']:.6e}"
-        )
-        logger.warning(
-            f"  [DEBUG test] g_fused: norm={g_fused.norm().item():.6e}, "
-            f"all_zero={(g_fused == 0).all().item()}, max_abs={g_fused.abs().max().item():.6e}, "
-            f"shape={list(g_fused.shape)}, dtype_orig={fused_res['grad_q_indexer'].dtype}"
-        )
-        logger.warning(
-            f"  [DEBUG test] g_unfused: norm={g_unfused.norm().item():.6e}, "
-            f"all_zero={(g_unfused == 0).all().item()}, max_abs={g_unfused.abs().max().item():.6e}, "
-            f"shape={list(g_unfused.shape)}, dtype_orig={unfused_res['grad_q_indexer'].dtype}"
-        )
-        # Check if fused grad is zero but unfused is not
-        if (g_fused == 0).all() and not (g_unfused == 0).all():
-            logger.warning(
-                "  [DEBUG test] FUSED GRAD IS ALL ZERO! Investigating precomputed grad..."
-            )
-            # Check grad_k and grad_w to see if they are also zero
-            gk_fused = fused_res["grad_k_indexer"].float()
-            gw_fused = fused_res["grad_weights"].float()
-            logger.warning(
-                f"  [DEBUG test] grad_k_fused: norm={gk_fused.norm().item():.6e}, all_zero={(gk_fused==0).all().item()}"
-            )
-            logger.warning(
-                f"  [DEBUG test] grad_w_fused: norm={gw_fused.norm().item():.6e}, all_zero={(gw_fused==0).all().item()}"
-            )
-
         cos_sim = torch.nn.functional.cosine_similarity(
             g_fused.reshape(-1).unsqueeze(0),
             g_unfused.reshape(-1).unsqueeze(0),
@@ -3294,4 +3266,3 @@ class TestIndexerLossConsistency:
             f"[sparse_loss={sparse_loss}] per_token_loss={loss.item():.6f}, "
             f"grad_query_norm={query.grad.float().norm().item():.4e}"
         )
-

--- a/tests/unit_tests/plugin/dsa_kernel/test_fused_dsa.py
+++ b/tests/unit_tests/plugin/dsa_kernel/test_fused_dsa.py
@@ -3266,3 +3266,323 @@ class TestIndexerLossConsistency:
             f"[sparse_loss={sparse_loss}] per_token_loss={loss.item():.6f}, "
             f"grad_query_norm={query.grad.float().norm().item():.4e}"
         )
+
+
+# ===========================================================================
+# Tests: Fused Backward Kernels (fused_dq, fused_dkv, sorted_scatter_add)
+# ===========================================================================
+
+
+def _reference_dq_dkv(
+    scores: Tensor,
+    lse: Tensor,
+    Di: Tensor,
+    dO: Tensor,
+    query: Tensor,
+    kv_gathered: Tensor,
+    valid_shared: Tensor,
+    softmax_scale: float,
+):
+    """Reference PyTorch implementation of dQ and dKV (original BMM path)."""
+    from megatron.plugin.dsa_kernel.triton_sparse_attn_bwd import fused_exp_mask
+
+    S, H, TopK = scores.shape
+
+    # P = exp(scores - lse) * valid
+    P = fused_exp_mask(scores, lse, valid_shared, H)
+
+    # dov = dO @ V^T (K==V in shared latent)
+    dov = torch.bmm(dO.float(), kv_gathered.float().transpose(1, 2))
+
+    # dS = P * (dov - Di) * scale
+    dS = P * (dov - Di.unsqueeze(-1)) * softmax_scale
+
+    # dQ = dS @ K
+    dq = torch.bmm(dS, kv_gathered.float())
+
+    # dKV = dS^T @ Q + P^T @ dO (combined dK + dV for shared latent)
+    dkv_gathered = torch.bmm(dS.transpose(1, 2), query.float())
+    torch.baddbmm(dkv_gathered, P.transpose(1, 2), dO.float(), out=dkv_gathered)
+
+    return dq, dkv_gathered
+
+
+def _make_fused_bwd_tensors(
+    total_Sq: int = 64,
+    H: int = 32,
+    D: int = 512,
+    TopK: int = 128,
+    total_Skv: int = 4096,
+    invalid_ratio: float = 0.1,
+    device: str = "cuda",
+    seed: int = 42,
+):
+    """Generate random test tensors mimicking HP backward inputs."""
+    torch.manual_seed(seed)
+
+    query = torch.randn(total_Sq, H, D, dtype=torch.bfloat16, device=device)
+    kv = torch.randn(total_Skv, D, dtype=torch.bfloat16, device=device)
+    dO = torch.randn(total_Sq, H, D, dtype=torch.bfloat16, device=device)
+    out = torch.randn(total_Sq, H, D, dtype=torch.bfloat16, device=device)
+
+    # Generate random indices (some invalid = -1)
+    topk_idxs = torch.randint(0, total_Skv, (total_Sq, TopK), device=device)
+    n_invalid = int(total_Sq * TopK * invalid_ratio)
+    if n_invalid > 0:
+        invalid_pos = torch.randperm(total_Sq * TopK, device=device)[:n_invalid]
+        topk_idxs.view(-1)[invalid_pos] = -1
+
+    valid_shared = topk_idxs >= 0
+    safe_shared = topk_idxs.clamp(min=0).long()
+
+    # Gather KV
+    flat_idxs = safe_shared.reshape(-1)
+    kv_gathered = kv[flat_idxs].reshape(total_Sq, TopK, D)
+
+    # Scores via BMM (same as real backward)
+    softmax_scale = 1.0 / (D ** 0.5)
+    q_f16 = query.to(torch.float16)
+    k_f16 = kv_gathered[:, :, :D].to(torch.float16)
+    scores = torch.bmm(q_f16, k_f16.transpose(1, 2)).float() * softmax_scale
+
+    # LSE (simulate forward online softmax)
+    scores_masked = scores.clone()
+    scores_masked[:, :, :][~valid_shared.unsqueeze(1).expand_as(scores)] = float("-inf")
+    lse = scores_masked.max(dim=-1).values + torch.log(
+        torch.exp(scores_masked - scores_masked.max(dim=-1, keepdim=True).values)
+        .sum(dim=-1).clamp(min=1e-6)
+    )
+
+    # Di
+    Di = (dO.float() * out.float()).sum(dim=-1)
+
+    return {
+        "scores": scores,
+        "lse": lse,
+        "Di": Di,
+        "dO": dO,
+        "query": query,
+        "kv_gathered": kv_gathered,
+        "valid_shared": valid_shared,
+        "flat_idxs": flat_idxs,
+        "kv": kv,
+        "softmax_scale": softmax_scale,
+        "total_Skv": total_Skv,
+    }
+
+
+@_skip_unless_sm90
+class TestFusedDQ:
+    """Tests for fused_dq Triton kernel."""
+
+    @pytest.fixture(autouse=True)
+    def device(self):
+        return "cuda"
+
+    @pytest.mark.parametrize("total_Sq,H,D,TopK", [
+        (32, 16, 512, 64),
+        (64, 32, 512, 128),
+        (128, 128, 512, 256),
+    ])
+    def test_numerical_accuracy(self, total_Sq, H, D, TopK, device):
+        """Fused dQ matches reference BMM-based dQ."""
+        from megatron.plugin.dsa_kernel.triton_sparse_attn_bwd import fused_dq
+
+        data = _make_fused_bwd_tensors(total_Sq=total_Sq, H=H, D=D, TopK=TopK, device=device)
+
+        ref_dq, _ = _reference_dq_dkv(
+            data["scores"], data["lse"], data["Di"], data["dO"],
+            data["query"], data["kv_gathered"], data["valid_shared"],
+            data["softmax_scale"],
+        )
+
+        fused_result = fused_dq(
+            data["scores"], data["lse"], data["Di"], data["dO"],
+            data["kv_gathered"], data["valid_shared"], data["softmax_scale"],
+        )
+
+        # bf16 WGMMA vs f32 BMM — relaxed tolerance
+        torch.testing.assert_close(fused_result, ref_dq, atol=5e-2, rtol=5e-2)
+        logger.info(
+            f"fused_dq [{total_Sq=}, {H=}, {D=}, {TopK=}]: "
+            f"max_diff={( fused_result - ref_dq).abs().max().item():.4e}"
+        )
+
+    def test_no_nan_inf(self, device):
+        """Fused dQ produces no NaN or Inf."""
+        from megatron.plugin.dsa_kernel.triton_sparse_attn_bwd import fused_dq
+
+        data = _make_fused_bwd_tensors(total_Sq=64, H=32, D=512, TopK=128, device=device)
+        result = fused_dq(
+            data["scores"], data["lse"], data["Di"], data["dO"],
+            data["kv_gathered"], data["valid_shared"], data["softmax_scale"],
+        )
+        assert not torch.isnan(result).any(), "dQ contains NaN"
+        assert not torch.isinf(result).any(), "dQ contains Inf"
+
+
+@_skip_unless_sm90
+class TestFusedDKV:
+    """Tests for fused_dkv Triton kernel."""
+
+    @pytest.fixture(autouse=True)
+    def device(self):
+        return "cuda"
+
+    @pytest.mark.parametrize("total_Sq,H,D,TopK", [
+        (32, 16, 512, 64),
+        (64, 32, 512, 128),
+        (128, 128, 512, 256),
+    ])
+    def test_numerical_accuracy(self, total_Sq, H, D, TopK, device):
+        """Fused dKV matches reference BMM-based dKV."""
+        from megatron.plugin.dsa_kernel.triton_sparse_attn_bwd import fused_dkv
+
+        data = _make_fused_bwd_tensors(total_Sq=total_Sq, H=H, D=D, TopK=TopK, device=device)
+
+        _, ref_dkv = _reference_dq_dkv(
+            data["scores"], data["lse"], data["Di"], data["dO"],
+            data["query"], data["kv_gathered"], data["valid_shared"],
+            data["softmax_scale"],
+        )
+
+        fused_result = fused_dkv(
+            data["scores"], data["lse"], data["Di"], data["dO"],
+            data["query"], data["kv_gathered"], data["valid_shared"],
+            data["softmax_scale"],
+        )
+
+        torch.testing.assert_close(fused_result, ref_dkv, atol=5e-2, rtol=5e-2)
+        logger.info(
+            f"fused_dkv [{total_Sq=}, {H=}, {D=}, {TopK=}]: "
+            f"max_diff={(fused_result - ref_dkv).abs().max().item():.4e}"
+        )
+
+    def test_no_nan_inf(self, device):
+        """Fused dKV produces no NaN or Inf."""
+        from megatron.plugin.dsa_kernel.triton_sparse_attn_bwd import fused_dkv
+
+        data = _make_fused_bwd_tensors(total_Sq=64, H=32, D=512, TopK=128, device=device)
+        result = fused_dkv(
+            data["scores"], data["lse"], data["Di"], data["dO"],
+            data["query"], data["kv_gathered"], data["valid_shared"],
+            data["softmax_scale"],
+        )
+        assert not torch.isnan(result).any(), "dKV contains NaN"
+        assert not torch.isinf(result).any(), "dKV contains Inf"
+
+
+@_skip_unless_sm90
+class TestSortedScatterAdd:
+    """Tests for sorted_scatter_add kernel."""
+
+    @pytest.fixture(autouse=True)
+    def device(self):
+        return "cuda"
+
+    @pytest.mark.parametrize("total_Sq,TopK,total_Skv,D", [
+        (64, 128, 4096, 512),
+        (128, 256, 8192, 512),
+    ])
+    def test_numerical_accuracy(self, total_Sq, TopK, total_Skv, D, device):
+        """Sorted scatter_add matches reference fused_mask_scatter_add."""
+        from megatron.plugin.dsa_kernel.triton_sparse_attn_bwd import (
+            sorted_scatter_add,
+            fused_mask_scatter_add,
+        )
+
+        torch.manual_seed(42)
+
+        dkv_gathered = torch.randn(total_Sq, TopK, D, dtype=torch.float32, device=device)
+        flat_idxs_raw = torch.randint(0, total_Skv, (total_Sq * TopK,), device=device)
+        valid_flat = torch.ones(total_Sq * TopK, dtype=torch.bool, device=device)
+        n_invalid = int(total_Sq * TopK * 0.1)
+        invalid_pos = torch.randperm(total_Sq * TopK, device=device)[:n_invalid]
+        valid_flat[invalid_pos] = False
+        flat_idxs = flat_idxs_raw.long()
+
+        # Reference
+        ref_out = torch.zeros(total_Skv, D, dtype=torch.float32, device=device)
+        fused_mask_scatter_add(dkv_gathered, flat_idxs, valid_flat, ref_out)
+
+        # Sorted scatter
+        test_out = torch.zeros(total_Skv, D, dtype=torch.float32, device=device)
+        sorted_scatter_add(dkv_gathered, flat_idxs, valid_flat, test_out)
+
+        torch.testing.assert_close(test_out, ref_out, atol=1e-5, rtol=1e-5)
+        logger.info(
+            f"sorted_scatter_add [{total_Sq=}, {TopK=}, {total_Skv=}]: "
+            f"max_diff={(test_out - ref_out).abs().max().item():.4e}"
+        )
+
+    def test_high_contention(self, device):
+        """Sorted scatter handles high-contention (many writes to same target)."""
+        from megatron.plugin.dsa_kernel.triton_sparse_attn_bwd import (
+            sorted_scatter_add,
+            fused_mask_scatter_add,
+        )
+
+        torch.manual_seed(123)
+        total_Sq, TopK, D = 128, 64, 512
+        total_Skv = 256  # Small KV pool → high contention
+
+        dkv_gathered = torch.randn(total_Sq, TopK, D, dtype=torch.float32, device=device)
+        flat_idxs = torch.randint(0, total_Skv, (total_Sq * TopK,), dtype=torch.int64, device=device)
+        valid_flat = torch.ones(total_Sq * TopK, dtype=torch.bool, device=device)
+
+        ref_out = torch.zeros(total_Skv, D, dtype=torch.float32, device=device)
+        fused_mask_scatter_add(dkv_gathered, flat_idxs, valid_flat, ref_out)
+
+        test_out = torch.zeros(total_Skv, D, dtype=torch.float32, device=device)
+        sorted_scatter_add(dkv_gathered, flat_idxs, valid_flat, test_out)
+
+        torch.testing.assert_close(test_out, ref_out, atol=1e-4, rtol=1e-4)
+        avg_run = (total_Sq * TopK) / total_Skv
+        logger.info(
+            f"sorted_scatter_add [high contention, avg_run≈{avg_run:.1f}]: "
+            f"max_diff={(test_out - ref_out).abs().max().item():.4e}"
+        )
+
+
+@_skip_unless_sm90
+class TestFusedBackwardIntegration:
+    """End-to-end test: fused backward produces valid gradients via autograd."""
+
+    @pytest.fixture(autouse=True)
+    def device(self):
+        return "cuda"
+
+    @pytest.mark.parametrize("total_Sq,H,D,TopK,total_Skv", [
+        (64, 32, 512, 128, 2048),
+        (128, 128, 512, 256, 4096),
+    ])
+    def test_autograd_no_nan(self, total_Sq, H, D, TopK, total_Skv, device):
+        """Full forward+backward via dsa_sparse_attn produces non-NaN gradients."""
+        from megatron.plugin.dsa_kernel.triton_dsa_kernels import dsa_sparse_attn
+
+        torch.manual_seed(42)
+
+        query = torch.randn(total_Sq, H, D, dtype=torch.bfloat16, device=device, requires_grad=True)
+        kv = torch.randn(total_Skv, D, dtype=torch.bfloat16, device=device, requires_grad=True)
+        topk_idxs = torch.randint(0, total_Skv, (total_Sq, 1, TopK), dtype=torch.int32, device=device)
+        topk_idxs[:, :, -10:] = -1  # Some invalid entries
+        attn_sink = torch.randn(H, dtype=torch.float32, device=device, requires_grad=True)
+        softmax_scale = 1.0 / (D ** 0.5)
+
+        out, lse, _ = dsa_sparse_attn(query, kv, topk_idxs, softmax_scale, D, attn_sink)
+
+        grad_out = torch.randn_like(out)
+        out.backward(grad_out)
+
+        for name, param in [("query", query), ("kv", kv), ("attn_sink", attn_sink)]:
+            assert param.grad is not None, f"{name}.grad is None"
+            assert not torch.isnan(param.grad).any(), f"{name}.grad has NaN"
+            assert not torch.isinf(param.grad).any(), f"{name}.grad has Inf"
+            assert param.grad.abs().sum() > 0, f"{name}.grad is all zeros"
+
+        logger.info(
+            f"autograd_no_nan [{total_Sq=}, {H=}, {TopK=}]: "
+            f"dq_norm={query.grad.float().norm().item():.4e}, "
+            f"dkv_norm={kv.grad.float().norm().item():.4e}"
+        )
+

--- a/tests/unit_tests/plugin/dsa_kernel/test_fused_dsa.py
+++ b/tests/unit_tests/plugin/dsa_kernel/test_fused_dsa.py
@@ -395,729 +395,6 @@ class TestFusedIndexerSparseAttnAccuracy:
 
 
 # ---------------------------------------------------------------------------
-# KL Loss accuracy and calculate_per_token_loss tests
-# ---------------------------------------------------------------------------
-
-
-def _compute_kl_loss_reference(
-    inputs: dict,
-    sparse_loss: bool,
-    calculate_per_token_loss: bool,
-    loss_coeff: float = 0.1,
-) -> Tensor:
-    """Megatron-core unfused KL loss reference (no Triton code).
-
-    Uses the fused path's indexer scoring + top-K selection (same indices),
-    then calls ``compute_dsa_indexer_loss`` for the KL divergence computation.
-
-    This ensures the test validates only the KL computation logic, not
-    differences in top-K selection between implementations.
-
-    Returns scalar loss (f32).
-    """
-    from unittest.mock import MagicMock
-    from megatron.core.transformer.experimental_attention_variant.dsa import (
-        compute_dsa_indexer_loss,
-        _compute_index_scores,
-    )
-    from megatron.plugin.dsa_kernel.triton_dsa_kernels import (
-        _sbhd_to_bshd_indexer_inputs,
-        _indexer_topk_bshd,
-    )
-    from megatron.plugin.dsa_kernel.triton_dsa_utils import compute_ratio_causal_mask
-
-    n_comp = inputs["n_comp"]
-    kv_offset = inputs["kv_offset"]
-    effective_topk = min(inputs["indexer_topk"], n_comp)
-    sq, b, np_, hn = inputs["query"].shape  # noqa: F841
-    ratio = inputs["ratio"]
-
-    # Step 1: Use fused path's indexer scoring + top-K (same as FusedIndexerSparseAttnFunc)
-    q_idx_bshd, k_idx_bsd, w_bsh, w_bsh_scaled = _sbhd_to_bshd_indexer_inputs(
-        inputs["q_indexer"], inputs["k_indexer"],
-        inputs["weights"], inputs["indexer_softmax_scale"],
-    )
-    topk_indices_cmp, _, _ = _indexer_topk_bshd(
-        q_idx_bshd, k_idx_bsd, w_bsh_scaled, effective_topk, ratio
-    )
-    # topk_indices_cmp: (b, sq, effective_topk) — same indices as fused path
-    # Sanitize -1 sentinel values: compute_dsa_indexer_loss uses scatter_ which
-    # does not support negative indices. Replace -1 with 0; the causal_mask ensures
-    # those early rows (all -inf) produce row_valid=False and are zeroed out.
-    topk_indices_for_ref = topk_indices_cmp.clone()
-    topk_indices_for_ref[topk_indices_for_ref < 0] = 0
-
-    # Step 2: Compute index_scores using Megatron-core's _compute_index_scores
-    # (produces full (b, sq, n_comp) scores for compute_dsa_indexer_loss)
-    q_idx = inputs["q_indexer"]        # (sq, b, idx_nh, idx_hd)
-    k_idx = inputs["k_indexer"]        # (n_comp, b, idx_hd)
-    w_idx = inputs["weights"].float() * inputs["indexer_softmax_scale"]  # (sq, b, idx_nh)
-    index_scores = _compute_index_scores(q_idx, w_idx, k_idx)  # (b, sq, n_comp)
-
-    # Step 3: Build causal mask matching fused path
-    causal_mask = compute_ratio_causal_mask(
-        sq, n_comp, ratio, inputs["query"].device, torch.float32
-    ).unsqueeze(0).expand(b, -1, -1)  # (b, sq, n_comp)
-
-    # Apply causal mask to index_scores (same as fused_qk_topk_naive does)
-    index_scores = index_scores + causal_mask
-
-    # Step 4: prepare query and key for attention score computation
-    compressed_kv = inputs["kv_full"][kv_offset:kv_offset + n_comp]  # (n_comp, b, hn)
-    key_for_loss = compressed_kv.unsqueeze(2).expand(-1, -1, np_, -1)  # (n_comp, b, np, hn)
-
-    # Step 5: mock pg_collection with tp.size()=1
-    mock_tp = MagicMock()
-    mock_tp.size.return_value = 1
-    mock_pg = MagicMock()
-    mock_pg.tp = mock_tp
-
-    # Step 6: call compute_dsa_indexer_loss with fused path's topk indices
-    loss = compute_dsa_indexer_loss(
-        index_scores=index_scores,
-        topk_indices=topk_indices_for_ref,
-        query=inputs["query"].detach(),           # (sq, b, np, hn)
-        key=key_for_loss.detach(),                # (n_comp, b, np, hn)
-        softmax_scale=inputs["softmax_scale"],
-        loss_coeff=loss_coeff,
-        sparse_loss=sparse_loss,
-        pg_collection=mock_pg,
-        causal_mask_override=causal_mask,
-        calculate_per_token_loss=calculate_per_token_loss,
-    )
-
-    return loss
-
-
-def _compute_kl_loss_reference_dense(
-    inputs: dict,
-    calculate_per_token_loss: bool,
-    loss_coeff: float = 0.1,
-) -> Tensor:
-    """Dense KL loss reference that matches the fused path's semantics.
-
-    The fused dense path computes target attention probabilities using the FULL
-    LSE from the sparse attention forward (which includes window + compressed +
-    attn_sink positions). This is different from compute_dsa_indexer_loss which
-    computes softmax purely within the compressed key space.
-
-    This reference replicates the fused inference path step-by-step:
-    1. Run indexer top-K selection (same indices as fused)
-    2. Combine indices (compressed + window) and run sparse attention forward
-       to obtain the full LSE
-    3. Call dense_attn_score_recompute with full LSE (target distribution)
-    4. Call dense_indexer_score_recompute (predict distribution)
-    5. Call _kl_loss_from_dense_scores to compute KL divergence
-
-    Returns scalar loss (f32).
-    """
-    from megatron.plugin.dsa_kernel.triton_sparse_attn import triton_sparse_attn_forward
-
-    sq, b, np_, d = inputs["query"].shape
-    n_comp = inputs["n_comp"]
-    kv_offset = inputs["kv_offset"]
-    ratio = inputs["ratio"]
-    softmax_scale = inputs["softmax_scale"]
-    indexer_softmax_scale = inputs["indexer_softmax_scale"]
-    effective_topk = min(inputs["indexer_topk"], n_comp)
-    skv = inputs["kv_full"].shape[0]
-    idx_nh = inputs["q_indexer"].shape[2]
-
-    # Step 1: Indexer top-K (same as fused path)
-    q_idx_bshd, k_idx_bsd, w_bsh, w_bsh_scaled = _sbhd_to_bshd_indexer_inputs(
-        inputs["q_indexer"], inputs["k_indexer"],
-        inputs["weights"], indexer_softmax_scale,
-    )
-    topk_indices_cmp, _, _ = _indexer_topk_bshd(
-        q_idx_bshd, k_idx_bsd, w_bsh_scaled, effective_topk, ratio
-    )
-
-    # Step 2: Combine indices and run sparse attention to get full LSE
-    topk_indices_global = topk_indices_cmp.clone()
-    valid_cmp = topk_indices_global >= 0
-    topk_indices_global[valid_cmp] += kv_offset
-
-    window_idxs = inputs["window_idxs"]
-    combined_idxs = torch.cat([topk_indices_global, window_idxs], dim=-1)
-    total_topk = combined_idxs.shape[-1]
-
-    q_flat = inputs["query"].reshape(sq * b, np_, d)
-    kv_flat = inputs["kv_full"].reshape(skv * b, -1)
-
-    batch_ids = torch.arange(b, device=inputs["query"].device, dtype=combined_idxs.dtype)
-    global_idxs = combined_idxs.clone()
-    valid_mask = global_idxs >= 0
-    global_idxs = torch.where(
-        valid_mask,
-        global_idxs * b + batch_ids.view(b, 1, 1),
-        global_idxs,
-    )
-    global_idxs = global_idxs.permute(1, 0, 2).reshape(sq * b, total_topk)
-    global_idxs = global_idxs.unsqueeze(1)
-    global_idxs_expanded = global_idxs.expand(-1, np_, -1)
-
-    _, lse, _ = triton_sparse_attn_forward(
-        q_flat, kv_flat, global_idxs_expanded, softmax_scale, d,
-        inputs["attn_sink"], indexer_topk=0,
-    )
-    lse_bsh = lse.reshape(sq, b, np_).permute(1, 0, 2)  # (b, sq, np)
-
-    # Step 3: Attention target via dense_attn_score_recompute (full LSE)
-    q_attn_bshd = inputs["query"].permute(1, 0, 2, 3)  # (b, sq, np, d)
-    k_attn_bsd = inputs["kv_full"][kv_offset:kv_offset + n_comp, :, :d].permute(1, 0, 2)
-
-    dense_attn_result = dense_attn_score_recompute(
-        q_attn_bshd, k_attn_bsd, lse_bsh,
-        qhead_per_kv_head=np_, softmax_scale=softmax_scale, ratio=ratio,
-    )
-
-    # Step 4: Indexer predict via dense_indexer_score_recompute
-    dense_idx_result = dense_indexer_score_recompute(
-        q_idx_bshd, k_idx_bsd, w_bsh_scaled,
-        qhead_per_kv_head=idx_nh, sm_scale=indexer_softmax_scale, ratio=ratio,
-    )
-
-    # Step 5: KL loss
-    loss = _kl_loss_from_dense_scores(
-        dense_attn_result["out"], dense_attn_result["denom"],
-        dense_idx_result["out"], dense_idx_result["denom"],
-        topk_indices_cmp, loss_coeff, calculate_per_token_loss,
-    )
-    return loss
-
-
-class TestKLLossAccuracy:
-    """KL loss precision tests and calculate_per_token_loss coverage.
-
-    Verifies:
-    1. Fused KL loss matches a pure-PyTorch reference (both sparse and dense).
-    2. calculate_per_token_loss=True produces correct sum-reduction semantics.
-    3. The relationship: loss_per_token = loss_mean * num_valid_rows holds.
-    """
-
-    @pytest.fixture
-    def device(self):
-        return torch.device("cuda:0")
-
-    # ------------------------------------------------------------------
-    # Per-token vs mean reduction relationship
-    # ------------------------------------------------------------------
-
-    @pytest.mark.parametrize(
-        "sq,b,np_,hn,n_comp,win_topk,idx_nh,idx_hd,indexer_topk,ratio",
-        [
-            (2048, 1, 32, 128, 512, 128, 4, 64, 256, 4),
-            (2048, 2, 32, 128, 512, 128, 4, 64, 256, 4),
-            (4096, 1, 32, 128, 1024, 256, 4, 64, 384, 4),
-        ],
-        ids=["7B_B1_sq2048", "7B_B2_sq2048", "13B_B1_sq4096"],
-    )
-    @pytest.mark.parametrize("sparse_loss", [True, False], ids=["sparse", "dense"])
-    def test_per_token_vs_mean_reduction(
-        self, sq, b, np_, hn, n_comp, win_topk, idx_nh, idx_hd,
-        indexer_topk, ratio, sparse_loss, device, dsa_metrics,
-    ):
-        """loss(per_token) = loss(mean) * num_elements / loss_coeff * loss_coeff.
-
-        More precisely: per_token uses sum, mean uses mean over B*S_q rows.
-        So per_token_loss / mean_loss ≈ B * S_q (for all-valid rows).
-        """
-        kv_offset = sq
-        inputs = _make_fused_inputs(
-            sq, b, np_, hn, n_comp, win_topk, idx_nh, idx_hd,
-            indexer_topk, ratio, kv_offset, device,
-        )
-
-        loss_coeff = 1.0  # Use 1.0 so ratio is cleaner
-
-        # Run with mean reduction (default)
-        _, loss_mean = fused_indexer_sparse_attn(
-            inputs["query"], inputs["kv_full"], inputs["attn_sink"],
-            inputs["window_idxs"], inputs["q_indexer"], inputs["k_indexer"],
-            inputs["weights"], inputs["indexer_topk"], inputs["ratio"],
-            inputs["softmax_scale"], inputs["indexer_softmax_scale"],
-            loss_coeff, sparse_loss, inputs["kv_offset"],
-            calculate_per_token_loss=False,
-        )
-
-        # Run with per-token (sum) reduction
-        _, loss_per_token = fused_indexer_sparse_attn(
-            inputs["query"], inputs["kv_full"], inputs["attn_sink"],
-            inputs["window_idxs"], inputs["q_indexer"], inputs["k_indexer"],
-            inputs["weights"], inputs["indexer_topk"], inputs["ratio"],
-            inputs["softmax_scale"], inputs["indexer_softmax_scale"],
-            loss_coeff, sparse_loss, inputs["kv_offset"],
-            calculate_per_token_loss=True,
-        )
-
-        # Expected number of rows = B * S_q
-        n_rows = b * sq
-        expected_ratio = float(n_rows)
-        actual_ratio = loss_per_token.item() / max(loss_mean.item(), 1e-12)
-
-        # Allow small tolerance due to f32 summation order
-        rel_err = abs(actual_ratio - expected_ratio) / expected_ratio
-        assert rel_err < 0.01, (
-            f"per_token/mean ratio mismatch: got {actual_ratio:.2f}, "
-            f"expected {expected_ratio:.2f} (rel_err={rel_err:.4e})"
-        )
-
-        logger.info(
-            f"[sq={sq}, b={b}, sparse_loss={sparse_loss}] "
-            f"per_token={loss_per_token.item():.6f}, mean={loss_mean.item():.6f}, "
-            f"ratio={actual_ratio:.2f}, expected={expected_ratio:.0f}"
-        )
-        dsa_metrics.record_accuracy(
-            params={"sq": sq, "b": b, "sparse_loss": sparse_loss},
-            cos_sim=1.0 - rel_err, target="per_token_vs_mean",
-        )
-
-    # ------------------------------------------------------------------
-    # KL loss precision: fused vs PyTorch reference (sparse)
-    # ------------------------------------------------------------------
-
-    @pytest.mark.parametrize(
-        "sq,b,np_,hn,n_comp,win_topk,idx_nh,idx_hd,indexer_topk,ratio",
-        [
-            (2048, 1, 32, 128, 512, 128, 4, 64, 256, 4),
-            (2048, 2, 32, 128, 512, 128, 4, 64, 256, 4),
-            (4096, 1, 32, 128, 1024, 256, 4, 64, 384, 4),
-        ],
-        ids=["7B_B1_sq2048", "7B_B2_sq2048", "13B_B1_sq4096"],
-    )
-    @pytest.mark.parametrize(
-        "calculate_per_token_loss", [False, True], ids=["mean", "per_token"]
-    )
-    def test_kl_loss_sparse_vs_reference(
-        self, sq, b, np_, hn, n_comp, win_topk, idx_nh, idx_hd,
-        indexer_topk, ratio, calculate_per_token_loss, device, dsa_metrics,
-    ):
-        """Fused sparse KL loss matches PyTorch reference."""
-        kv_offset = sq
-        loss_coeff = 0.1
-        inputs = _make_fused_inputs(
-            sq, b, np_, hn, n_comp, win_topk, idx_nh, idx_hd,
-            indexer_topk, ratio, kv_offset, device,
-        )
-
-        # ===== DEBUG: comprehensive step-by-step diagnosis =====
-        from megatron.plugin.dsa_kernel.triton_dsa_kernels import (
-            _sbhd_to_bshd_indexer_inputs, _indexer_topk_bshd,
-        )
-        from megatron.plugin.dsa_kernel.triton_sparse_attn import triton_sparse_attn_forward
-        from megatron.plugin.dsa_kernel.triton_dsa_utils import compute_ratio_causal_mask
-        from megatron.core.transformer.experimental_attention_variant.dsa import (
-            fused_qk_topk_naive, _compute_index_scores,
-        )
-
-        effective_topk = min(inputs["indexer_topk"], n_comp)
-        q_idx_bshd, k_idx_bsd, w_bsh, w_bsh_scaled = _sbhd_to_bshd_indexer_inputs(
-            inputs["q_indexer"], inputs["k_indexer"],
-            inputs["weights"], inputs["indexer_softmax_scale"],
-        )
-        topk_indices_cmp, _, full_scores_fused = _indexer_topk_bshd(
-            q_idx_bshd, k_idx_bsd, w_bsh_scaled, effective_topk, ratio
-        )
-
-        logger.debug(f"===== STEP-BY-STEP DIAGNOSIS =====")
-        logger.debug(f"shapes: sq={sq}, b={b}, np={np_}, hn={hn}, n_comp={n_comp}, "
-              f"effective_topk={effective_topk}, kv_offset={kv_offset}, ratio={ratio}")
-        logger.debug(f"topk_indices_cmp: shape={topk_indices_cmp.shape}, "
-              f"min={topk_indices_cmp.min().item()}, max={topk_indices_cmp.max().item()}")
-        n_invalid = (topk_indices_cmp < 0).sum().item()
-        logger.debug(f"invalid indices (< 0): {n_invalid} / {topk_indices_cmp.numel()}")
-
-        # ----- STEP A: Compare fused vs reference indexer scores -----
-        causal_mask = compute_ratio_causal_mask(
-            sq, n_comp, ratio, device, torch.float32
-        ).unsqueeze(0).expand(b, -1, -1)
-
-        # Reference scores from _compute_index_scores (SBHD format)
-        w_idx_ref = inputs["weights"].float() * inputs["indexer_softmax_scale"]
-        ref_index_scores = _compute_index_scores(
-            inputs["q_indexer"], w_idx_ref, inputs["k_indexer"]
-        )  # (b, sq, n_comp)
-        logger.debug(f"ref_index_scores: shape={ref_index_scores.shape}, "
-              f"min={ref_index_scores.min().item():.6e}, max={ref_index_scores.max().item():.6e}")
-        logger.debug(f"full_scores_fused: shape={full_scores_fused.shape}, "
-              f"min={full_scores_fused.min().item():.6e}, max={full_scores_fused.max().item():.6e}")
-
-        # Compare the two score computations
-        score_diff = (full_scores_fused - ref_index_scores).abs()
-        logger.debug(f"indexer score diff (fused vs ref): "
-              f"max={score_diff.max().item():.6e}, mean={score_diff.mean().item():.6e}")
-
-        # ----- STEP B: Predict distribution comparison -----
-        # Fused predict: sparse_indexer_score_recompute over topk
-        predict_result = sparse_indexer_score_recompute(
-            q_idx_bshd, k_idx_bsd, w_bsh_scaled, topk_indices_cmp,
-            qhead_per_kv_head=idx_nh,
-        )
-        predict_fused = predict_result["predict"]  # (b, sq, topk)
-
-        # Reference predict: full index_scores + causal_mask + index_mask → softmax
-        ref_scores_masked = ref_index_scores + causal_mask
-        # Apply index_mask (sparse): mask non-topk to -inf
-        # Need to handle -1 in topk_indices_cmp for scatter
-        topk_safe = topk_indices_cmp.clone()
-        valid_topk_mask = topk_safe >= 0
-        topk_safe[~valid_topk_mask] = 0  # dummy position, will be re-masked
-        index_mask_correct = torch.full(
-            (b, sq, n_comp), float("-inf"), dtype=torch.float32, device=device
-        )
-        index_mask_correct.scatter_(-1, topk_safe.long(), 0.0)
-        # Fix: position 0 may have been incorrectly unmasked by invalid (-1→0) entries.
-        # Re-check: for each (b,s), if position 0 is NOT in the valid topk set, re-mask it.
-        pos0_in_valid = (topk_indices_cmp == 0).any(dim=-1)  # (b, sq)
-        index_mask_correct[:, :, 0] = torch.where(
-            pos0_in_valid, torch.zeros_like(index_mask_correct[:, :, 0]),
-            torch.full_like(index_mask_correct[:, :, 0], float("-inf"))
-        )
-        ref_scores_sparse = ref_scores_masked + index_mask_correct
-        # row_valid check
-        row_valid_ref = (causal_mask > float('-inf')).any(dim=-1)  # (b, sq)
-        idx_row_mask = row_valid_ref.view(b, sq, 1)
-        ref_scores_sparse = ref_scores_sparse.masked_fill(~idx_row_mask, 0.0)
-        predict_ref_full = torch.nn.functional.softmax(ref_scores_sparse, dim=-1)  # (b, sq, n_comp)
-        predict_ref_full = predict_ref_full * idx_row_mask.float()
-
-        # Gather reference predict at topk positions for comparison
-        predict_ref_at_topk = predict_ref_full[
-            torch.arange(b, device=device)[:, None, None],
-            torch.arange(sq, device=device)[None, :, None],
-            topk_safe.long(),
-        ]  # (b, sq, topk)
-        predict_ref_at_topk[~valid_topk_mask] = 0.0
-
-        predict_diff = (predict_fused - predict_ref_at_topk).abs()
-        logger.debug(f"PREDICT fused: sum_per_row_mean={predict_fused.sum(-1).mean().item():.6f}, "
-              f"max={predict_fused.max().item():.6e}")
-        logger.debug(f"PREDICT ref_at_topk: sum_per_row_mean={predict_ref_at_topk.sum(-1).mean().item():.6f}, "
-              f"max={predict_ref_at_topk.max().item():.6e}")
-        logger.debug(f"PREDICT diff: max={predict_diff.max().item():.6e}, "
-              f"mean={predict_diff.mean().item():.6e}")
-
-        # ----- STEP C: Target distribution comparison -----
-        # Fused target: via lse_indexer from sparse attn forward
-        q_flat = inputs["query"].reshape(sq * b, np_, hn)
-        kv_flat = inputs["kv_full"].reshape((kv_offset + n_comp) * b, -1)
-        topk_indices_global = topk_indices_cmp.clone()
-        valid_cmp = topk_indices_global >= 0
-        topk_indices_global[valid_cmp] += kv_offset
-        combined_idxs = torch.cat([topk_indices_global, inputs["window_idxs"]], dim=-1)
-        total_topk = combined_idxs.shape[-1]
-        batch_ids = torch.arange(b, device=device, dtype=combined_idxs.dtype)
-        global_idxs = combined_idxs.clone()
-        valid_mask = global_idxs >= 0
-        global_idxs = torch.where(valid_mask, global_idxs * b + batch_ids.view(b, 1, 1), global_idxs)
-        global_idxs = global_idxs.permute(1, 0, 2).reshape(sq * b, total_topk)
-        global_idxs = global_idxs.unsqueeze(1)
-        global_idxs_expanded = global_idxs.expand(-1, np_, -1)
-
-        _, lse_full, lse_indexer_raw = triton_sparse_attn_forward(
-            q_flat, kv_flat, global_idxs_expanded, inputs["softmax_scale"], hn,
-            inputs["attn_sink"], indexer_topk=effective_topk,
-        )
-        lse_indexer_bsh = lse_indexer_raw.reshape(sq, b, np_).permute(1, 0, 2)  # (b, sq, np)
-
-        k_attn_bsd = inputs["kv_full"][:, :, :hn].permute(1, 0, 2)  # (b, skv, d)
-        q_attn_bshd = inputs["query"].permute(1, 0, 2, 3)  # (b, sq, np, hn)
-
-        # Shift valid indices by kv_offset, keep -1 as-is for invalid mask
-        topk_for_target = topk_indices_cmp.clone()
-        valid_cmp_target = topk_for_target >= 0
-        topk_for_target[valid_cmp_target] += kv_offset
-
-        target_result = sparse_attn_score_recompute(
-            q_attn_bshd, k_attn_bsd, lse_indexer_bsh, topk_for_target,
-            inputs["softmax_scale"], qhead_per_kv_head=np_,
-        )
-        target_fused = target_result["target"]  # (b, sq, topk)
-
-        # Reference target: direct softmax over topk attention scores
-        # q @ K_compressed_topk * scale, per head, then softmax, sum heads, L1 norm
-        compressed_kv = inputs["kv_full"][kv_offset:kv_offset + n_comp]  # (n_comp, b, hn)
-        key_for_ref = compressed_kv.unsqueeze(2).expand(-1, -1, np_, -1)  # (n_comp, b, np, hn)
-        # Compute full attention scores: [b*np, sq, n_comp]
-        q_ref = inputs["query"].permute(1, 2, 0, 3).reshape(b * np_, sq, hn).float()
-        k_ref = key_for_ref.permute(1, 2, 3, 0).reshape(b * np_, hn, n_comp).float()
-        attn_scores_full = torch.bmm(q_ref, k_ref) * inputs["softmax_scale"]
-        attn_scores_full = attn_scores_full.reshape(b, np_, sq, n_comp)  # (b, np, sq, n_comp)
-
-        # Apply causal_mask + index_mask
-        attn_scores_full = attn_scores_full + causal_mask.unsqueeze(1)  # (b, 1, sq, n_comp)
-        attn_scores_full = attn_scores_full + index_mask_correct.unsqueeze(1)  # sparse mask
-
-        # row_valid handling
-        attn_row_mask = row_valid_ref.view(b, 1, sq, 1)
-        attn_scores_full = attn_scores_full.masked_fill(~attn_row_mask, 0.0)
-
-        # Softmax per head
-        attn_probs_ref = torch.nn.functional.softmax(attn_scores_full, dim=-1)  # (b, np, sq, n_comp)
-        attn_probs_ref = attn_probs_ref * attn_row_mask.float()
-
-        # Sum heads, L1 normalize
-        attn_target_ref = attn_probs_ref.sum(dim=1)  # (b, sq, n_comp)
-        attn_target_ref = attn_target_ref / attn_target_ref.sum(dim=-1, keepdim=True).clamp(min=1e-10)
-
-        # Gather target at topk positions
-        target_ref_at_topk = attn_target_ref[
-            torch.arange(b, device=device)[:, None, None],
-            torch.arange(sq, device=device)[None, :, None],
-            topk_safe.long(),
-        ]
-        target_ref_at_topk[~valid_topk_mask] = 0.0
-
-        target_diff = (target_fused - target_ref_at_topk).abs()
-        logger.debug(f"TARGET fused: sum_per_row_mean={target_fused.sum(-1).mean().item():.6f}, "
-              f"max={target_fused.max().item():.6e}")
-        logger.debug(f"TARGET ref_at_topk: sum_per_row_mean={target_ref_at_topk.sum(-1).mean().item():.6f}, "
-              f"max={target_ref_at_topk.max().item():.6e}")
-        logger.debug(f"TARGET diff: max={target_diff.max().item():.6e}, "
-              f"mean={target_diff.mean().item():.6e}, "
-              f"rel_max={target_diff.max().item() / max(target_ref_at_topk.abs().max().item(), 1e-10):.4e}")
-
-        # ----- STEP D: Diagnose lse_indexer vs direct softmax -----
-        # For fused target, the per-head probs are exp(score - lse_indexer)
-        # For reference target, they are softmax(scores_at_topk_only)
-        # These should be identical if lse_indexer = logsumexp(scores_at_topk)
-        # Let's check: recompute scores at topk positions and compare with lse_indexer
-        idx_for_gather = (topk_indices_cmp + kv_offset).long().clamp(min=0)  # (b, sq, topk)
-        batch_idx_d = torch.arange(b, device=device)[:, None, None]
-        k_gathered_f32 = k_attn_bsd.float()[batch_idx_d, idx_for_gather]  # (b, sq, topk, hn)
-        scores_at_topk = torch.einsum(
-            "bqhd,bqtd->bqht", q_attn_bshd.float(), k_gathered_f32
-        ) * inputs["softmax_scale"]  # (b, sq, np, topk)
-        # Mask invalid
-        scores_at_topk_masked = scores_at_topk.clone()
-        inv_mask_4d = (~valid_topk_mask).unsqueeze(2).expand_as(scores_at_topk)
-        scores_at_topk_masked[inv_mask_4d] = float("-inf")
-
-        # Direct logsumexp from f32 scores
-        lse_direct_f32 = torch.logsumexp(scores_at_topk_masked, dim=-1)  # (b, sq, np)
-        # Compare with lse_indexer from triton forward
-        lse_diff = (lse_indexer_bsh - lse_direct_f32).abs()
-        logger.debug(f"LSE comparison (triton_fwd vs direct_f32):")
-        logger.debug(f"  lse_indexer: mean={lse_indexer_bsh.mean().item():.4f}, "
-              f"min={lse_indexer_bsh.min().item():.4f}, max={lse_indexer_bsh.max().item():.4f}")
-        logger.debug(f"  lse_direct:  mean={lse_direct_f32.mean().item():.4f}, "
-              f"min={lse_direct_f32.min().item():.4f}, max={lse_direct_f32.max().item():.4f}")
-        logger.debug(f"  diff: max={lse_diff.max().item():.6e}, mean={lse_diff.mean().item():.6e}")
-
-        # Check what softmax probs look like from each LSE
-        probs_from_triton_lse = torch.exp(scores_at_topk_masked - lse_indexer_bsh.unsqueeze(-1))
-        probs_from_direct_lse = torch.exp(scores_at_topk_masked - lse_direct_f32.unsqueeze(-1))
-        logger.debug(f"probs_from_triton_lse: max={probs_from_triton_lse.max().item():.6e}, "
-              f"sum_per_row_mean={probs_from_triton_lse.sum(-1).mean().item():.6f}")
-        logger.debug(f"probs_from_direct_lse: max={probs_from_direct_lse.max().item():.6e}, "
-              f"sum_per_row_mean={probs_from_direct_lse.sum(-1).mean().item():.6f}")
-
-        # ----- STEP E: Compute KL from both paths for final comparison -----
-        # Manual fused-style KL
-        eps = torch.finfo(torch.float32).tiny
-        t_f = target_fused.clamp(min=eps)
-        p_f = predict_fused.clamp(min=eps)
-        kl_fused_rows = (t_f * (torch.log(t_f) - torch.log(p_f))).sum(dim=-1)
-        row_valid_fused = (topk_indices_cmp >= 0).any(dim=-1)
-        kl_fused_rows = torch.where(row_valid_fused, kl_fused_rows, torch.zeros_like(kl_fused_rows))
-        manual_loss = kl_fused_rows.mean() * loss_coeff
-
-        # Manual ref-style KL (same indices, same mask)
-        t_r = target_ref_at_topk.clamp(min=eps)
-        p_r = predict_ref_at_topk.clamp(min=eps)
-        kl_ref_rows = (t_r * (torch.log(t_r) - torch.log(p_r))).sum(dim=-1)
-        kl_ref_rows = torch.where(row_valid_fused, kl_ref_rows, torch.zeros_like(kl_ref_rows))
-        manual_ref_loss = kl_ref_rows.mean() * loss_coeff
-
-        logger.debug(f"----- KL DECOMPOSITION -----")
-        logger.debug(f"manual_loss (fused target+predict): {manual_loss.item():.6e}")
-        logger.debug(f"manual_ref_loss (ref target+predict): {manual_ref_loss.item():.6e}")
-
-        # Cross KL: fused target with ref predict
-        kl_cross1 = (t_f * (torch.log(t_f) - torch.log(p_r))).sum(dim=-1)
-        kl_cross1 = torch.where(row_valid_fused, kl_cross1, torch.zeros_like(kl_cross1))
-        logger.debug(f"KL(fused_target || ref_predict): {kl_cross1.mean().item() * loss_coeff:.6e}")
-        # Cross KL: ref target with fused predict
-        kl_cross2 = (t_r * (torch.log(t_r) - torch.log(p_f))).sum(dim=-1)
-        kl_cross2 = torch.where(row_valid_fused, kl_cross2, torch.zeros_like(kl_cross2))
-        logger.debug(f"KL(ref_target || fused_predict): {kl_cross2.mean().item() * loss_coeff:.6e}")
-
-        # Show worst rows
-        kl_diff_per_row = (kl_fused_rows - kl_ref_rows).abs()
-        worst_flat = kl_diff_per_row.reshape(-1).topk(5)
-        logger.debug(f"top-5 worst row KL diffs: {worst_flat.values.tolist()}")
-        for idx in worst_flat.indices[:3]:
-            bi = idx.item() // sq
-            si = idx.item() % sq
-            logger.debug(f"  row [{bi},{si}]: "
-                  f"fused_target={target_fused[bi,si,:8].tolist()}, "
-                  f"ref_target={target_ref_at_topk[bi,si,:8].tolist()}")
-            logger.debug(f"           "
-                  f"fused_predict={predict_fused[bi,si,:8].tolist()}, "
-                  f"ref_predict={predict_ref_at_topk[bi,si,:8].tolist()}")
-
-        logger.debug(f"fused loss will be printed after call below...")
-        # ===== END DEBUG =====
-
-        # Fused path
-        _, loss_fused = fused_indexer_sparse_attn(
-            inputs["query"], inputs["kv_full"], inputs["attn_sink"],
-            inputs["window_idxs"], inputs["q_indexer"], inputs["k_indexer"],
-            inputs["weights"], inputs["indexer_topk"], inputs["ratio"],
-            inputs["softmax_scale"], inputs["indexer_softmax_scale"],
-            loss_coeff, True, inputs["kv_offset"],
-            calculate_per_token_loss=calculate_per_token_loss,
-        )
-
-        # Reference
-        loss_ref = _compute_kl_loss_reference(
-            inputs, sparse_loss=True,
-            calculate_per_token_loss=calculate_per_token_loss,
-            loss_coeff=loss_coeff,
-        )
-
-        fused_val = loss_fused.item()
-        ref_val = loss_ref.item()
-        rel_err = abs(fused_val - ref_val) / max(abs(ref_val), 1e-8)
-
-        logger.debug(f"=== FINAL COMPARISON ===")
-        logger.debug(f"loss_fused={fused_val:.6e}, loss_ref={ref_val:.6e}, manual_loss={manual_loss.item():.6e}")
-        logger.debug(f"fused vs manual rel_err={abs(fused_val - manual_loss.item()) / max(abs(manual_loss.item()), 1e-8):.4e}")
-        logger.debug(f"manual vs ref rel_err={abs(manual_loss.item() - ref_val) / max(abs(ref_val), 1e-8):.4e}")
-
-        logger.info(
-            f"[sq={sq}, b={b}, per_token={calculate_per_token_loss}] "
-            f"sparse KL: fused={fused_val:.6e}, ref={ref_val:.6e}, rel_err={rel_err:.4e}"
-        )
-
-        assert rel_err < 5e-3, (
-            f"Sparse KL loss mismatch: fused={fused_val:.6e}, ref={ref_val:.6e}, "
-            f"rel_err={rel_err:.4e}"
-        )
-        assert torch.isfinite(loss_fused), f"Fused loss is not finite: {fused_val}"
-
-        dsa_metrics.record_accuracy(
-            params={"sq": sq, "b": b, "per_token": calculate_per_token_loss},
-            cos_sim=1.0 - rel_err, target="kl_loss_sparse",
-        )
-
-    # ------------------------------------------------------------------
-    # KL loss precision: fused vs PyTorch reference (dense)
-    # ------------------------------------------------------------------
-
-    @pytest.mark.parametrize(
-        "sq,b,np_,hn,n_comp,win_topk,idx_nh,idx_hd,indexer_topk,ratio",
-        [
-            (2048, 1, 32, 128, 512, 128, 4, 64, 256, 4),
-            (2048, 2, 32, 128, 512, 128, 4, 64, 256, 4),
-            (4096, 1, 32, 128, 1024, 256, 4, 64, 384, 4),
-        ],
-        ids=["7B_B1_sq2048", "7B_B2_sq2048", "13B_B1_sq4096"],
-    )
-    @pytest.mark.parametrize(
-        "calculate_per_token_loss", [False, True], ids=["mean", "per_token"]
-    )
-    def test_kl_loss_dense_vs_reference(
-        self, sq, b, np_, hn, n_comp, win_topk, idx_nh, idx_hd,
-        indexer_topk, ratio, calculate_per_token_loss, device, dsa_metrics,
-    ):
-        """Fused dense KL loss matches PyTorch reference."""
-        kv_offset = sq
-        loss_coeff = 0.1
-        inputs = _make_fused_inputs(
-            sq, b, np_, hn, n_comp, win_topk, idx_nh, idx_hd,
-            indexer_topk, ratio, kv_offset, device,
-        )
-
-        # Fused path
-        _, loss_fused = fused_indexer_sparse_attn(
-            inputs["query"], inputs["kv_full"], inputs["attn_sink"],
-            inputs["window_idxs"], inputs["q_indexer"], inputs["k_indexer"],
-            inputs["weights"], inputs["indexer_topk"], inputs["ratio"],
-            inputs["softmax_scale"], inputs["indexer_softmax_scale"],
-            loss_coeff, False, inputs["kv_offset"],
-            calculate_per_token_loss=calculate_per_token_loss,
-        )
-
-        # Reference — uses full LSE from sparse attn forward (matches fused semantics)
-        loss_ref = _compute_kl_loss_reference_dense(
-            inputs,
-            calculate_per_token_loss=calculate_per_token_loss,
-            loss_coeff=loss_coeff,
-        )
-
-        fused_val = loss_fused.item()
-        ref_val = loss_ref.item()
-        rel_err = abs(fused_val - ref_val) / max(abs(ref_val), 1e-8)
-
-        logger.info(
-            f"[sq={sq}, b={b}, per_token={calculate_per_token_loss}] "
-            f"dense KL: fused={fused_val:.6e}, ref={ref_val:.6e}, rel_err={rel_err:.4e}"
-        )
-
-        assert rel_err < 5e-3, (
-            f"Dense KL loss mismatch: fused={fused_val:.6e}, ref={ref_val:.6e}, "
-            f"rel_err={rel_err:.4e}"
-        )
-        assert torch.isfinite(loss_fused), f"Fused loss is not finite: {fused_val}"
-
-        dsa_metrics.record_accuracy(
-            params={"sq": sq, "b": b, "per_token": calculate_per_token_loss},
-            cos_sim=1.0 - rel_err, target="kl_loss_dense",
-        )
-
-    # ------------------------------------------------------------------
-    # Per-token loss with gradient — ensure backward still works
-    # ------------------------------------------------------------------
-
-    @pytest.mark.parametrize(
-        "sq,b,np_,hn,n_comp,win_topk,idx_nh,idx_hd,indexer_topk,ratio",
-        [
-            (2048, 1, 32, 128, 512, 128, 4, 64, 256, 4),
-        ],
-    )
-    @pytest.mark.parametrize("sparse_loss", [True, False], ids=["sparse", "dense"])
-    def test_per_token_loss_backward_no_nan(
-        self, sq, b, np_, hn, n_comp, win_topk, idx_nh, idx_hd,
-        indexer_topk, ratio, sparse_loss, device,
-    ):
-        """Backward with calculate_per_token_loss=True produces no NaN/Inf."""
-        kv_offset = sq
-        inputs = _make_fused_inputs(
-            sq, b, np_, hn, n_comp, win_topk, idx_nh, idx_hd,
-            indexer_topk, ratio, kv_offset, device,
-        )
-
-        query = inputs["query"].clone().detach().requires_grad_(True)
-        kv_full = inputs["kv_full"].clone().detach().requires_grad_(True)
-        attn_sink = inputs["attn_sink"].clone().detach().requires_grad_(True)
-
-        out, loss = fused_indexer_sparse_attn(
-            query, kv_full, attn_sink, inputs["window_idxs"],
-            inputs["q_indexer"], inputs["k_indexer"], inputs["weights"],
-            inputs["indexer_topk"], inputs["ratio"],
-            inputs["softmax_scale"], inputs["indexer_softmax_scale"],
-            0.1, sparse_loss, inputs["kv_offset"],
-            calculate_per_token_loss=True,
-        )
-
-        scalar = out.float().sum() + loss
-        scalar.backward()
-
-        for name, param in [("query", query), ("kv_full", kv_full), ("attn_sink", attn_sink)]:
-            assert param.grad is not None, f"{name}.grad is None"
-            assert not torch.isnan(param.grad).any(), f"{name}.grad has NaN"
-            assert not torch.isinf(param.grad).any(), f"{name}.grad has Inf"
-
-        # Loss should be larger than mean version (since it's sum over B*S_q rows)
-        assert loss.item() > 0, f"Per-token loss should be positive, got {loss.item()}"
-        logger.info(
-            f"[sparse_loss={sparse_loss}] per_token_loss={loss.item():.6f}, "
-            f"grad_query_norm={query.grad.float().norm().item():.4e}"
-        )
-
-
-# ---------------------------------------------------------------------------
 # Backward accuracy tests
 # ---------------------------------------------------------------------------
 
@@ -1449,6 +726,8 @@ class TestFusedIndexerSparseAttnPerformance:
             (2048, 2, 32, 128, 512, 128, 4, 64, 256, 4),
             (4096, 1, 32, 128, 1024, 256, 4, 64, 384, 4),
             (2048, 1, 64, 128, 512, 128, 4, 64, 512, 4),
+            (4096, 1, 32, 128, 1024, 128, 4, 64, 512, 4),
+            (4096, 1, 32, 128, 1024, 128, 4, 64, 1024, 4),
             (8192, 1, 32, 128, 2048, 256, 4, 64, 512, 4),
         ],
         ids=[
@@ -1456,6 +735,8 @@ class TestFusedIndexerSparseAttnPerformance:
             "7B_B2_sq2048_topk256",
             "13B_B1_sq4096_topk384",
             "70B_B1_sq2048_topk512",
+            "13B_B1_sq4096_topk512",
+            "13B_B1_sq4096_topk1024",
             "longctx_B1_sq8192_topk512",
         ],
     )
@@ -2594,8 +1875,10 @@ class TestCSAFusedVsUnfusedPerformance:
             (2048, 1, 32, 128, 128, 256),
             (4096, 1, 32, 128, 256, 384),
             (2048, 1, 64, 128, 128, 512),
+            (4096, 1, 32, 128, 128, 512),
+            (4096, 1, 32, 128, 128, 1024),
         ],
-        ids=["7B_sq2048_topk256", "13B_sq4096_topk384", "70B_sq2048_topk512"],
+        ids=["7B_sq2048_topk256", "13B_sq4096_topk384", "70B_sq2048_topk512", "13B_sq4096_topk512", "13B_sq4096_topk1024"],
     )
     @pytest.mark.parametrize("sparse_loss", [True, False], ids=["sparse", "dense"])
     def test_e2e_performance(
@@ -2675,8 +1958,10 @@ class TestCSAFusedVsUnfusedPerformance:
             (2048, 1, 32, 128, 128, 256),
             (4096, 1, 32, 128, 256, 384),
             (2048, 1, 64, 128, 128, 512),
+            (4096, 1, 32, 128, 128, 512),
+            (4096, 1, 32, 128, 128, 1024),
         ],
-        ids=["7B_sq2048_topk256", "13B_sq4096_topk384", "70B_sq2048_topk512"],
+        ids=["7B_sq2048_topk256", "13B_sq4096_topk384", "70B_sq2048_topk512", "13B_sq4096_topk512", "13B_sq4096_topk1024"],
     )
     @pytest.mark.parametrize("sparse_loss", [True, False], ids=["sparse", "dense"])
     def test_e2e_memory(
@@ -3410,5 +2695,603 @@ class TestDSASparseAttnBackward:
         dsa_metrics.record_accuracy(
             params={"sq": total_sq, "skv": total_skv, "np": np_, "topk": topk},
             cos_sim=cos_sim, target="kernel_grad_kv",
+        )
+
+
+# ---------------------------------------------------------------------------
+# Indexer gradient accuracy: fused (triton plugin) vs unfused (Megatron core)
+# ---------------------------------------------------------------------------
+
+
+class TestIndexerGradAccuracy:
+    """Validate indexer gradient accuracy: fused plugin vs Megatron core reference.
+
+    The fused path pre-computes indexer gradients in forward via
+    ``fused_sparse_indexer_loss_and_backward`` / ``fused_dense_indexer_loss_and_backward``
+    (triton plugin). The unfused path uses ``FusedDSAIndexerLoss`` + autograd
+    (``bwd_fused_indexer_loss_naive``) from Megatron core.
+
+    We verify: grad_q_indexer, grad_k_indexer, grad_weights match between the two.
+    """
+
+    @pytest.fixture
+    def device(self):
+        return torch.device("cuda:0")
+
+    @staticmethod
+    def _run_fused_indexer_grads(inputs: dict, sparse_loss: bool) -> dict:
+        """Run fused path, extract indexer gradients."""
+        assert torch.is_grad_enabled(), "grad must be enabled for fused indexer grad test"
+
+        q_indexer = inputs["q_indexer"].clone().detach().requires_grad_(True)
+        k_indexer = inputs["k_indexer"].clone().detach().requires_grad_(True)
+        weights = inputs["weights"].clone().detach().requires_grad_(True)
+
+        # query/kv_full need grad so FusedIndexerSparseAttnFunc.forward enters needs_grad path
+        query = inputs["query"].clone().detach().requires_grad_(True)
+        kv_full = inputs["kv_full"].clone().detach().requires_grad_(True)
+        attn_sink = inputs["attn_sink"].clone().detach().requires_grad_(True)
+
+        out, loss = fused_indexer_sparse_attn(
+            query, kv_full, attn_sink, inputs["window_idxs"],
+            q_indexer, k_indexer, weights,
+            inputs["indexer_topk"], inputs["ratio"],
+            inputs["softmax_scale"], inputs["indexer_softmax_scale"],
+            0.1, sparse_loss, inputs["kv_offset"], False,
+        )
+
+        assert loss.requires_grad, "loss must require grad"
+        assert out.requires_grad, "out must require grad"
+
+        # Backward through both out and loss. The attention backward (from out)
+        # only contributes to query/kv_full/attn_sink grads, not indexer grads.
+        # The indexer grads come solely from grad_loss * precomputed_grads.
+        (out.float().sum() + loss).backward()
+
+        return {
+            "loss": loss.item(),
+            "grad_q_indexer": q_indexer.grad,
+            "grad_k_indexer": k_indexer.grad,
+            "grad_weights": weights.grad,
+        }
+
+    @staticmethod
+    def _make_mock_pg_collection():
+        """Create a mock ProcessGroupCollection with TP size=1 (no all-reduce)."""
+        class _MockPG:
+            def size(self):
+                return 1
+        class _MockPGCollection:
+            tp = _MockPG()
+            cp = None
+        return _MockPGCollection()
+
+    @staticmethod
+    def _run_unfused_indexer_grads(inputs: dict, sparse_loss: bool) -> dict:
+        """Run Megatron core FusedDSAIndexerLoss, extract indexer gradients."""
+        from megatron.core.transformer.experimental_attention_variant.dsa import (
+            FusedDSAIndexerLoss,
+        )
+
+        sq = inputs["sq"]
+        b = inputs["b"]
+        np_ = inputs["np"]
+        hn = inputs["hn"]
+        n_comp = inputs["n_comp"]
+        kv_offset = inputs["kv_offset"]
+
+        # FusedDSAIndexerLoss expects SBHD layout
+        q_indexer = inputs["q_indexer"].clone().detach().requires_grad_(True)
+        k_indexer = inputs["k_indexer"].clone().detach().requires_grad_(True)
+
+        # weights_for_unfused = weights * indexer_softmax_scale (pre-scaled)
+        weights_raw = inputs["weights"].clone().detach().float()
+        weights_for_unfused = (weights_raw * inputs["indexer_softmax_scale"]).requires_grad_(True)
+
+        # query and key are detached in the real unfused path
+        query_det = inputs["query"].clone().detach()
+        # key_for_loss: [n_comp, b, np, hn] — compressed KV expanded to np heads
+        kv_compressed = inputs["kv_full"][kv_offset:kv_offset + n_comp]  # (n_comp, b, hn)
+        key_for_loss = kv_compressed.unsqueeze(2).expand(-1, -1, np_, -1).detach()
+
+        # Build causal mask [b, sq, n_comp]
+        causal_mask = (
+            torch.arange(n_comp, device=q_indexer.device).unsqueeze(0).expand(sq, -1)
+        )
+        positions = torch.arange(1, sq + 1, device=q_indexer.device).unsqueeze(1)
+        ratio = inputs["ratio"]
+        causal_mask = (
+            torch.where(causal_mask >= positions // ratio, float("-inf"), 0.0)
+            .unsqueeze(0)
+            .expand(b, -1, -1)
+        )
+
+        pg_collection = TestIndexerGradAccuracy._make_mock_pg_collection()
+
+        topk_indices, loss = FusedDSAIndexerLoss.apply(
+            q_indexer,
+            weights_for_unfused,
+            k_indexer,
+            query_det,
+            key_for_loss,
+            inputs["softmax_scale"],
+            min(inputs["indexer_topk"], n_comp),
+            0.1,  # loss_coeff
+            causal_mask,
+            sparse_loss,
+            pg_collection,
+            False,  # calculate_per_token_loss
+        )
+
+        loss.backward()
+
+        return {
+            "loss": loss.item(),
+            "grad_q_indexer": q_indexer.grad,
+            "grad_k_indexer": k_indexer.grad,
+            "grad_weights": weights_for_unfused.grad,
+        }
+
+    @pytest.mark.parametrize(
+        "sq,b,np_,hn,n_comp,win_topk,idx_nh,idx_hd,indexer_topk,ratio",
+        [
+            (2048, 1, 32, 128, 512, 128, 4, 64, 256, 4),
+            (2048, 2, 32, 128, 512, 128, 4, 64, 256, 4),
+            (4096, 1, 32, 128, 1024, 256, 4, 64, 384, 4),
+            (2048, 1, 64, 128, 512, 128, 4, 64, 512, 4),
+        ],
+        ids=[
+            "7B_B1_sq2048_topk256",
+            "7B_B2_sq2048_topk256",
+            "13B_B1_sq4096_topk384",
+            "70B_B1_sq2048_topk512",
+        ],
+    )
+    @pytest.mark.parametrize("sparse_loss", [True, False], ids=["sparse", "dense"])
+    def test_grad_q_indexer_accuracy(
+        self, sq, b, np_, hn, n_comp, win_topk, idx_nh, idx_hd,
+        indexer_topk, ratio, sparse_loss, device, dsa_metrics,
+    ):
+        """grad_q_indexer from fused plugin matches Megatron core reference."""
+        kv_offset = sq
+        inputs = _make_fused_inputs(
+            sq, b, np_, hn, n_comp, win_topk, idx_nh, idx_hd,
+            indexer_topk, ratio, kv_offset, device,
+        )
+
+        fused_res = self._run_fused_indexer_grads(inputs, sparse_loss)
+        unfused_res = self._run_unfused_indexer_grads(inputs, sparse_loss)
+
+        g_fused = fused_res["grad_q_indexer"].float()
+        g_unfused = unfused_res["grad_q_indexer"].float()
+
+        logger.warning(
+            f"  [DEBUG test] fused_loss={fused_res['loss']:.6e}, unfused_loss={unfused_res['loss']:.6e}"
+        )
+        logger.warning(
+            f"  [DEBUG test] g_fused: norm={g_fused.norm().item():.6e}, "
+            f"all_zero={(g_fused == 0).all().item()}, max_abs={g_fused.abs().max().item():.6e}, "
+            f"shape={list(g_fused.shape)}, dtype_orig={fused_res['grad_q_indexer'].dtype}"
+        )
+        logger.warning(
+            f"  [DEBUG test] g_unfused: norm={g_unfused.norm().item():.6e}, "
+            f"all_zero={(g_unfused == 0).all().item()}, max_abs={g_unfused.abs().max().item():.6e}, "
+            f"shape={list(g_unfused.shape)}, dtype_orig={unfused_res['grad_q_indexer'].dtype}"
+        )
+        # Check if fused grad is zero but unfused is not
+        if (g_fused == 0).all() and not (g_unfused == 0).all():
+            logger.warning(
+                "  [DEBUG test] FUSED GRAD IS ALL ZERO! Investigating precomputed grad..."
+            )
+            # Check grad_k and grad_w to see if they are also zero
+            gk_fused = fused_res["grad_k_indexer"].float()
+            gw_fused = fused_res["grad_weights"].float()
+            logger.warning(
+                f"  [DEBUG test] grad_k_fused: norm={gk_fused.norm().item():.6e}, all_zero={(gk_fused==0).all().item()}"
+            )
+            logger.warning(
+                f"  [DEBUG test] grad_w_fused: norm={gw_fused.norm().item():.6e}, all_zero={(gw_fused==0).all().item()}"
+            )
+
+        cos_sim = torch.nn.functional.cosine_similarity(
+            g_fused.reshape(-1).unsqueeze(0),
+            g_unfused.reshape(-1).unsqueeze(0),
+        ).item()
+
+        abs_diff = (g_fused - g_unfused).abs()
+        max_diff = abs_diff.max().item()
+        mean_diff = abs_diff.mean().item()
+
+        logger.info(
+            f"[sq={sq}, b={b}, topk={indexer_topk}, sparse_loss={sparse_loss}] "
+            f"grad_q_indexer: cos_sim={cos_sim:.6f}, max_diff={max_diff:.4e}"
+        )
+
+        assert cos_sim > 0.95, (
+            f"grad_q_indexer cosine similarity too low: {cos_sim:.6f} "
+            f"(max_diff={max_diff:.4e}, mean_diff={mean_diff:.4e})"
+        )
+        dsa_metrics.record_accuracy(
+            params={"sq": sq, "b": b, "np": np_, "topk": indexer_topk, "sparse_loss": sparse_loss},
+            cos_sim=cos_sim, max_diff=max_diff, mean_diff=mean_diff, target="grad_q_indexer",
+        )
+
+    @pytest.mark.parametrize(
+        "sq,b,np_,hn,n_comp,win_topk,idx_nh,idx_hd,indexer_topk,ratio",
+        [
+            (2048, 1, 32, 128, 512, 128, 4, 64, 256, 4),
+            (2048, 2, 32, 128, 512, 128, 4, 64, 256, 4),
+            (4096, 1, 32, 128, 1024, 256, 4, 64, 384, 4),
+            (2048, 1, 64, 128, 512, 128, 4, 64, 512, 4),
+        ],
+        ids=[
+            "7B_B1_sq2048_topk256",
+            "7B_B2_sq2048_topk256",
+            "13B_B1_sq4096_topk384",
+            "70B_B1_sq2048_topk512",
+        ],
+    )
+    @pytest.mark.parametrize("sparse_loss", [True, False], ids=["sparse", "dense"])
+    def test_grad_k_indexer_accuracy(
+        self, sq, b, np_, hn, n_comp, win_topk, idx_nh, idx_hd,
+        indexer_topk, ratio, sparse_loss, device, dsa_metrics,
+    ):
+        """grad_k_indexer from fused plugin matches Megatron core reference."""
+        kv_offset = sq
+        inputs = _make_fused_inputs(
+            sq, b, np_, hn, n_comp, win_topk, idx_nh, idx_hd,
+            indexer_topk, ratio, kv_offset, device,
+        )
+
+        fused_res = self._run_fused_indexer_grads(inputs, sparse_loss)
+        unfused_res = self._run_unfused_indexer_grads(inputs, sparse_loss)
+
+        g_fused = fused_res["grad_k_indexer"].float()
+        g_unfused = unfused_res["grad_k_indexer"].float()
+
+        cos_sim = torch.nn.functional.cosine_similarity(
+            g_fused.reshape(-1).unsqueeze(0),
+            g_unfused.reshape(-1).unsqueeze(0),
+        ).item()
+
+        abs_diff = (g_fused - g_unfused).abs()
+        max_diff = abs_diff.max().item()
+        mean_diff = abs_diff.mean().item()
+
+        logger.info(
+            f"[sq={sq}, b={b}, topk={indexer_topk}, sparse_loss={sparse_loss}] "
+            f"grad_k_indexer: cos_sim={cos_sim:.6f}, max_diff={max_diff:.4e}"
+        )
+
+        assert cos_sim > 0.95, (
+            f"grad_k_indexer cosine similarity too low: {cos_sim:.6f} "
+            f"(max_diff={max_diff:.4e}, mean_diff={mean_diff:.4e})"
+        )
+        dsa_metrics.record_accuracy(
+            params={"sq": sq, "b": b, "np": np_, "topk": indexer_topk, "sparse_loss": sparse_loss},
+            cos_sim=cos_sim, max_diff=max_diff, mean_diff=mean_diff, target="grad_k_indexer",
+        )
+
+    @pytest.mark.parametrize(
+        "sq,b,np_,hn,n_comp,win_topk,idx_nh,idx_hd,indexer_topk,ratio",
+        [
+            (2048, 1, 32, 128, 512, 128, 4, 64, 256, 4),
+            (2048, 2, 32, 128, 512, 128, 4, 64, 256, 4),
+            (4096, 1, 32, 128, 1024, 256, 4, 64, 384, 4),
+            (2048, 1, 64, 128, 512, 128, 4, 64, 512, 4),
+        ],
+        ids=[
+            "7B_B1_sq2048_topk256",
+            "7B_B2_sq2048_topk256",
+            "13B_B1_sq4096_topk384",
+            "70B_B1_sq2048_topk512",
+        ],
+    )
+    @pytest.mark.parametrize("sparse_loss", [True, False], ids=["sparse", "dense"])
+    def test_grad_weights_accuracy(
+        self, sq, b, np_, hn, n_comp, win_topk, idx_nh, idx_hd,
+        indexer_topk, ratio, sparse_loss, device, dsa_metrics,
+    ):
+        """grad_weights from fused plugin matches Megatron core reference.
+
+        Note: fused returns d(loss)/d(weights_raw), unfused returns
+        d(loss)/d(weights_scaled) where scaled = raw * indexer_softmax_scale.
+        These differ by a constant factor. If they match, fused correctly
+        accounts for the scale in its backward; if not, this test catches it.
+        """
+        kv_offset = sq
+        inputs = _make_fused_inputs(
+            sq, b, np_, hn, n_comp, win_topk, idx_nh, idx_hd,
+            indexer_topk, ratio, kv_offset, device,
+        )
+
+        fused_res = self._run_fused_indexer_grads(inputs, sparse_loss)
+        unfused_res = self._run_unfused_indexer_grads(inputs, sparse_loss)
+
+        g_fused = fused_res["grad_weights"].float()
+        g_unfused = unfused_res["grad_weights"].float()
+
+        cos_sim = torch.nn.functional.cosine_similarity(
+            g_fused.reshape(-1).unsqueeze(0),
+            g_unfused.reshape(-1).unsqueeze(0),
+        ).item()
+
+        abs_diff = (g_fused - g_unfused).abs()
+        max_diff = abs_diff.max().item()
+        mean_diff = abs_diff.mean().item()
+
+        logger.info(
+            f"[sq={sq}, b={b}, topk={indexer_topk}, sparse_loss={sparse_loss}] "
+            f"grad_weights: cos_sim={cos_sim:.6f}, max_diff={max_diff:.4e}"
+        )
+
+        assert cos_sim > 0.95, (
+            f"grad_weights cosine similarity too low: {cos_sim:.6f} "
+            f"(max_diff={max_diff:.4e}, mean_diff={mean_diff:.4e})"
+        )
+        dsa_metrics.record_accuracy(
+            params={"sq": sq, "b": b, "np": np_, "topk": indexer_topk, "sparse_loss": sparse_loss},
+            cos_sim=cos_sim, max_diff=max_diff, mean_diff=mean_diff, target="grad_weights",
+        )
+
+
+# ---------------------------------------------------------------------------
+# Indexer loss value consistency: fused (triton plugin) vs unfused (Megatron core)
+# ---------------------------------------------------------------------------
+
+
+class TestIndexerLossConsistency:
+    """Validate indexer loss value matches between fused and unfused paths.
+
+    The fused path computes indexer loss inside ``FusedIndexerSparseAttnFunc.forward``
+    via ``fused_sparse_indexer_loss_and_backward`` / ``fused_dense_indexer_loss_and_backward``.
+    The unfused path uses ``FusedDSAIndexerLoss.forward`` → ``fwd_fused_indexer_loss_naive``
+    from Megatron core.
+
+    We compare the scalar loss values and verify they agree within bf16 tolerance.
+    """
+
+    @pytest.fixture
+    def device(self):
+        return torch.device("cuda:0")
+
+    @staticmethod
+    def _get_fused_loss(inputs: dict, sparse_loss: bool) -> float:
+        """Run fused path, return indexer loss scalar."""
+        with torch.no_grad():
+            _, loss = fused_indexer_sparse_attn(
+                inputs["query"], inputs["kv_full"], inputs["attn_sink"],
+                inputs["window_idxs"], inputs["q_indexer"], inputs["k_indexer"],
+                inputs["weights"], inputs["indexer_topk"], inputs["ratio"],
+                inputs["softmax_scale"], inputs["indexer_softmax_scale"],
+                0.1, sparse_loss, inputs["kv_offset"], False,
+            )
+        return loss.item()
+
+    @staticmethod
+    def _get_unfused_loss(inputs: dict, sparse_loss: bool) -> float:
+        """Run Megatron core FusedDSAIndexerLoss, return indexer loss scalar."""
+        from megatron.core.transformer.experimental_attention_variant.dsa import (
+            FusedDSAIndexerLoss,
+        )
+
+        sq = inputs["sq"]
+        b = inputs["b"]
+        np_ = inputs["np"]
+        hn = inputs["hn"]
+        n_comp = inputs["n_comp"]
+        kv_offset = inputs["kv_offset"]
+        ratio = inputs["ratio"]
+
+        q_indexer = inputs["q_indexer"].clone().detach()
+        k_indexer = inputs["k_indexer"].clone().detach()
+        weights_raw = inputs["weights"].clone().detach().float()
+        weights_for_unfused = weights_raw * inputs["indexer_softmax_scale"]
+
+        query_det = inputs["query"].clone().detach()
+        kv_compressed = inputs["kv_full"][kv_offset:kv_offset + n_comp]
+        key_for_loss = kv_compressed.unsqueeze(2).expand(-1, -1, np_, -1).detach()
+
+        # Build causal mask [b, sq, n_comp]
+        causal_mask = (
+            torch.arange(n_comp, device=q_indexer.device).unsqueeze(0).expand(sq, -1)
+        )
+        positions = torch.arange(1, sq + 1, device=q_indexer.device).unsqueeze(1)
+        causal_mask = (
+            torch.where(causal_mask >= positions // ratio, float("-inf"), 0.0)
+            .unsqueeze(0)
+            .expand(b, -1, -1)
+        )
+
+        # Mock pg_collection with TP size=1
+        class _MockPG:
+            def size(self):
+                return 1
+        class _MockPGCollection:
+            tp = _MockPG()
+            cp = None
+        pg_collection = _MockPGCollection()
+
+        with torch.no_grad():
+            _, loss = FusedDSAIndexerLoss.apply(
+                q_indexer,
+                weights_for_unfused,
+                k_indexer,
+                query_det,
+                key_for_loss,
+                inputs["softmax_scale"],
+                min(inputs["indexer_topk"], n_comp),
+                0.1,  # loss_coeff
+                causal_mask,
+                sparse_loss,
+                pg_collection,
+                False,  # calculate_per_token_loss
+            )
+
+        return loss.item()
+
+    @pytest.mark.parametrize(
+        "sq,b,np_,hn,n_comp,win_topk,idx_nh,idx_hd,indexer_topk,ratio",
+        [
+            (2048, 1, 32, 128, 512, 128, 4, 64, 256, 4),
+            (2048, 2, 32, 128, 512, 128, 4, 64, 256, 4),
+            (4096, 1, 32, 128, 1024, 256, 4, 64, 384, 4),
+            (2048, 1, 64, 128, 512, 128, 4, 64, 512, 4),
+        ],
+        ids=[
+            "7B_B1_sq2048_topk256",
+            "7B_B2_sq2048_topk256",
+            "13B_B1_sq4096_topk384",
+            "70B_B1_sq2048_topk512",
+        ],
+    )
+    @pytest.mark.parametrize("sparse_loss", [True, False], ids=["sparse", "dense"])
+    def test_loss_value_consistency(
+        self, sq, b, np_, hn, n_comp, win_topk, idx_nh, idx_hd,
+        indexer_topk, ratio, sparse_loss, device, dsa_metrics,
+    ):
+        """Indexer loss from fused plugin matches Megatron core reference."""
+        kv_offset = sq
+        inputs = _make_fused_inputs(
+            sq, b, np_, hn, n_comp, win_topk, idx_nh, idx_hd,
+            indexer_topk, ratio, kv_offset, device,
+        )
+
+        loss_fused = self._get_fused_loss(inputs, sparse_loss)
+        loss_unfused = self._get_unfused_loss(inputs, sparse_loss)
+
+        # Both losses are f32 scalars; use relative tolerance
+        abs_diff = abs(loss_fused - loss_unfused)
+        denom = max(abs(loss_fused), abs(loss_unfused), 1e-8)
+        rel_diff = abs_diff / denom
+
+        logger.info(
+            f"[sq={sq}, b={b}, topk={indexer_topk}, sparse_loss={sparse_loss}] "
+            f"loss_fused={loss_fused:.6e}, loss_unfused={loss_unfused:.6e}, "
+            f"rel_diff={rel_diff:.4e}"
+        )
+
+        # bf16 inputs → allow up to 5% relative error for loss accumulation
+        assert rel_diff < 0.05, (
+            f"Indexer loss mismatch: fused={loss_fused:.6e}, unfused={loss_unfused:.6e}, "
+            f"rel_diff={rel_diff:.4e}"
+        )
+        dsa_metrics.record_accuracy(
+            params={"sq": sq, "b": b, "np": np_, "topk": indexer_topk, "sparse_loss": sparse_loss},
+            cos_sim=1.0 - rel_diff, max_diff=abs_diff, target="indexer_loss",
+        )
+
+    # ------------------------------------------------------------------
+    # Per-token vs mean reduction relationship
+    # ------------------------------------------------------------------
+
+    @pytest.mark.parametrize(
+        "sq,b,np_,hn,n_comp,win_topk,idx_nh,idx_hd,indexer_topk,ratio",
+        [
+            (2048, 1, 32, 128, 512, 128, 4, 64, 256, 4),
+            (2048, 2, 32, 128, 512, 128, 4, 64, 256, 4),
+            (4096, 1, 32, 128, 1024, 256, 4, 64, 384, 4),
+        ],
+        ids=["7B_B1_sq2048", "7B_B2_sq2048", "13B_B1_sq4096"],
+    )
+    @pytest.mark.parametrize("sparse_loss", [True, False], ids=["sparse", "dense"])
+    def test_per_token_vs_mean_reduction(
+        self, sq, b, np_, hn, n_comp, win_topk, idx_nh, idx_hd,
+        indexer_topk, ratio, sparse_loss, device, dsa_metrics,
+    ):
+        """loss(per_token) / loss(mean) ≈ B * S_q (sum vs mean over rows)."""
+        kv_offset = sq
+        inputs = _make_fused_inputs(
+            sq, b, np_, hn, n_comp, win_topk, idx_nh, idx_hd,
+            indexer_topk, ratio, kv_offset, device,
+        )
+
+        loss_coeff = 1.0  # Use 1.0 so ratio is cleaner
+
+        _, loss_mean = fused_indexer_sparse_attn(
+            inputs["query"], inputs["kv_full"], inputs["attn_sink"],
+            inputs["window_idxs"], inputs["q_indexer"], inputs["k_indexer"],
+            inputs["weights"], inputs["indexer_topk"], inputs["ratio"],
+            inputs["softmax_scale"], inputs["indexer_softmax_scale"],
+            loss_coeff, sparse_loss, inputs["kv_offset"],
+            calculate_per_token_loss=False,
+        )
+
+        _, loss_per_token = fused_indexer_sparse_attn(
+            inputs["query"], inputs["kv_full"], inputs["attn_sink"],
+            inputs["window_idxs"], inputs["q_indexer"], inputs["k_indexer"],
+            inputs["weights"], inputs["indexer_topk"], inputs["ratio"],
+            inputs["softmax_scale"], inputs["indexer_softmax_scale"],
+            loss_coeff, sparse_loss, inputs["kv_offset"],
+            calculate_per_token_loss=True,
+        )
+
+        n_rows = b * sq
+        expected_ratio = float(n_rows)
+        actual_ratio = loss_per_token.item() / max(loss_mean.item(), 1e-12)
+
+        rel_err = abs(actual_ratio - expected_ratio) / expected_ratio
+        assert rel_err < 0.01, (
+            f"per_token/mean ratio mismatch: got {actual_ratio:.2f}, "
+            f"expected {expected_ratio:.2f} (rel_err={rel_err:.4e})"
+        )
+
+        logger.info(
+            f"[sq={sq}, b={b}, sparse_loss={sparse_loss}] "
+            f"per_token={loss_per_token.item():.6f}, mean={loss_mean.item():.6f}, "
+            f"ratio={actual_ratio:.2f}, expected={expected_ratio:.0f}"
+        )
+        dsa_metrics.record_accuracy(
+            params={"sq": sq, "b": b, "sparse_loss": sparse_loss},
+            cos_sim=1.0 - rel_err, target="per_token_vs_mean",
+        )
+
+    # ------------------------------------------------------------------
+    # Per-token loss with gradient — ensure backward still works
+    # ------------------------------------------------------------------
+
+    @pytest.mark.parametrize(
+        "sq,b,np_,hn,n_comp,win_topk,idx_nh,idx_hd,indexer_topk,ratio",
+        [
+            (2048, 1, 32, 128, 512, 128, 4, 64, 256, 4),
+        ],
+    )
+    @pytest.mark.parametrize("sparse_loss", [True, False], ids=["sparse", "dense"])
+    def test_per_token_loss_backward_no_nan(
+        self, sq, b, np_, hn, n_comp, win_topk, idx_nh, idx_hd,
+        indexer_topk, ratio, sparse_loss, device,
+    ):
+        """Backward with calculate_per_token_loss=True produces no NaN/Inf."""
+        kv_offset = sq
+        inputs = _make_fused_inputs(
+            sq, b, np_, hn, n_comp, win_topk, idx_nh, idx_hd,
+            indexer_topk, ratio, kv_offset, device,
+        )
+
+        query = inputs["query"].clone().detach().requires_grad_(True)
+        kv_full = inputs["kv_full"].clone().detach().requires_grad_(True)
+        attn_sink = inputs["attn_sink"].clone().detach().requires_grad_(True)
+
+        out, loss = fused_indexer_sparse_attn(
+            query, kv_full, attn_sink, inputs["window_idxs"],
+            inputs["q_indexer"], inputs["k_indexer"], inputs["weights"],
+            inputs["indexer_topk"], inputs["ratio"],
+            inputs["softmax_scale"], inputs["indexer_softmax_scale"],
+            0.1, sparse_loss, inputs["kv_offset"],
+            calculate_per_token_loss=True,
+        )
+
+        scalar = out.float().sum() + loss
+        scalar.backward()
+
+        for name, param in [("query", query), ("kv_full", kv_full), ("attn_sink", attn_sink)]:
+            assert param.grad is not None, f"{name}.grad is None"
+            assert not torch.isnan(param.grad).any(), f"{name}.grad has NaN"
+            assert not torch.isinf(param.grad).any(), f"{name}.grad has Inf"
+
+        assert loss.item() > 0, f"Per-token loss should be positive, got {loss.item()}"
+        logger.info(
+            f"[sparse_loss={sparse_loss}] per_token_loss={loss.item():.6f}, "
+            f"grad_query_norm={query.grad.float().norm().item():.4e}"
         )
 

--- a/tests/unit_tests/plugin/dsa_kernel/test_fused_dsa.py
+++ b/tests/unit_tests/plugin/dsa_kernel/test_fused_dsa.py
@@ -1,0 +1,1729 @@
+# Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
+
+"""
+Accuracy and performance tests for FusedIndexerSparseAttnFunc.
+
+Validates that ``fused_indexer_sparse_attn`` from the Triton plugin produces
+numerically equivalent attention output to ``unfused_compressed_sparse_attn``
+from ``megatron.core.transformer.experimental_attention_variant.csa``.
+
+The fused path:
+1. Scores + top-K selection via indexer (q_indexer, k_indexer, weights)
+2. Combines compressed top-K indices with window indices
+3. Runs sparse attention over combined indices
+4. Computes indexer KL loss (sparse or dense variant)
+
+The unfused path takes pre-computed indices and runs only the sparse attention.
+We compare the attention output (not the loss) between them.
+
+Run with: pytest tests/unit_tests/plugin/dsa_kernel/test_fused_indexer_sparse_attn.py -v -s
+Requires: CUDA GPU with Triton support.
+"""
+
+from __future__ import annotations
+
+import math
+import time
+from typing import Tuple
+
+import pytest
+import torch
+from torch import Tensor
+
+# Skip entire module if CUDA is not available
+pytestmark = pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+
+# ---------------------------------------------------------------------------
+# Imports
+# ---------------------------------------------------------------------------
+
+from megatron.plugin.dsa_kernel.triton_dsa_kernels import (
+    fused_indexer_sparse_attn,
+    _sbhd_to_bshd_indexer_inputs,
+    _indexer_topk_bshd,
+    _kl_loss_from_target_predict,
+    _kl_loss_from_dense_scores,
+)
+from megatron.plugin.dsa_kernel.triton_indexer_kernels import (
+    sparse_indexer_score_recompute,
+    sparse_attn_score_recompute,
+    dense_indexer_score_recompute,
+    dense_attn_score_recompute,
+)
+from megatron.core.transformer.experimental_attention_variant.csa import (
+    unfused_compressed_sparse_attn,
+    get_window_topk_idxs,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_fused_inputs(
+    sq: int,
+    b: int,
+    np_: int,
+    hn: int,
+    n_comp: int,
+    win_topk: int,
+    idx_nh: int,
+    idx_hd: int,
+    indexer_topk: int,
+    ratio: int,
+    kv_offset: int,
+    device: torch.device,
+    seed: int = 42,
+) -> dict:
+    """Generate random inputs for fused_indexer_sparse_attn.
+
+    KV layout: [n_kv, b, hn] where n_kv = kv_offset + n_comp (total KV length
+    including original tokens and compressed tokens).
+
+    Convention:
+    - Positions [0, kv_offset) are original tokens
+    - Positions [kv_offset, kv_offset + n_comp) are compressed tokens
+    - window_idxs refer to original token positions [0, kv_offset)
+    - k_indexer has n_comp positions (compressed tokens)
+    - indexer top-K indices are offsets into k_indexer [0, n_comp), later
+      shifted by kv_offset for the combined index set
+    """
+    torch.manual_seed(seed)
+
+    n_kv = kv_offset + n_comp
+
+    query = torch.randn(sq, b, np_, hn, device=device, dtype=torch.bfloat16)
+    kv_full = torch.randn(n_kv, b, hn, device=device, dtype=torch.bfloat16)
+    attn_sink = torch.randn(np_, device=device, dtype=torch.float32) * 0.1
+
+    # Window indices: point to original token positions [0, kv_offset)
+    # Use a simple sliding window pattern
+    window_idxs = get_window_topk_idxs(win_topk, b, sq, device).int()
+    # Clamp to valid range [0, kv_offset) and mark out-of-range as -1
+    invalid_win = window_idxs >= kv_offset
+    window_idxs = window_idxs.clamp(max=kv_offset - 1)
+    window_idxs[invalid_win] = -1
+
+    # Indexer inputs
+    q_indexer = torch.randn(sq, b, idx_nh, idx_hd, device=device, dtype=torch.bfloat16)
+    k_indexer = torch.randn(n_comp, b, idx_hd, device=device, dtype=torch.bfloat16)
+    weights = torch.randn(sq, b, idx_nh, device=device, dtype=torch.bfloat16).abs()
+
+    softmax_scale = 1.0 / math.sqrt(hn)
+    indexer_softmax_scale = 1.0 / math.sqrt(idx_hd)
+
+    return {
+        "query": query,
+        "kv_full": kv_full,
+        "attn_sink": attn_sink,
+        "window_idxs": window_idxs,
+        "q_indexer": q_indexer,
+        "k_indexer": k_indexer,
+        "weights": weights,
+        "indexer_topk": indexer_topk,
+        "ratio": ratio,
+        "softmax_scale": softmax_scale,
+        "indexer_softmax_scale": indexer_softmax_scale,
+        "kv_offset": kv_offset,
+        "n_kv": n_kv,
+        "sq": sq,
+        "b": b,
+        "np": np_,
+        "hn": hn,
+        "n_comp": n_comp,
+        "win_topk": win_topk,
+    }
+
+
+def _run_fused(inputs: dict, sparse_loss: bool, loss_coeff: float = 0.1) -> Tuple[Tensor, Tensor]:
+    """Run fused_indexer_sparse_attn and return (output, indexer_loss)."""
+    return fused_indexer_sparse_attn(
+        inputs["query"],
+        inputs["kv_full"],
+        inputs["attn_sink"],
+        inputs["window_idxs"],
+        inputs["q_indexer"],
+        inputs["k_indexer"],
+        inputs["weights"],
+        inputs["indexer_topk"],
+        inputs["ratio"],
+        inputs["softmax_scale"],
+        inputs["indexer_softmax_scale"],
+        loss_coeff,
+        sparse_loss,
+        inputs["kv_offset"],
+        calculate_per_token_loss=False,
+    )
+
+
+def _run_unfused_with_same_indices(inputs: dict) -> Tuple[Tensor, Tensor]:
+    """Run unfused_compressed_sparse_attn with the same indices that the fused
+    path would compute.
+
+    Steps:
+    1. Replicate the indexer scoring + top-K selection from the fused path
+    2. Combine indices (compressed + window) — same order as fused
+    3. Run unfused_compressed_sparse_attn (ground truth)
+
+    Returns:
+        (output, combined_topk_idxs)
+    """
+    from megatron.plugin.dsa_kernel.triton_dsa_kernels import (
+        _sbhd_to_bshd_indexer_inputs,
+        _indexer_topk_bshd,
+    )
+
+    n_comp = inputs["n_comp"]
+    kv_offset = inputs["kv_offset"]
+    effective_topk = min(inputs["indexer_topk"], n_comp)
+
+    # Replicate indexer scoring (same as fused path steps 1-3)
+    q_idx_bshd, k_idx_bsd, w_bsh, w_bsh_scaled = _sbhd_to_bshd_indexer_inputs(
+        inputs["q_indexer"], inputs["k_indexer"],
+        inputs["weights"], inputs["indexer_softmax_scale"]
+    )
+    topk_indices_cmp, _, _ = _indexer_topk_bshd(
+        q_idx_bshd, k_idx_bsd, w_bsh_scaled, effective_topk, inputs["ratio"]
+    )
+
+    # Add kv_offset to compressed indices
+    topk_indices_global = topk_indices_cmp.clone()
+    valid_cmp = topk_indices_global >= 0
+    topk_indices_global[valid_cmp] += kv_offset
+
+    # Combine: compressed first, then window (same order as fused)
+    combined_idxs = torch.cat(
+        [topk_indices_global, inputs["window_idxs"]], dim=-1
+    )  # (b, sq, total_topk)
+
+    # Run unfused sparse attention (ground truth)
+    output = unfused_compressed_sparse_attn(
+        inputs["query"],
+        inputs["kv_full"],
+        inputs["attn_sink"],
+        combined_idxs,
+        inputs["softmax_scale"],
+    )
+
+    return output, combined_idxs
+
+
+# ---------------------------------------------------------------------------
+# Accuracy tests
+# ---------------------------------------------------------------------------
+
+
+class TestFusedIndexerSparseAttnAccuracy:
+    """Compare fused_indexer_sparse_attn output against unfused_compressed_sparse_attn.
+
+    The fused path uses triton_sparse_attn_forward (online softmax) while the
+    unfused path uses standard materialized softmax. Both include the attention
+    sink. We verify the attention outputs are numerically close.
+    """
+
+    @pytest.fixture
+    def device(self):
+        return torch.device("cuda:0")
+
+    @pytest.mark.parametrize(
+        "sq,b,np_,hn,n_comp,win_topk,idx_nh,idx_hd,indexer_topk,ratio",
+        [
+            # Small shapes — tighter tolerance
+            (32, 1, 4, 128, 16, 8, 2, 64, 8, 4),
+            (32, 2, 4, 128, 32, 16, 2, 64, 16, 4),
+            # Medium shapes
+            (64, 2, 4, 128, 64, 32, 2, 64, 32, 4),
+            (128, 1, 8, 128, 32, 16, 4, 64, 16, 4),
+            # Larger topk (closer to production)
+            (64, 1, 4, 128, 128, 32, 2, 64, 64, 4),
+            (128, 1, 4, 128, 256, 64, 2, 64, 128, 4),
+        ],
+        ids=[
+            "small_B1",
+            "small_B2",
+            "medium_B2",
+            "medium_8heads",
+            "large_topk64",
+            "large_topk128",
+        ],
+    )
+    @pytest.mark.parametrize("sparse_loss", [True, False], ids=["sparse", "dense"])
+    def test_output_accuracy(
+        self, sq, b, np_, hn, n_comp, win_topk, idx_nh, idx_hd,
+        indexer_topk, ratio, sparse_loss, device,
+    ):
+        """Fused attention output matches unfused path (both with attn_sink)."""
+        kv_offset = sq  # original tokens occupy [0, sq)
+        inputs = _make_fused_inputs(
+            sq, b, np_, hn, n_comp, win_topk, idx_nh, idx_hd,
+            indexer_topk, ratio, kv_offset, device,
+        )
+
+        # Fused path
+        out_fused, indexer_loss = _run_fused(inputs, sparse_loss=sparse_loss)
+
+        # Unfused path (same indices)
+        out_unfused, _ = _run_unfused_with_same_indices(inputs)
+
+        # Compare attention output
+        out_fused_f = out_fused.float()
+        out_unfused_f = out_unfused.float()
+
+        abs_diff = (out_fused_f - out_unfused_f).abs()
+        max_diff = abs_diff.max().item()
+        mean_diff = abs_diff.mean().item()
+
+        # Tolerance: bf16 accumulation in triton online softmax vs PyTorch materialized
+        atol = 5e-2
+        rtol = 5e-2
+        assert torch.allclose(out_fused_f, out_unfused_f, atol=atol, rtol=rtol), (
+            f"Output mismatch (sparse_loss={sparse_loss}): "
+            f"max abs diff = {max_diff:.4e}, mean abs diff = {mean_diff:.4e}"
+        )
+
+        # Cosine similarity should be very high
+        cos_sim = torch.nn.functional.cosine_similarity(
+            out_fused_f.reshape(-1).unsqueeze(0),
+            out_unfused_f.reshape(-1).unsqueeze(0),
+        ).item()
+        assert cos_sim > 0.99, (
+            f"Cosine similarity too low: {cos_sim:.6f}"
+        )
+
+        # Indexer loss should be finite and non-negative
+        assert torch.isfinite(indexer_loss), f"Indexer loss is not finite: {indexer_loss.item()}"
+        assert indexer_loss.item() >= 0, f"Indexer loss is negative: {indexer_loss.item()}"
+
+    @pytest.mark.parametrize(
+        "sq,b,np_,hn,n_comp,win_topk,idx_nh,idx_hd,indexer_topk,ratio",
+        [
+            (64, 2, 4, 128, 64, 32, 2, 64, 32, 4),
+        ],
+    )
+    def test_loss_nonzero(
+        self, sq, b, np_, hn, n_comp, win_topk, idx_nh, idx_hd,
+        indexer_topk, ratio, device,
+    ):
+        """Indexer loss is non-trivially > 0 (not degenerate)."""
+        kv_offset = sq
+        inputs = _make_fused_inputs(
+            sq, b, np_, hn, n_comp, win_topk, idx_nh, idx_hd,
+            indexer_topk, ratio, kv_offset, device,
+        )
+
+        _, loss_sparse = _run_fused(inputs, sparse_loss=True, loss_coeff=1.0)
+        _, loss_dense = _run_fused(inputs, sparse_loss=False, loss_coeff=1.0)
+
+        # With random inputs, KL divergence should be > 0
+        assert loss_sparse.item() > 1e-6, (
+            f"Sparse loss is suspiciously close to zero: {loss_sparse.item()}"
+        )
+        assert loss_dense.item() > 1e-6, (
+            f"Dense loss is suspiciously close to zero: {loss_dense.item()}"
+        )
+
+    @pytest.mark.parametrize(
+        "sq,b,np_,hn,n_comp,win_topk,idx_nh,idx_hd,indexer_topk,ratio",
+        [
+            (32, 2, 4, 128, 32, 16, 2, 64, 16, 4),
+        ],
+    )
+    def test_deterministic(
+        self, sq, b, np_, hn, n_comp, win_topk, idx_nh, idx_hd,
+        indexer_topk, ratio, device,
+    ):
+        """Multiple calls with same input produce identical results."""
+        kv_offset = sq
+        inputs = _make_fused_inputs(
+            sq, b, np_, hn, n_comp, win_topk, idx_nh, idx_hd,
+            indexer_topk, ratio, kv_offset, device,
+        )
+
+        out1, loss1 = _run_fused(inputs, sparse_loss=True)
+        out2, loss2 = _run_fused(inputs, sparse_loss=True)
+
+        assert torch.equal(out1, out2), "Fused output is non-deterministic"
+        assert torch.equal(loss1, loss2), "Fused loss is non-deterministic"
+
+    @pytest.mark.parametrize(
+        "sq,b,np_,hn,n_comp,win_topk,idx_nh,idx_hd,indexer_topk,ratio",
+        [
+            (32, 1, 4, 128, 16, 8, 2, 64, 8, 4),
+        ],
+    )
+    def test_loss_coeff_scaling(
+        self, sq, b, np_, hn, n_comp, win_topk, idx_nh, idx_hd,
+        indexer_topk, ratio, device,
+    ):
+        """Indexer loss scales linearly with loss_coeff."""
+        kv_offset = sq
+        inputs = _make_fused_inputs(
+            sq, b, np_, hn, n_comp, win_topk, idx_nh, idx_hd,
+            indexer_topk, ratio, kv_offset, device,
+        )
+
+        _, loss_1x = _run_fused(inputs, sparse_loss=True, loss_coeff=1.0)
+        _, loss_2x = _run_fused(inputs, sparse_loss=True, loss_coeff=2.0)
+
+        ratio_actual = loss_2x.item() / max(loss_1x.item(), 1e-12)
+        assert abs(ratio_actual - 2.0) < 0.01, (
+            f"Loss does not scale linearly: ratio = {ratio_actual:.4f}, expected 2.0"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Backward accuracy tests
+# ---------------------------------------------------------------------------
+
+
+class TestFusedIndexerSparseAttnBackward:
+    """Validate backward-pass gradient accuracy of fused_indexer_sparse_attn.
+
+    Compares gradients (d_query, d_kv_full, d_attn_sink) from the fused Triton
+    path against PyTorch-autograd gradients from unfused_compressed_sparse_attn.
+
+    The indexer branch (q_indexer, k_indexer, weights) has a simplified backward
+    in the fused path, so we only validate gradients that flow through the sparse
+    attention portion.
+    """
+
+    @pytest.fixture
+    def device(self):
+        return torch.device("cuda:0")
+
+    @staticmethod
+    def _run_fused_with_grad(inputs: dict, sparse_loss: bool) -> dict:
+        """Run fused path with gradients enabled, return output + grads."""
+        query = inputs["query"].clone().detach().requires_grad_(True)
+        kv_full = inputs["kv_full"].clone().detach().requires_grad_(True)
+        attn_sink = inputs["attn_sink"].clone().detach().requires_grad_(True)
+
+        out, loss = fused_indexer_sparse_attn(
+            query, kv_full, attn_sink, inputs["window_idxs"],
+            inputs["q_indexer"], inputs["k_indexer"], inputs["weights"],
+            inputs["indexer_topk"], inputs["ratio"],
+            inputs["softmax_scale"], inputs["indexer_softmax_scale"],
+            0.1, sparse_loss, inputs["kv_offset"], False,
+        )
+
+        # Backward with a simple scalar objective
+        scalar = out.float().sum() + loss
+        scalar.backward()
+
+        return {
+            "output": out,
+            "loss": loss,
+            "grad_query": query.grad,
+            "grad_kv_full": kv_full.grad,
+            "grad_attn_sink": attn_sink.grad,
+        }
+
+    @staticmethod
+    def _run_unfused_with_grad(inputs: dict) -> dict:
+        """Run unfused path with gradients enabled, return output + grads."""
+        from megatron.plugin.dsa_kernel.triton_dsa_kernels import (
+            _sbhd_to_bshd_indexer_inputs,
+            _indexer_topk_bshd,
+        )
+
+        query = inputs["query"].clone().detach().requires_grad_(True)
+        kv_full = inputs["kv_full"].clone().detach().requires_grad_(True)
+        attn_sink = inputs["attn_sink"].clone().detach().requires_grad_(True)
+
+        n_comp = inputs["n_comp"]
+        kv_offset = inputs["kv_offset"]
+        effective_topk = min(inputs["indexer_topk"], n_comp)
+
+        # Replicate indexer to get same indices (no grad needed for indices)
+        q_idx_bshd, k_idx_bsd, _, w_bsh_scaled = _sbhd_to_bshd_indexer_inputs(
+            inputs["q_indexer"], inputs["k_indexer"],
+            inputs["weights"], inputs["indexer_softmax_scale"]
+        )
+        topk_indices_cmp, _, _ = _indexer_topk_bshd(
+            q_idx_bshd, k_idx_bsd, w_bsh_scaled, effective_topk, inputs["ratio"]
+        )
+
+        topk_indices_global = topk_indices_cmp.clone()
+        valid_cmp = topk_indices_global >= 0
+        topk_indices_global[valid_cmp] += kv_offset
+
+        combined_idxs = torch.cat(
+            [topk_indices_global, inputs["window_idxs"]], dim=-1
+        )
+
+        out = unfused_compressed_sparse_attn(
+            query, kv_full, attn_sink, combined_idxs, inputs["softmax_scale"],
+        )
+
+        scalar = out.float().sum()
+        scalar.backward()
+
+        return {
+            "output": out,
+            "grad_query": query.grad,
+            "grad_kv_full": kv_full.grad,
+            "grad_attn_sink": attn_sink.grad,
+        }
+
+    @pytest.mark.parametrize(
+        "sq,b,np_,hn,n_comp,win_topk,idx_nh,idx_hd,indexer_topk,ratio",
+        [
+            (32, 1, 4, 128, 16, 8, 2, 64, 8, 4),
+            (32, 2, 4, 128, 32, 16, 2, 64, 16, 4),
+            (64, 2, 4, 128, 64, 32, 2, 64, 32, 4),
+            (128, 1, 8, 128, 32, 16, 4, 64, 16, 4),
+            (64, 1, 4, 128, 128, 32, 2, 64, 64, 4),
+        ],
+        ids=[
+            "small_B1",
+            "small_B2",
+            "medium_B2",
+            "medium_8heads",
+            "large_topk64",
+        ],
+    )
+    @pytest.mark.parametrize("sparse_loss", [True, False], ids=["sparse", "dense"])
+    def test_grad_query_accuracy(
+        self, sq, b, np_, hn, n_comp, win_topk, idx_nh, idx_hd,
+        indexer_topk, ratio, sparse_loss, device,
+    ):
+        """Gradient w.r.t. query matches unfused reference."""
+        kv_offset = sq
+        inputs = _make_fused_inputs(
+            sq, b, np_, hn, n_comp, win_topk, idx_nh, idx_hd,
+            indexer_topk, ratio, kv_offset, device,
+        )
+
+        fused_res = self._run_fused_with_grad(inputs, sparse_loss)
+        unfused_res = self._run_unfused_with_grad(inputs)
+
+        g_fused = fused_res["grad_query"].float()
+        g_unfused = unfused_res["grad_query"].float()
+
+        abs_diff = (g_fused - g_unfused).abs()
+        max_diff = abs_diff.max().item()
+        mean_diff = abs_diff.mean().item()
+
+        # bf16 backward through online softmax vs materialized — use cosine similarity
+        # as primary metric since element-wise tolerance is too strict for bf16 numerics
+        cos_sim = torch.nn.functional.cosine_similarity(
+            g_fused.reshape(-1).unsqueeze(0),
+            g_unfused.reshape(-1).unsqueeze(0),
+        ).item()
+
+        assert cos_sim > 0.95, (
+            f"grad_query cosine similarity too low: {cos_sim:.6f} "
+            f"(max_diff={max_diff:.4e}, mean_diff={mean_diff:.4e})"
+        )
+        print(
+            f"\n  grad_query: cos_sim={cos_sim:.6f}, "
+            f"max_diff={max_diff:.4e}, mean_diff={mean_diff:.4e}"
+        )
+
+    @pytest.mark.parametrize(
+        "sq,b,np_,hn,n_comp,win_topk,idx_nh,idx_hd,indexer_topk,ratio",
+        [
+            (32, 1, 4, 128, 16, 8, 2, 64, 8, 4),
+            (32, 2, 4, 128, 32, 16, 2, 64, 16, 4),
+            (64, 2, 4, 128, 64, 32, 2, 64, 32, 4),
+            (128, 1, 8, 128, 32, 16, 4, 64, 16, 4),
+        ],
+        ids=[
+            "small_B1",
+            "small_B2",
+            "medium_B2",
+            "medium_8heads",
+        ],
+    )
+    @pytest.mark.parametrize("sparse_loss", [True, False], ids=["sparse", "dense"])
+    def test_grad_kv_accuracy(
+        self, sq, b, np_, hn, n_comp, win_topk, idx_nh, idx_hd,
+        indexer_topk, ratio, sparse_loss, device,
+    ):
+        """Gradient w.r.t. kv_full matches unfused reference."""
+        kv_offset = sq
+        inputs = _make_fused_inputs(
+            sq, b, np_, hn, n_comp, win_topk, idx_nh, idx_hd,
+            indexer_topk, ratio, kv_offset, device,
+        )
+
+        fused_res = self._run_fused_with_grad(inputs, sparse_loss)
+        unfused_res = self._run_unfused_with_grad(inputs)
+
+        g_fused = fused_res["grad_kv_full"].float()
+        g_unfused = unfused_res["grad_kv_full"].float()
+
+        abs_diff = (g_fused - g_unfused).abs()
+        max_diff = abs_diff.max().item()
+        mean_diff = abs_diff.mean().item()
+
+        cos_sim = torch.nn.functional.cosine_similarity(
+            g_fused.reshape(-1).unsqueeze(0),
+            g_unfused.reshape(-1).unsqueeze(0),
+        ).item()
+
+        assert cos_sim > 0.95, (
+            f"grad_kv_full cosine similarity too low: {cos_sim:.6f} "
+            f"(max_diff={max_diff:.4e}, mean_diff={mean_diff:.4e})"
+        )
+        print(
+            f"\n  grad_kv_full: cos_sim={cos_sim:.6f}, "
+            f"max_diff={max_diff:.4e}, mean_diff={mean_diff:.4e}"
+        )
+
+    @pytest.mark.parametrize(
+        "sq,b,np_,hn,n_comp,win_topk,idx_nh,idx_hd,indexer_topk,ratio",
+        [
+            (32, 1, 4, 128, 16, 8, 2, 64, 8, 4),
+            (64, 2, 4, 128, 64, 32, 2, 64, 32, 4),
+            (128, 1, 8, 128, 32, 16, 4, 64, 16, 4),
+        ],
+        ids=[
+            "small_B1",
+            "medium_B2",
+            "medium_8heads",
+        ],
+    )
+    def test_grad_attn_sink_accuracy(
+        self, sq, b, np_, hn, n_comp, win_topk, idx_nh, idx_hd,
+        indexer_topk, ratio, device,
+    ):
+        """Gradient w.r.t. attn_sink matches unfused reference."""
+        kv_offset = sq
+        inputs = _make_fused_inputs(
+            sq, b, np_, hn, n_comp, win_topk, idx_nh, idx_hd,
+            indexer_topk, ratio, kv_offset, device,
+        )
+
+        fused_res = self._run_fused_with_grad(inputs, sparse_loss=True)
+        unfused_res = self._run_unfused_with_grad(inputs)
+
+        g_fused = fused_res["grad_attn_sink"].float()
+        g_unfused = unfused_res["grad_attn_sink"].float()
+
+        abs_diff = (g_fused - g_unfused).abs()
+        max_diff = abs_diff.max().item()
+        mean_diff = abs_diff.mean().item()
+
+        # attn_sink is a small vector (np,), use relative tolerance
+        cos_sim = torch.nn.functional.cosine_similarity(
+            g_fused.reshape(-1).unsqueeze(0),
+            g_unfused.reshape(-1).unsqueeze(0),
+        ).item()
+
+        assert cos_sim > 0.90, (
+            f"grad_attn_sink cosine similarity too low: {cos_sim:.6f} "
+            f"(max_diff={max_diff:.4e}, mean_diff={mean_diff:.4e})"
+        )
+        print(
+            f"\n  grad_attn_sink: cos_sim={cos_sim:.6f}, "
+            f"max_diff={max_diff:.4e}, mean_diff={mean_diff:.4e}"
+        )
+
+    @pytest.mark.parametrize(
+        "sq,b,np_,hn,n_comp,win_topk,idx_nh,idx_hd,indexer_topk,ratio",
+        [
+            (32, 1, 4, 128, 16, 8, 2, 64, 8, 4),
+            (64, 2, 4, 128, 64, 32, 2, 64, 32, 4),
+        ],
+        ids=["small", "medium"],
+    )
+    def test_backward_no_nan_inf(
+        self, sq, b, np_, hn, n_comp, win_topk, idx_nh, idx_hd,
+        indexer_topk, ratio, device,
+    ):
+        """Ensure backward pass produces no NaN or Inf in any gradient."""
+        kv_offset = sq
+        inputs = _make_fused_inputs(
+            sq, b, np_, hn, n_comp, win_topk, idx_nh, idx_hd,
+            indexer_topk, ratio, kv_offset, device,
+        )
+
+        fused_res = self._run_fused_with_grad(inputs, sparse_loss=True)
+
+        for name in ("grad_query", "grad_kv_full", "grad_attn_sink"):
+            g = fused_res[name]
+            assert not torch.isnan(g).any(), f"{name} contains NaN"
+            assert not torch.isinf(g).any(), f"{name} contains Inf"
+
+
+# ---------------------------------------------------------------------------
+# Performance tests
+# ---------------------------------------------------------------------------
+
+
+class TestFusedIndexerSparseAttnPerformance:
+    """Performance benchmarks: Fused Triton path vs unfused PyTorch CSA path.
+
+    Measures:
+    - Forward time for both paths
+    - Speedup from fused operation
+    - Reports per-shape timing
+    """
+
+    @pytest.fixture
+    def device(self):
+        return torch.device("cuda:0")
+
+    @staticmethod
+    def _benchmark(fn, warmup: int = 10, iters: int = 50) -> float:
+        """Benchmark a CUDA function. Returns median elapsed ms."""
+        for _ in range(warmup):
+            fn()
+        torch.cuda.synchronize()
+
+        times = []
+        for _ in range(iters):
+            torch.cuda.synchronize()
+            t0 = time.perf_counter()
+            fn()
+            torch.cuda.synchronize()
+            t1 = time.perf_counter()
+            times.append((t1 - t0) * 1000)
+
+        times.sort()
+        return times[len(times) // 2]
+
+    @pytest.mark.parametrize(
+        "sq,b,np_,hn,n_comp,win_topk,idx_nh,idx_hd,indexer_topk,ratio",
+        [
+            # Production-scale shapes with large topk
+            (512, 1, 16, 128, 128, 64, 4, 64, 64, 4),
+            (512, 2, 16, 128, 256, 64, 4, 64, 128, 4),
+            (1024, 1, 16, 128, 256, 128, 4, 64, 128, 4),
+            (1024, 1, 16, 128, 512, 128, 4, 64, 256, 4),
+            (2048, 1, 8, 128, 512, 128, 4, 64, 256, 4),
+            (2048, 1, 8, 128, 512, 128, 4, 64, 512, 4),
+        ],
+        ids=[
+            "sq512_b1_topk64",
+            "sq512_b2_topk128",
+            "sq1024_b1_topk128",
+            "sq1024_b1_topk256",
+            "sq2048_b1_topk256",
+            "sq2048_b1_topk512",
+        ],
+    )
+    @pytest.mark.parametrize("sparse_loss", [True, False], ids=["sparse", "dense"])
+    def test_performance_forward(
+        self, sq, b, np_, hn, n_comp, win_topk, idx_nh, idx_hd,
+        indexer_topk, ratio, sparse_loss, device,
+    ):
+        """Measure forward performance: fused Triton vs unfused CSA + indexer loss."""
+        kv_offset = sq
+        inputs = _make_fused_inputs(
+            sq, b, np_, hn, n_comp, win_topk, idx_nh, idx_hd,
+            indexer_topk, ratio, kv_offset, device,
+        )
+
+        # Fused path benchmark (attention + indexer loss in one call)
+        time_fused = self._benchmark(
+            lambda: _run_fused(inputs, sparse_loss=sparse_loss)
+        )
+
+        # Unfused path benchmark: attention + indexer loss separately (fair comparison)
+        # Pre-compute indices (not timed — same for both paths)
+        with torch.no_grad():
+            q_idx_bshd, k_idx_bsd, _, w_bsh_scaled = _sbhd_to_bshd_indexer_inputs(
+                inputs["q_indexer"], inputs["k_indexer"],
+                inputs["weights"], inputs["indexer_softmax_scale"]
+            )
+            effective_topk = min(inputs["indexer_topk"], n_comp)
+            topk_indices_cmp, _, _ = _indexer_topk_bshd(
+                q_idx_bshd, k_idx_bsd, w_bsh_scaled, effective_topk, ratio
+            )
+            topk_indices_global = topk_indices_cmp.clone()
+            valid_cmp = topk_indices_global >= 0
+            topk_indices_global[valid_cmp] += kv_offset
+            combined_idxs = torch.cat(
+                [topk_indices_global, inputs["window_idxs"]], dim=-1
+            )
+
+        d = hn
+        idx_nh_val = inputs["q_indexer"].shape[2]
+
+        def run_unfused_forward_with_loss():
+            # 1. Unfused sparse attention forward
+            out = unfused_compressed_sparse_attn(
+                inputs["query"], inputs["kv_full"], inputs["attn_sink"],
+                combined_idxs, inputs["softmax_scale"],
+            )
+
+            # 2. Compute LSE (needed for indexer loss target)
+            kv_t = inputs["kv_full"].permute(1, 0, 2)  # (b, n_kv, hn)
+            safe_idx = combined_idxs.clamp(min=0).long()
+            safe_idx_exp = safe_idx.unsqueeze(-1).expand(-1, -1, -1, hn)
+            kv_g = torch.gather(
+                kv_t.unsqueeze(1).expand(-1, sq, -1, -1), dim=2, index=safe_idx_exp
+            ).float()
+            q_perm = inputs["query"].permute(1, 2, 0, 3).float()  # (b, np, sq, hn)
+            scores = torch.einsum("bnsh,bskh->bnsk", q_perm, kv_g) * inputs["softmax_scale"]
+            invalid_mask = (combined_idxs < 0).unsqueeze(1)
+            scores = scores.masked_fill(invalid_mask, float("-inf"))
+            sink_val = inputs["attn_sink"].view(1, np_, 1, 1).float()
+            scores_max = torch.max(scores.max(dim=-1, keepdim=True).values, sink_val)
+            exp_scores = torch.exp(scores - scores_max)
+            exp_sink_val = torch.exp(sink_val - scores_max)
+            sum_exp = exp_scores.sum(dim=-1, keepdim=True) + exp_sink_val
+            lse_full = (scores_max + torch.log(sum_exp)).squeeze(-1)  # (b, np, sq)
+            lse_bsh = lse_full.permute(0, 2, 1).contiguous()  # (b, sq, np)
+
+            # 3. Indexer loss computation
+            qi_bshd = inputs["q_indexer"].permute(1, 0, 2, 3).contiguous()
+            ki_bsd = inputs["k_indexer"].permute(1, 0, 2).contiguous()
+            w_raw = inputs["weights"].permute(1, 0, 2).contiguous()
+            w_scaled = w_raw * inputs["indexer_softmax_scale"]
+
+            if sparse_loss:
+                # Partial LSE over compressed indices only
+                safe_cmp_global = topk_indices_cmp.clone()
+                valid_m = safe_cmp_global >= 0
+                safe_cmp_global[valid_m] += kv_offset
+                safe_cmp_idx = safe_cmp_global.clamp(min=0).long()
+                safe_cmp_idx_exp = safe_cmp_idx.unsqueeze(-1).expand(-1, -1, -1, hn)
+                kv_cmp = torch.gather(
+                    kv_t.unsqueeze(1).expand(-1, sq, -1, -1), dim=2, index=safe_cmp_idx_exp
+                ).float()
+                scores_cmp = torch.einsum("bnsh,bskh->bnsk", q_perm, kv_cmp) * inputs["softmax_scale"]
+                inv_cmp_mask = (~valid_m).unsqueeze(1)
+                scores_cmp = scores_cmp.masked_fill(inv_cmp_mask, float("-inf"))
+                sc_max = torch.max(scores_cmp.max(dim=-1, keepdim=True).values, sink_val)
+                ec = torch.exp(scores_cmp - sc_max)
+                es = torch.exp(sink_val - sc_max)
+                se = ec.sum(dim=-1, keepdim=True) + es
+                lse_indexer_bsh = (sc_max + torch.log(se)).squeeze(-1).permute(0, 2, 1).contiguous()
+
+                predict_result = sparse_indexer_score_recompute(
+                    qi_bshd, ki_bsd, w_scaled, topk_indices_cmp,
+                    qhead_per_kv_head=idx_nh_val,
+                )
+                q_attn_bshd = inputs["query"].permute(1, 0, 2, 3).contiguous()
+                k_attn_bsd = inputs["kv_full"][:, :, :d].permute(1, 0, 2).contiguous()
+                target_result = sparse_attn_score_recompute(
+                    q_attn_bshd, k_attn_bsd, lse_indexer_bsh,
+                    topk_indices_cmp + kv_offset,
+                    inputs["softmax_scale"], qhead_per_kv_head=np_,
+                )
+                _loss = _kl_loss_from_target_predict(
+                    target_result["target"], predict_result["predict"],
+                    topk_indices_cmp, 0.1, False,
+                )
+            else:
+                q_attn_bshd = inputs["query"].permute(1, 0, 2, 3).contiguous()
+                k_attn_bsd = inputs["kv_full"][kv_offset:kv_offset + n_comp, :, :d].permute(1, 0, 2).contiguous()
+                dense_idx_result = dense_indexer_score_recompute(
+                    qi_bshd, ki_bsd, w_scaled,
+                    qhead_per_kv_head=idx_nh_val,
+                    sm_scale=inputs["indexer_softmax_scale"],
+                    ratio=ratio,
+                )
+                dense_attn_result = dense_attn_score_recompute(
+                    q_attn_bshd, k_attn_bsd, lse_bsh,
+                    qhead_per_kv_head=np_,
+                    softmax_scale=inputs["softmax_scale"],
+                    ratio=ratio,
+                )
+                _loss = _kl_loss_from_dense_scores(
+                    dense_attn_result["out"], dense_attn_result["denom"],
+                    dense_idx_result["out"], dense_idx_result["denom"],
+                    topk_indices_cmp, 0.1, False,
+                )
+            return out, _loss
+
+        time_unfused = self._benchmark(run_unfused_forward_with_loss)
+
+        speedup = time_unfused / max(time_fused, 1e-6)
+
+        print(
+            f"\n  [sq={sq}, b={b}, np={np_}, topk={indexer_topk}, "
+            f"win={win_topk}, sparse_loss={sparse_loss}]"
+        )
+        print(f"    Fused (Triton):  {time_fused:.3f} ms")
+        print(f"    Unfused (CSA):   {time_unfused:.3f} ms")
+        print(f"    Speedup:         {speedup:.2f}x")
+
+        # The fused path should not be catastrophically slower
+        # (it may be slower at very small shapes due to kernel launch overhead)
+        assert speedup > 0.3, (
+            f"Fused path is too slow compared to unfused: {speedup:.2f}x"
+        )
+
+    @pytest.mark.parametrize(
+        "sq,b,np_,hn,n_comp,win_topk,idx_nh,idx_hd,indexer_topk,ratio",
+        [
+            (512, 1, 16, 128, 128, 64, 4, 64, 64, 4),
+            (1024, 1, 16, 128, 256, 128, 4, 64, 128, 4),
+            (2048, 1, 8, 128, 512, 128, 4, 64, 256, 4),
+        ],
+        ids=[
+            "sq512_topk64",
+            "sq1024_topk128",
+            "sq2048_topk256",
+        ],
+    )
+    def test_performance_backward(
+        self, sq, b, np_, hn, n_comp, win_topk, idx_nh, idx_hd,
+        indexer_topk, ratio, device,
+    ):
+        """Measure backward pass performance for the fused path."""
+        kv_offset = sq
+        inputs = _make_fused_inputs(
+            sq, b, np_, hn, n_comp, win_topk, idx_nh, idx_hd,
+            indexer_topk, ratio, kv_offset, device,
+        )
+
+        # Make inputs require grad for backward
+        query = inputs["query"].clone().requires_grad_(True)
+        kv_full = inputs["kv_full"].clone().requires_grad_(True)
+
+        def run_fwd_bwd():
+            out, loss = fused_indexer_sparse_attn(
+                query, kv_full, inputs["attn_sink"], inputs["window_idxs"],
+                inputs["q_indexer"], inputs["k_indexer"], inputs["weights"],
+                inputs["indexer_topk"], inputs["ratio"],
+                inputs["softmax_scale"], inputs["indexer_softmax_scale"],
+                0.1, True, inputs["kv_offset"], False,
+            )
+            total = out.float().sum() + loss
+            total.backward()
+            # Zero grads for next iteration
+            query.grad = None
+            kv_full.grad = None
+
+        time_bwd = self._benchmark(run_fwd_bwd, warmup=5, iters=20)
+
+        print(
+            f"\n  [sq={sq}, b={b}, np={np_}, topk={indexer_topk}, win={win_topk}]"
+        )
+        print(f"    Fwd+Bwd (Triton): {time_bwd:.3f} ms")
+
+    @pytest.mark.parametrize(
+        "sq,b,np_,hn,n_comp,win_topk,idx_nh,idx_hd,indexer_topk,ratio",
+        [
+            (1024, 1, 16, 128, 256, 128, 4, 64, 128, 4),
+        ],
+    )
+    def test_peak_memory(
+        self, sq, b, np_, hn, n_comp, win_topk, idx_nh, idx_hd,
+        indexer_topk, ratio, device,
+    ):
+        """Measure peak GPU memory usage for fused vs unfused paths."""
+        kv_offset = sq
+        inputs = _make_fused_inputs(
+            sq, b, np_, hn, n_comp, win_topk, idx_nh, idx_hd,
+            indexer_topk, ratio, kv_offset, device,
+        )
+
+        # Measure fused path memory
+        torch.cuda.reset_peak_memory_stats(device)
+        torch.cuda.synchronize()
+        mem_before = torch.cuda.memory_allocated(device)
+        _run_fused(inputs, sparse_loss=True)
+        torch.cuda.synchronize()
+        mem_fused_peak = torch.cuda.max_memory_allocated(device) - mem_before
+
+        # Clear
+        torch.cuda.empty_cache()
+        torch.cuda.reset_peak_memory_stats(device)
+        torch.cuda.synchronize()
+        mem_before = torch.cuda.memory_allocated(device)
+        _run_unfused_with_same_indices(inputs)
+        torch.cuda.synchronize()
+        mem_unfused_peak = torch.cuda.max_memory_allocated(device) - mem_before
+
+        print(
+            f"\n  [sq={sq}, b={b}, np={np_}, topk={indexer_topk}]"
+        )
+        print(f"    Fused peak memory:   {mem_fused_peak / 1024**2:.1f} MB")
+        print(f"    Unfused peak memory: {mem_unfused_peak / 1024**2:.1f} MB")
+
+    @pytest.mark.parametrize(
+        "sq,b,np_,hn,n_comp,win_topk,idx_nh,idx_hd,indexer_topk,ratio",
+        [
+            (512, 1, 16, 128, 128, 64, 4, 64, 64, 4),
+            (512, 2, 16, 128, 256, 64, 4, 64, 128, 4),
+            (1024, 1, 16, 128, 256, 128, 4, 64, 128, 4),
+            (2048, 1, 8, 128, 512, 128, 4, 64, 256, 4),
+        ],
+        ids=[
+            "sq512_b1_topk64",
+            "sq512_b2_topk128",
+            "sq1024_b1_topk128",
+            "sq2048_b1_topk256",
+        ],
+    )
+    @pytest.mark.parametrize("sparse_loss", [True, False], ids=["sparse", "dense"])
+    def test_performance_end_to_end(
+        self, sq, b, np_, hn, n_comp, win_topk, idx_nh, idx_hd,
+        indexer_topk, ratio, sparse_loss, device,
+    ):
+        """End-to-end (forward + backward) performance: fused Triton vs unfused CSA."""
+        kv_offset = sq
+        inputs = _make_fused_inputs(
+            sq, b, np_, hn, n_comp, win_topk, idx_nh, idx_hd,
+            indexer_topk, ratio, kv_offset, device,
+        )
+
+        # --- Fused path (forward + backward) ---
+        fused_query = inputs["query"].clone().requires_grad_(True)
+        fused_kv = inputs["kv_full"].clone().requires_grad_(True)
+        fused_sink = inputs["attn_sink"].clone().requires_grad_(True)
+
+        def run_fused_e2e():
+            out, loss = fused_indexer_sparse_attn(
+                fused_query, fused_kv, fused_sink, inputs["window_idxs"],
+                inputs["q_indexer"], inputs["k_indexer"], inputs["weights"],
+                inputs["indexer_topk"], inputs["ratio"],
+                inputs["softmax_scale"], inputs["indexer_softmax_scale"],
+                0.1, sparse_loss, inputs["kv_offset"], False,
+            )
+            total = out.float().sum() + loss
+            total.backward()
+            fused_query.grad = None
+            fused_kv.grad = None
+            fused_sink.grad = None
+
+        # --- Unfused path (forward + backward + indexer loss) ---
+        # Fair comparison: unfused path also computes indexer loss (score_recompute
+        # + KL divergence) and backpropagates through indexer parameters.
+        unfused_query = inputs["query"].clone().requires_grad_(True)
+        unfused_kv = inputs["kv_full"].clone().requires_grad_(True)
+        unfused_sink = inputs["attn_sink"].clone().requires_grad_(True)
+        unfused_q_indexer = inputs["q_indexer"].clone().requires_grad_(True)
+        unfused_k_indexer = inputs["k_indexer"].clone().requires_grad_(True)
+        unfused_weights = inputs["weights"].clone().requires_grad_(True)
+
+        # Pre-compute indices (same as fused path would — not timed)
+        with torch.no_grad():
+            q_idx_bshd, k_idx_bsd, _, w_bsh_scaled = _sbhd_to_bshd_indexer_inputs(
+                inputs["q_indexer"], inputs["k_indexer"],
+                inputs["weights"], inputs["indexer_softmax_scale"]
+            )
+            effective_topk = min(inputs["indexer_topk"], inputs["n_comp"])
+            topk_indices_cmp, _, _ = _indexer_topk_bshd(
+                q_idx_bshd, k_idx_bsd, w_bsh_scaled, effective_topk, inputs["ratio"]
+            )
+            topk_indices_global = topk_indices_cmp.clone()
+            valid_cmp = topk_indices_global >= 0
+            topk_indices_global[valid_cmp] += kv_offset
+            combined_idxs = torch.cat(
+                [topk_indices_global, inputs["window_idxs"]], dim=-1
+            )
+
+        n_comp = inputs["n_comp"]
+        idx_nh = inputs["q_indexer"].shape[2]
+        np_ = inputs["np"]
+        d = inputs["hn"]
+        loss_coeff = 0.1
+
+        def run_unfused_e2e():
+            # 1. Unfused sparse attention (forward + backward)
+            out = unfused_compressed_sparse_attn(
+                unfused_query, unfused_kv, unfused_sink,
+                combined_idxs, inputs["softmax_scale"],
+            )
+
+            # 2. Indexer loss computation (mirrors fused path step 6)
+            # Transpose indexer inputs for score_recompute
+            qi_bshd = unfused_q_indexer.permute(1, 0, 2, 3).contiguous()
+            ki_bsd = unfused_k_indexer.permute(1, 0, 2).contiguous()
+            w_raw = unfused_weights.permute(1, 0, 2).contiguous()
+            w_scaled = w_raw * inputs["indexer_softmax_scale"]
+
+            if sparse_loss:
+                # Sparse indexer loss needs LSE from attention forward.
+                # Recompute LSE inline from scores (same as unfused_compressed_sparse_attn).
+                sq_val, _, np_val, hn_val = unfused_query.shape
+                kv_t = unfused_kv.permute(1, 0, 2)  # (b, n_kv, hn)
+                safe_idx = combined_idxs.clamp(min=0).long()
+                safe_idx_exp = safe_idx.unsqueeze(-1).expand(-1, -1, -1, hn_val)
+                kv_g = torch.gather(
+                    kv_t.unsqueeze(1).expand(-1, sq_val, -1, -1), dim=2, index=safe_idx_exp
+                ).float()
+                q_perm = unfused_query.permute(1, 2, 0, 3).float()  # (b, np, sq, hn)
+                scores = torch.einsum("bnsh,bskh->bnsk", q_perm, kv_g) * inputs["softmax_scale"]
+                invalid_mask = (combined_idxs < 0).unsqueeze(1)
+                scores = scores.masked_fill(invalid_mask, float("-inf"))
+                sink_val = unfused_sink.view(1, np_val, 1, 1).float()
+                scores_max = torch.max(scores.max(dim=-1, keepdim=True).values, sink_val)
+                exp_scores = torch.exp(scores - scores_max)
+                exp_sink = torch.exp(sink_val - scores_max)
+                sum_exp = exp_scores.sum(dim=-1, keepdim=True) + exp_sink
+                # lse: (b, np, sq, 1) -> (b, sq, np)
+                lse_full = (scores_max + torch.log(sum_exp)).squeeze(-1)  # (b, np, sq)
+                lse_bsh = lse_full.permute(0, 2, 1).contiguous()  # (b, sq, np)
+
+                # Only need LSE from first effective_topk positions (indexer subset)
+                # Recompute with only compressed indices for the partial LSE
+                safe_cmp_global = (topk_indices_cmp.clone())
+                valid_cmp_mask = safe_cmp_global >= 0
+                safe_cmp_global[valid_cmp_mask] += kv_offset
+                safe_cmp_idx = safe_cmp_global.clamp(min=0).long()
+                safe_cmp_idx_exp = safe_cmp_idx.unsqueeze(-1).expand(-1, -1, -1, hn_val)
+                kv_cmp = torch.gather(
+                    kv_t.unsqueeze(1).expand(-1, sq_val, -1, -1), dim=2, index=safe_cmp_idx_exp
+                ).float()
+                scores_cmp = torch.einsum("bnsh,bskh->bnsk", q_perm, kv_cmp) * inputs["softmax_scale"]
+                invalid_cmp_mask = (~valid_cmp_mask).unsqueeze(1)
+                scores_cmp = scores_cmp.masked_fill(invalid_cmp_mask, float("-inf"))
+                scores_cmp_max = torch.max(scores_cmp.max(dim=-1, keepdim=True).values, sink_val)
+                exp_cmp = torch.exp(scores_cmp - scores_cmp_max)
+                exp_sink_cmp = torch.exp(sink_val - scores_cmp_max)
+                sum_exp_cmp = exp_cmp.sum(dim=-1, keepdim=True) + exp_sink_cmp
+                lse_cmp = (scores_cmp_max + torch.log(sum_exp_cmp)).squeeze(-1)
+                lse_indexer_bsh = lse_cmp.permute(0, 2, 1).contiguous()  # (b, sq, np)
+
+                predict_result = sparse_indexer_score_recompute(
+                    qi_bshd, ki_bsd, w_scaled, topk_indices_cmp,
+                    qhead_per_kv_head=idx_nh,
+                )
+                predict = predict_result["predict"]
+
+                q_attn_bshd = unfused_query.permute(1, 0, 2, 3).contiguous()
+                k_attn_bsd = unfused_kv[:, :, :d].permute(1, 0, 2).contiguous()
+
+                target_result = sparse_attn_score_recompute(
+                    q_attn_bshd, k_attn_bsd, lse_indexer_bsh,
+                    topk_indices_cmp + kv_offset,
+                    inputs["softmax_scale"], qhead_per_kv_head=np_,
+                )
+                target = target_result["target"]
+
+                indexer_loss = _kl_loss_from_target_predict(
+                    target, predict, topk_indices_cmp, loss_coeff, False
+                )
+            else:
+                # Dense indexer loss
+                q_attn_bshd = unfused_query.permute(1, 0, 2, 3).contiguous()
+                k_attn_bsd = unfused_kv[kv_offset:kv_offset + n_comp, :, :d].permute(1, 0, 2).contiguous()
+
+                # Need full LSE for dense path
+                sq_val, _, np_val, hn_val = unfused_query.shape
+                kv_t = unfused_kv.permute(1, 0, 2)
+                safe_idx = combined_idxs.clamp(min=0).long()
+                safe_idx_exp = safe_idx.unsqueeze(-1).expand(-1, -1, -1, hn_val)
+                kv_g = torch.gather(
+                    kv_t.unsqueeze(1).expand(-1, sq_val, -1, -1), dim=2, index=safe_idx_exp
+                ).float()
+                q_perm = unfused_query.permute(1, 2, 0, 3).float()
+                scores = torch.einsum("bnsh,bskh->bnsk", q_perm, kv_g) * inputs["softmax_scale"]
+                invalid_mask = (combined_idxs < 0).unsqueeze(1)
+                scores = scores.masked_fill(invalid_mask, float("-inf"))
+                sink_val = unfused_sink.view(1, np_val, 1, 1).float()
+                scores_max = torch.max(scores.max(dim=-1, keepdim=True).values, sink_val)
+                exp_scores = torch.exp(scores - scores_max)
+                exp_sink = torch.exp(sink_val - scores_max)
+                sum_exp = exp_scores.sum(dim=-1, keepdim=True) + exp_sink
+                lse_full = (scores_max + torch.log(sum_exp)).squeeze(-1)  # (b, np, sq)
+                lse_bsh = lse_full.permute(0, 2, 1).contiguous()  # (b, sq, np)
+
+                dense_idx_result = dense_indexer_score_recompute(
+                    qi_bshd, ki_bsd, w_scaled,
+                    qhead_per_kv_head=idx_nh,
+                    sm_scale=inputs["indexer_softmax_scale"],
+                    ratio=inputs["ratio"],
+                )
+                index_score = dense_idx_result["out"]
+                index_lse = dense_idx_result["denom"]
+
+                dense_attn_result = dense_attn_score_recompute(
+                    q_attn_bshd, k_attn_bsd, lse_bsh,
+                    qhead_per_kv_head=np_,
+                    softmax_scale=inputs["softmax_scale"],
+                    ratio=inputs["ratio"],
+                )
+                attn_score = dense_attn_result["out"]
+                attn_l1norm = dense_attn_result["denom"]
+
+                indexer_loss = _kl_loss_from_dense_scores(
+                    attn_score, attn_l1norm, index_score, index_lse,
+                    topk_indices_cmp, loss_coeff, False,
+                )
+
+            # 3. Combined backward
+            total = out.float().sum() + indexer_loss
+            total.backward()
+            unfused_query.grad = None
+            unfused_kv.grad = None
+            unfused_sink.grad = None
+            unfused_q_indexer.grad = None
+            unfused_k_indexer.grad = None
+            unfused_weights.grad = None
+
+        time_fused = self._benchmark(run_fused_e2e, warmup=5, iters=20)
+        time_unfused = self._benchmark(run_unfused_e2e, warmup=5, iters=20)
+        speedup = time_unfused / max(time_fused, 1e-6)
+
+        print(
+            f"\n  [sq={sq}, b={b}, np={np_}, topk={indexer_topk}, "
+            f"win={win_topk}, sparse_loss={sparse_loss}]"
+        )
+        print(f"    Fused E2E (Triton):  {time_fused:.3f} ms")
+        print(f"    Unfused E2E (CSA):   {time_unfused:.3f} ms")
+        print(f"    E2E Speedup:         {speedup:.2f}x")
+
+
+# ---------------------------------------------------------------------------
+# Module-level tests: CompressedSparseAttention unfused vs fused (triton)
+# ---------------------------------------------------------------------------
+
+from unittest.mock import patch
+
+from megatron.core.transformer.experimental_attention_variant.csa import (
+    CompressedSparseAttention,
+    CompressedSparseAttentionSubmodules,
+    Compressor,
+    CompressorSubmodules,
+    CSAIndexer,
+    CSAIndexerSubmodules,
+)
+from megatron.core.transformer.transformer_config import MLATransformerConfig
+from tests.unit_tests.test_utilities import Utils
+
+try:
+    from fast_hadamard_transform import hadamard_transform as _hadamard_transform
+
+    _HAVE_HADAMARD = True
+except ImportError:
+    _HAVE_HADAMARD = False
+
+
+def _mock_hadamard_transform(x: torch.Tensor, scale: float = 1.0) -> torch.Tensor:
+    return x * scale
+
+
+def _make_test_mla_config(
+    num_attention_heads=8,
+    v_head_dim=128,
+    hidden_size=256,
+    csa_window_size=64,
+    dsa_indexer_topk=64,
+    dsa_indexer_n_heads=4,
+    dsa_indexer_head_dim=64,
+    dsa_indexer_loss_coeff=0.1,
+    dsa_indexer_use_sparse_loss=True,
+):
+    """Helper to create MLATransformerConfig for module-level CSA tests."""
+    qk_pos_emb_head_dim = 32
+    return MLATransformerConfig(
+        num_layers=4,
+        hidden_size=hidden_size,
+        num_attention_heads=num_attention_heads,
+        use_cpu_initialization=True,
+        bf16=True,
+        params_dtype=torch.bfloat16,
+        tensor_model_parallel_size=1,
+        sequence_parallel=False,
+        q_lora_rank=64,
+        kv_lora_rank=64,
+        qk_head_dim=v_head_dim - qk_pos_emb_head_dim,
+        qk_pos_emb_head_dim=qk_pos_emb_head_dim,
+        v_head_dim=v_head_dim,
+        rope_type='rope',
+        rotary_base=10000,
+        rotary_percent=1.0,
+        multi_latent_attention=True,
+        experimental_attention_variant='dsv4_hybrid',
+        csa_compress_ratios=[4, 4, 4, 4],
+        csa_window_size=csa_window_size,
+        csa_dense_mode=False,
+        dsa_indexer_n_heads=dsa_indexer_n_heads,
+        dsa_indexer_head_dim=dsa_indexer_head_dim,
+        dsa_indexer_topk=dsa_indexer_topk,
+        dsa_indexer_loss_coeff=dsa_indexer_loss_coeff,
+        dsa_indexer_use_sparse_loss=dsa_indexer_use_sparse_loss,
+    )
+
+
+def _make_test_compressor_submodules():
+    from megatron.core.extensions.transformer_engine import TELinear, TENorm
+    from megatron.core.transformer.spec_utils import ModuleSpec
+
+    return CompressorSubmodules(
+        linear_wkv=ModuleSpec(module=TELinear),
+        linear_wgate=ModuleSpec(module=TELinear),
+        norm=ModuleSpec(module=TENorm),
+    )
+
+
+def _make_test_csa_indexer_submodules():
+    from megatron.core.extensions.transformer_engine import TELinear
+    from megatron.core.transformer.spec_utils import ModuleSpec
+
+    return CSAIndexerSubmodules(
+        linear_wq_b=ModuleSpec(module=TELinear),
+        linear_weights_proj=ModuleSpec(module=TELinear),
+        compressor=ModuleSpec(module=Compressor, submodules=_make_test_compressor_submodules()),
+    )
+
+
+def _make_test_csa_submodules():
+    from megatron.core.transformer.spec_utils import ModuleSpec
+
+    return CompressedSparseAttentionSubmodules(
+        compressor=ModuleSpec(module=Compressor, submodules=_make_test_compressor_submodules()),
+        indexer=ModuleSpec(module=CSAIndexer, submodules=_make_test_csa_indexer_submodules()),
+    )
+
+
+def _build_csa_module(config, compress_ratio=4):
+    """Build a CompressedSparseAttention module ready for testing."""
+    from megatron.core.models.common.embeddings import RotaryEmbedding
+    from megatron.core.process_groups_config import ProcessGroupCollection
+    from megatron.core.transformer.enums import AttnMaskType
+
+    pg_collection = ProcessGroupCollection.use_mpu_process_groups(required_pgs=['tp', 'cp'])
+    rotary_pos_emb = RotaryEmbedding(
+        config.qk_pos_emb_head_dim,
+        rotary_percent=config.rotary_percent,
+        rotary_base=config.rotary_base,
+        cp_group=pg_collection.cp,
+    )
+    csa = CompressedSparseAttention(
+        config=config,
+        submodules=_make_test_csa_submodules(),
+        layer_number=1,
+        attn_mask_type=AttnMaskType.causal,
+        attention_type='self',
+        pg_collection=pg_collection,
+        rotary_pos_emb=rotary_pos_emb,
+        compress_ratio=compress_ratio,
+    ).cuda()
+    return csa
+
+
+def _make_csa_inputs(sq, b, config, device="cuda"):
+    """Generate inputs matching CompressedSparseAttention.forward signature."""
+    np_ = config.num_attention_heads
+    hn = config.v_head_dim
+
+    query = torch.randn(sq, b, np_, hn, dtype=torch.bfloat16, device=device)
+    key = torch.randn(sq, b, 1, hn, dtype=torch.bfloat16, device=device)
+    x = torch.randn(sq, b, config.hidden_size, dtype=torch.bfloat16, device=device)
+    qr = torch.randn(sq, b, config.q_lora_rank, dtype=torch.bfloat16, device=device)
+
+    return {"query": query, "key": key, "value": key.clone(), "x": x, "qr": qr}
+
+
+# Patch target for fused_indexer_sparse_attn in the csa module
+_PATCH_TARGET = (
+    'megatron.core.transformer.experimental_attention_variant.csa.fused_indexer_sparse_attn'
+)
+
+# Reuse the already-imported triton fused_indexer_sparse_attn
+_triton_fused_indexer_sparse_attn = fused_indexer_sparse_attn
+
+
+def _hadamard_patches():
+    """Context manager patches for hadamard transform if not installed."""
+    if _HAVE_HADAMARD:
+        from contextlib import nullcontext
+        return nullcontext()
+    else:
+        from contextlib import ExitStack
+        stack = ExitStack()
+        # Enter patches immediately; ExitStack.__enter__ returns self and
+        # __exit__ will undo all entered contexts.
+        stack.enter_context(patch(
+            'megatron.core.transformer.experimental_attention_variant.dsa.hadamard_transform',
+            _mock_hadamard_transform,
+        ))
+        stack.enter_context(patch(
+            'megatron.core.transformer.experimental_attention_variant.csa.rotate_activation',
+            lambda x: x * (x.size(-1) ** -0.5),
+        ))
+        return stack
+
+
+class TestCSAFusedVsUnfusedAccuracy:
+    """Module-level accuracy: CompressedSparseAttention unfused path vs fused (triton).
+
+    Instantiates the full CSA module and switches between _forward_unfused_csa
+    and _forward_fused_indexer_training (with triton plugin intercepting the call).
+    """
+
+    @pytest.fixture(scope='class', autouse=True)
+    def setup_class(self, request):
+        Utils.initialize_model_parallel(
+            tensor_model_parallel_size=1, pipeline_model_parallel_size=1
+        )
+        yield
+        Utils.destroy_model_parallel()
+
+    @pytest.fixture
+    def device(self):
+        return torch.device("cuda:0")
+
+    @pytest.mark.parametrize(
+        "sq,b,num_heads,v_head_dim,window_size,indexer_topk",
+        [
+            (64, 1, 8, 128, 16, 16),
+            (128, 1, 8, 128, 32, 32),
+            (256, 2, 8, 128, 64, 64),
+        ],
+        ids=["sq64_topk16", "sq128_topk32", "sq256_topk64"],
+    )
+    @pytest.mark.parametrize("sparse_loss", [True, False], ids=["sparse", "dense"])
+    def test_output_accuracy(
+        self, sq, b, num_heads, v_head_dim, window_size, indexer_topk,
+        sparse_loss, device,
+    ):
+        """Fused (triton) output matches unfused CSA path at module level."""
+        with _hadamard_patches():
+            config = _make_test_mla_config(
+                num_attention_heads=num_heads,
+                v_head_dim=v_head_dim,
+                csa_window_size=window_size,
+                dsa_indexer_topk=indexer_topk,
+                dsa_indexer_loss_coeff=0.1,
+                dsa_indexer_use_sparse_loss=sparse_loss,
+            )
+
+            torch.manual_seed(42)
+            csa = _build_csa_module(config, compress_ratio=4)
+            csa.train()
+
+            inputs = _make_csa_inputs(sq, b, config, device)
+
+            # --- Unfused path ---
+            csa.apply_dsa_kernel_fusion = False
+            torch.manual_seed(7)
+            out_unfused = csa(
+                query=inputs["query"].clone(),
+                key=inputs["key"].clone(),
+                value=inputs["value"].clone(),
+                attention_mask=None,
+                x=inputs["x"].clone(),
+                qr=inputs["qr"].clone(),
+            )
+
+            # --- Fused path (triton) ---
+            csa.apply_dsa_kernel_fusion = True
+            with patch(_PATCH_TARGET, _triton_fused_indexer_sparse_attn):
+                torch.manual_seed(7)
+                out_fused = csa(
+                    query=inputs["query"].clone(),
+                    key=inputs["key"].clone(),
+                    value=inputs["value"].clone(),
+                    attention_mask=None,
+                    x=inputs["x"].clone(),
+                    qr=inputs["qr"].clone(),
+                )
+
+            # Compare
+            out_f = out_fused.float()
+            out_u = out_unfused.float()
+
+            cos_sim = torch.nn.functional.cosine_similarity(
+                out_f.reshape(-1).unsqueeze(0),
+                out_u.reshape(-1).unsqueeze(0),
+            ).item()
+
+            abs_diff = (out_f - out_u).abs()
+            max_diff = abs_diff.max().item()
+            mean_diff = abs_diff.mean().item()
+
+            print(
+                f"\n  [sq={sq}, b={b}, np={num_heads}, topk={indexer_topk}, "
+                f"sparse_loss={sparse_loss}]"
+            )
+            print(f"    cos_sim={cos_sim:.6f}, max_diff={max_diff:.4e}, mean_diff={mean_diff:.4e}")
+
+            assert cos_sim > 0.95, (
+                f"Module-level output mismatch: cos_sim={cos_sim:.6f}"
+            )
+
+    @pytest.mark.parametrize(
+        "sq,b,num_heads,v_head_dim,window_size,indexer_topk",
+        [
+            (128, 1, 8, 128, 32, 32),
+        ],
+    )
+    @pytest.mark.parametrize("sparse_loss", [True, False], ids=["sparse", "dense"])
+    def test_grad_accuracy(
+        self, sq, b, num_heads, v_head_dim, window_size, indexer_topk,
+        sparse_loss, device,
+    ):
+        """Gradients from fused (triton) path match unfused CSA path."""
+        with _hadamard_patches():
+            config = _make_test_mla_config(
+                num_attention_heads=num_heads,
+                v_head_dim=v_head_dim,
+                csa_window_size=window_size,
+                dsa_indexer_topk=indexer_topk,
+                dsa_indexer_loss_coeff=0.1,
+                dsa_indexer_use_sparse_loss=sparse_loss,
+            )
+
+            torch.manual_seed(42)
+            csa = _build_csa_module(config, compress_ratio=4)
+            csa.train()
+
+            inputs = _make_csa_inputs(sq, b, config, device)
+
+            # --- Unfused path with grad ---
+            csa.apply_dsa_kernel_fusion = False
+            query_u = inputs["query"].clone().requires_grad_(True)
+            key_u = inputs["key"].clone().requires_grad_(True)
+            out_u = csa(
+                query=query_u, key=key_u, value=key_u.clone(),
+                attention_mask=None, x=inputs["x"].clone(), qr=inputs["qr"].clone(),
+            )
+            out_u.sum().backward()
+            grad_q_unfused = query_u.grad.float().clone()
+            grad_k_unfused = key_u.grad.float().clone()
+
+            csa.zero_grad()
+
+            # --- Fused path with grad ---
+            csa.apply_dsa_kernel_fusion = True
+            query_f = inputs["query"].clone().requires_grad_(True)
+            key_f = inputs["key"].clone().requires_grad_(True)
+            with patch(_PATCH_TARGET, _triton_fused_indexer_sparse_attn):
+                out_f = csa(
+                    query=query_f, key=key_f, value=key_f.clone(),
+                    attention_mask=None, x=inputs["x"].clone(), qr=inputs["qr"].clone(),
+                )
+                out_f.sum().backward()
+            grad_q_fused = query_f.grad.float().clone()
+            grad_k_fused = key_f.grad.float().clone()
+
+            # Compare grad_query
+            cos_q = torch.nn.functional.cosine_similarity(
+                grad_q_fused.reshape(-1).unsqueeze(0),
+                grad_q_unfused.reshape(-1).unsqueeze(0),
+            ).item()
+            # Compare grad_key
+            cos_k = torch.nn.functional.cosine_similarity(
+                grad_k_fused.reshape(-1).unsqueeze(0),
+                grad_k_unfused.reshape(-1).unsqueeze(0),
+            ).item()
+
+            print(
+                f"\n  grad_query cos_sim={cos_q:.6f}, "
+                f"grad_key cos_sim={cos_k:.6f}"
+            )
+
+            assert cos_q > 0.90, f"grad_query cos_sim too low: {cos_q:.6f}"
+            assert cos_k > 0.90, f"grad_key cos_sim too low: {cos_k:.6f}"
+
+
+class TestCSAFusedVsUnfusedPerformance:
+    """Module-level performance: CompressedSparseAttention unfused vs fused (triton).
+
+    End-to-end forward+backward timing comparison using the full module pipeline.
+    """
+
+    @pytest.fixture(scope='class', autouse=True)
+    def setup_class(self, request):
+        Utils.initialize_model_parallel(
+            tensor_model_parallel_size=1, pipeline_model_parallel_size=1
+        )
+        yield
+        Utils.destroy_model_parallel()
+
+    @pytest.fixture
+    def device(self):
+        return torch.device("cuda:0")
+
+    @staticmethod
+    def _benchmark(fn, warmup: int = 5, iters: int = 20) -> float:
+        """Benchmark a CUDA function. Returns median elapsed ms."""
+        for _ in range(warmup):
+            fn()
+        torch.cuda.synchronize()
+
+        times = []
+        for _ in range(iters):
+            torch.cuda.synchronize()
+            t0 = time.perf_counter()
+            fn()
+            torch.cuda.synchronize()
+            t1 = time.perf_counter()
+            times.append((t1 - t0) * 1000)
+
+        times.sort()
+        return times[len(times) // 2]
+
+    @pytest.mark.parametrize(
+        "sq,b,num_heads,v_head_dim,window_size,indexer_topk",
+        [
+            (512, 1, 16, 128, 64, 64),
+            (1024, 1, 16, 128, 128, 128),
+            (2048, 1, 8, 128, 128, 256),
+        ],
+        ids=["sq512_topk64", "sq1024_topk128", "sq2048_topk256"],
+    )
+    @pytest.mark.parametrize("sparse_loss", [True, False], ids=["sparse", "dense"])
+    def test_e2e_performance(
+        self, sq, b, num_heads, v_head_dim, window_size, indexer_topk,
+        sparse_loss, device,
+    ):
+        """End-to-end (forward + backward) module-level performance comparison."""
+        with _hadamard_patches():
+            config = _make_test_mla_config(
+                num_attention_heads=num_heads,
+                v_head_dim=v_head_dim,
+                hidden_size=256,
+                csa_window_size=window_size,
+                dsa_indexer_topk=indexer_topk,
+                dsa_indexer_loss_coeff=0.1,
+                dsa_indexer_use_sparse_loss=sparse_loss,
+            )
+
+            torch.manual_seed(42)
+            csa = _build_csa_module(config, compress_ratio=4)
+            csa.train()
+
+            inputs = _make_csa_inputs(sq, b, config, device)
+
+            # --- Unfused benchmark ---
+            csa.apply_dsa_kernel_fusion = False
+            query_u = inputs["query"].clone().requires_grad_(True)
+            key_u = inputs["key"].clone().requires_grad_(True)
+
+            def run_unfused():
+                out = csa(
+                    query=query_u, key=key_u, value=key_u.clone(),
+                    attention_mask=None, x=inputs["x"], qr=inputs["qr"],
+                )
+                out.sum().backward()
+                query_u.grad = None
+                key_u.grad = None
+                csa.zero_grad()
+
+            time_unfused = self._benchmark(run_unfused)
+
+            # --- Fused benchmark (triton) ---
+            csa.apply_dsa_kernel_fusion = True
+            query_f = inputs["query"].clone().requires_grad_(True)
+            key_f = inputs["key"].clone().requires_grad_(True)
+
+            def run_fused():
+                out = csa(
+                    query=query_f, key=key_f, value=key_f.clone(),
+                    attention_mask=None, x=inputs["x"], qr=inputs["qr"],
+                )
+                out.sum().backward()
+                query_f.grad = None
+                key_f.grad = None
+                csa.zero_grad()
+
+            with patch(_PATCH_TARGET, _triton_fused_indexer_sparse_attn):
+                time_fused = self._benchmark(run_fused)
+
+            speedup = time_unfused / max(time_fused, 1e-6)
+
+            print(
+                f"\n  [sq={sq}, b={b}, np={num_heads}, topk={indexer_topk}, "
+                f"win={window_size}, sparse_loss={sparse_loss}]"
+            )
+            print(f"    Unfused CSA E2E:    {time_unfused:.3f} ms")
+            print(f"    Fused Triton E2E:   {time_fused:.3f} ms")
+            print(f"    Speedup:            {speedup:.2f}x")
+
+    @pytest.mark.parametrize(
+        "sq,b,num_heads,v_head_dim,window_size,indexer_topk",
+        [
+            (512, 1, 16, 128, 64, 64),
+            (1024, 1, 16, 128, 128, 128),
+            (2048, 1, 8, 128, 128, 256),
+        ],
+        ids=["sq512_topk64", "sq1024_topk128", "sq2048_topk256"],
+    )
+    @pytest.mark.parametrize("sparse_loss", [True, False], ids=["sparse", "dense"])
+    def test_e2e_memory(
+        self, sq, b, num_heads, v_head_dim, window_size, indexer_topk,
+        sparse_loss, device,
+    ):
+        """Peak GPU memory comparison: fused vs unfused E2E (forward + backward)."""
+        with _hadamard_patches():
+            config = _make_test_mla_config(
+                num_attention_heads=num_heads,
+                v_head_dim=v_head_dim,
+                hidden_size=256,
+                csa_window_size=window_size,
+                dsa_indexer_topk=indexer_topk,
+                dsa_indexer_loss_coeff=0.1,
+                dsa_indexer_use_sparse_loss=sparse_loss,
+            )
+
+            torch.manual_seed(42)
+            csa = _build_csa_module(config, compress_ratio=4)
+            csa.train()
+
+            inputs = _make_csa_inputs(sq, b, config, device)
+
+            # --- Unfused memory measurement ---
+            csa.apply_dsa_kernel_fusion = False
+            query_u = inputs["query"].clone().requires_grad_(True)
+            key_u = inputs["key"].clone().requires_grad_(True)
+
+            # Warmup
+            out = csa(
+                query=query_u, key=key_u, value=key_u.clone(),
+                attention_mask=None, x=inputs["x"], qr=inputs["qr"],
+            )
+            out.sum().backward()
+            query_u.grad = None
+            key_u.grad = None
+            csa.zero_grad()
+            torch.cuda.synchronize()
+
+            torch.cuda.reset_peak_memory_stats(device)
+            torch.cuda.synchronize()
+            mem_before_unfused = torch.cuda.memory_allocated(device)
+
+            out = csa(
+                query=query_u, key=key_u, value=key_u.clone(),
+                attention_mask=None, x=inputs["x"], qr=inputs["qr"],
+            )
+            out.sum().backward()
+            torch.cuda.synchronize()
+            mem_unfused_peak = torch.cuda.max_memory_allocated(device) - mem_before_unfused
+
+            query_u.grad = None
+            key_u.grad = None
+            csa.zero_grad()
+            torch.cuda.empty_cache()
+
+            # --- Fused memory measurement ---
+            csa.apply_dsa_kernel_fusion = True
+            query_f = inputs["query"].clone().requires_grad_(True)
+            key_f = inputs["key"].clone().requires_grad_(True)
+
+            # Warmup
+            with patch(_PATCH_TARGET, _triton_fused_indexer_sparse_attn):
+                out = csa(
+                    query=query_f, key=key_f, value=key_f.clone(),
+                    attention_mask=None, x=inputs["x"], qr=inputs["qr"],
+                )
+                out.sum().backward()
+            query_f.grad = None
+            key_f.grad = None
+            csa.zero_grad()
+            torch.cuda.synchronize()
+
+            torch.cuda.reset_peak_memory_stats(device)
+            torch.cuda.synchronize()
+            mem_before_fused = torch.cuda.memory_allocated(device)
+
+            with patch(_PATCH_TARGET, _triton_fused_indexer_sparse_attn):
+                out = csa(
+                    query=query_f, key=key_f, value=key_f.clone(),
+                    attention_mask=None, x=inputs["x"], qr=inputs["qr"],
+                )
+                out.sum().backward()
+            torch.cuda.synchronize()
+            mem_fused_peak = torch.cuda.max_memory_allocated(device) - mem_before_fused
+
+            ratio = mem_unfused_peak / max(mem_fused_peak, 1)
+
+            print(
+                f"\n  [sq={sq}, b={b}, np={num_heads}, topk={indexer_topk}, "
+                f"win={window_size}, sparse_loss={sparse_loss}]"
+            )
+            print(f"    Unfused peak memory: {mem_unfused_peak / 1024**2:.1f} MB")
+            print(f"    Fused peak memory:   {mem_fused_peak / 1024**2:.1f} MB")
+            print(f"    Memory ratio:        {ratio:.2f}x")

--- a/tests/unit_tests/plugin/dsa_kernel/test_fused_dsa.py
+++ b/tests/unit_tests/plugin/dsa_kernel/test_fused_dsa.py
@@ -39,6 +39,14 @@ from torch import Tensor
 # Skip entire module if CUDA is not available
 pytestmark = pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
 
+# SM90+ check for module-level tests that use apply_dsa_kernel_fusion=True
+_SM90_AVAILABLE = (
+    torch.cuda.is_available() and torch.cuda.get_device_capability(0)[0] >= 9
+)
+_skip_unless_sm90 = pytest.mark.skipif(
+    not _SM90_AVAILABLE, reason="SM90+ (Hopper or later) required for apply_dsa_kernel_fusion"
+)
+
 # ---------------------------------------------------------------------------
 # Logging setup — use `pytest -s --log-cli-level=INFO` for detailed output,
 # or `--log-cli-level=WARNING` to suppress per-test metric prints.
@@ -383,6 +391,729 @@ class TestFusedIndexerSparseAttnAccuracy:
         ratio_actual = loss_2x.item() / max(loss_1x.item(), 1e-12)
         assert abs(ratio_actual - 2.0) < 0.01, (
             f"Loss does not scale linearly: ratio = {ratio_actual:.4f}, expected 2.0"
+        )
+
+
+# ---------------------------------------------------------------------------
+# KL Loss accuracy and calculate_per_token_loss tests
+# ---------------------------------------------------------------------------
+
+
+def _compute_kl_loss_reference(
+    inputs: dict,
+    sparse_loss: bool,
+    calculate_per_token_loss: bool,
+    loss_coeff: float = 0.1,
+) -> Tensor:
+    """Megatron-core unfused KL loss reference (no Triton code).
+
+    Uses the fused path's indexer scoring + top-K selection (same indices),
+    then calls ``compute_dsa_indexer_loss`` for the KL divergence computation.
+
+    This ensures the test validates only the KL computation logic, not
+    differences in top-K selection between implementations.
+
+    Returns scalar loss (f32).
+    """
+    from unittest.mock import MagicMock
+    from megatron.core.transformer.experimental_attention_variant.dsa import (
+        compute_dsa_indexer_loss,
+        _compute_index_scores,
+    )
+    from megatron.plugin.dsa_kernel.triton_dsa_kernels import (
+        _sbhd_to_bshd_indexer_inputs,
+        _indexer_topk_bshd,
+    )
+    from megatron.plugin.dsa_kernel.triton_dsa_utils import compute_ratio_causal_mask
+
+    n_comp = inputs["n_comp"]
+    kv_offset = inputs["kv_offset"]
+    effective_topk = min(inputs["indexer_topk"], n_comp)
+    sq, b, np_, hn = inputs["query"].shape  # noqa: F841
+    ratio = inputs["ratio"]
+
+    # Step 1: Use fused path's indexer scoring + top-K (same as FusedIndexerSparseAttnFunc)
+    q_idx_bshd, k_idx_bsd, w_bsh, w_bsh_scaled = _sbhd_to_bshd_indexer_inputs(
+        inputs["q_indexer"], inputs["k_indexer"],
+        inputs["weights"], inputs["indexer_softmax_scale"],
+    )
+    topk_indices_cmp, _, _ = _indexer_topk_bshd(
+        q_idx_bshd, k_idx_bsd, w_bsh_scaled, effective_topk, ratio
+    )
+    # topk_indices_cmp: (b, sq, effective_topk) — same indices as fused path
+    # Sanitize -1 sentinel values: compute_dsa_indexer_loss uses scatter_ which
+    # does not support negative indices. Replace -1 with 0; the causal_mask ensures
+    # those early rows (all -inf) produce row_valid=False and are zeroed out.
+    topk_indices_for_ref = topk_indices_cmp.clone()
+    topk_indices_for_ref[topk_indices_for_ref < 0] = 0
+
+    # Step 2: Compute index_scores using Megatron-core's _compute_index_scores
+    # (produces full (b, sq, n_comp) scores for compute_dsa_indexer_loss)
+    q_idx = inputs["q_indexer"]        # (sq, b, idx_nh, idx_hd)
+    k_idx = inputs["k_indexer"]        # (n_comp, b, idx_hd)
+    w_idx = inputs["weights"].float() * inputs["indexer_softmax_scale"]  # (sq, b, idx_nh)
+    index_scores = _compute_index_scores(q_idx, w_idx, k_idx)  # (b, sq, n_comp)
+
+    # Step 3: Build causal mask matching fused path
+    causal_mask = compute_ratio_causal_mask(
+        sq, n_comp, ratio, inputs["query"].device, torch.float32
+    ).unsqueeze(0).expand(b, -1, -1)  # (b, sq, n_comp)
+
+    # Apply causal mask to index_scores (same as fused_qk_topk_naive does)
+    index_scores = index_scores + causal_mask
+
+    # Step 4: prepare query and key for attention score computation
+    compressed_kv = inputs["kv_full"][kv_offset:kv_offset + n_comp]  # (n_comp, b, hn)
+    key_for_loss = compressed_kv.unsqueeze(2).expand(-1, -1, np_, -1)  # (n_comp, b, np, hn)
+
+    # Step 5: mock pg_collection with tp.size()=1
+    mock_tp = MagicMock()
+    mock_tp.size.return_value = 1
+    mock_pg = MagicMock()
+    mock_pg.tp = mock_tp
+
+    # Step 6: call compute_dsa_indexer_loss with fused path's topk indices
+    loss = compute_dsa_indexer_loss(
+        index_scores=index_scores,
+        topk_indices=topk_indices_for_ref,
+        query=inputs["query"].detach(),           # (sq, b, np, hn)
+        key=key_for_loss.detach(),                # (n_comp, b, np, hn)
+        softmax_scale=inputs["softmax_scale"],
+        loss_coeff=loss_coeff,
+        sparse_loss=sparse_loss,
+        pg_collection=mock_pg,
+        causal_mask_override=causal_mask,
+        calculate_per_token_loss=calculate_per_token_loss,
+    )
+
+    return loss
+
+
+def _compute_kl_loss_reference_dense(
+    inputs: dict,
+    calculate_per_token_loss: bool,
+    loss_coeff: float = 0.1,
+) -> Tensor:
+    """Dense KL loss reference that matches the fused path's semantics.
+
+    The fused dense path computes target attention probabilities using the FULL
+    LSE from the sparse attention forward (which includes window + compressed +
+    attn_sink positions). This is different from compute_dsa_indexer_loss which
+    computes softmax purely within the compressed key space.
+
+    This reference replicates the fused inference path step-by-step:
+    1. Run indexer top-K selection (same indices as fused)
+    2. Combine indices (compressed + window) and run sparse attention forward
+       to obtain the full LSE
+    3. Call dense_attn_score_recompute with full LSE (target distribution)
+    4. Call dense_indexer_score_recompute (predict distribution)
+    5. Call _kl_loss_from_dense_scores to compute KL divergence
+
+    Returns scalar loss (f32).
+    """
+    from megatron.plugin.dsa_kernel.triton_sparse_attn import triton_sparse_attn_forward
+
+    sq, b, np_, d = inputs["query"].shape
+    n_comp = inputs["n_comp"]
+    kv_offset = inputs["kv_offset"]
+    ratio = inputs["ratio"]
+    softmax_scale = inputs["softmax_scale"]
+    indexer_softmax_scale = inputs["indexer_softmax_scale"]
+    effective_topk = min(inputs["indexer_topk"], n_comp)
+    skv = inputs["kv_full"].shape[0]
+    idx_nh = inputs["q_indexer"].shape[2]
+
+    # Step 1: Indexer top-K (same as fused path)
+    q_idx_bshd, k_idx_bsd, w_bsh, w_bsh_scaled = _sbhd_to_bshd_indexer_inputs(
+        inputs["q_indexer"], inputs["k_indexer"],
+        inputs["weights"], indexer_softmax_scale,
+    )
+    topk_indices_cmp, _, _ = _indexer_topk_bshd(
+        q_idx_bshd, k_idx_bsd, w_bsh_scaled, effective_topk, ratio
+    )
+
+    # Step 2: Combine indices and run sparse attention to get full LSE
+    topk_indices_global = topk_indices_cmp.clone()
+    valid_cmp = topk_indices_global >= 0
+    topk_indices_global[valid_cmp] += kv_offset
+
+    window_idxs = inputs["window_idxs"]
+    combined_idxs = torch.cat([topk_indices_global, window_idxs], dim=-1)
+    total_topk = combined_idxs.shape[-1]
+
+    q_flat = inputs["query"].reshape(sq * b, np_, d)
+    kv_flat = inputs["kv_full"].reshape(skv * b, -1)
+
+    batch_ids = torch.arange(b, device=inputs["query"].device, dtype=combined_idxs.dtype)
+    global_idxs = combined_idxs.clone()
+    valid_mask = global_idxs >= 0
+    global_idxs = torch.where(
+        valid_mask,
+        global_idxs * b + batch_ids.view(b, 1, 1),
+        global_idxs,
+    )
+    global_idxs = global_idxs.permute(1, 0, 2).reshape(sq * b, total_topk)
+    global_idxs = global_idxs.unsqueeze(1)
+    global_idxs_expanded = global_idxs.expand(-1, np_, -1)
+
+    _, lse, _ = triton_sparse_attn_forward(
+        q_flat, kv_flat, global_idxs_expanded, softmax_scale, d,
+        inputs["attn_sink"], indexer_topk=0,
+    )
+    lse_bsh = lse.reshape(sq, b, np_).permute(1, 0, 2)  # (b, sq, np)
+
+    # Step 3: Attention target via dense_attn_score_recompute (full LSE)
+    q_attn_bshd = inputs["query"].permute(1, 0, 2, 3)  # (b, sq, np, d)
+    k_attn_bsd = inputs["kv_full"][kv_offset:kv_offset + n_comp, :, :d].permute(1, 0, 2)
+
+    dense_attn_result = dense_attn_score_recompute(
+        q_attn_bshd, k_attn_bsd, lse_bsh,
+        qhead_per_kv_head=np_, softmax_scale=softmax_scale, ratio=ratio,
+    )
+
+    # Step 4: Indexer predict via dense_indexer_score_recompute
+    dense_idx_result = dense_indexer_score_recompute(
+        q_idx_bshd, k_idx_bsd, w_bsh_scaled,
+        qhead_per_kv_head=idx_nh, sm_scale=indexer_softmax_scale, ratio=ratio,
+    )
+
+    # Step 5: KL loss
+    loss = _kl_loss_from_dense_scores(
+        dense_attn_result["out"], dense_attn_result["denom"],
+        dense_idx_result["out"], dense_idx_result["denom"],
+        topk_indices_cmp, loss_coeff, calculate_per_token_loss,
+    )
+    return loss
+
+
+class TestKLLossAccuracy:
+    """KL loss precision tests and calculate_per_token_loss coverage.
+
+    Verifies:
+    1. Fused KL loss matches a pure-PyTorch reference (both sparse and dense).
+    2. calculate_per_token_loss=True produces correct sum-reduction semantics.
+    3. The relationship: loss_per_token = loss_mean * num_valid_rows holds.
+    """
+
+    @pytest.fixture
+    def device(self):
+        return torch.device("cuda:0")
+
+    # ------------------------------------------------------------------
+    # Per-token vs mean reduction relationship
+    # ------------------------------------------------------------------
+
+    @pytest.mark.parametrize(
+        "sq,b,np_,hn,n_comp,win_topk,idx_nh,idx_hd,indexer_topk,ratio",
+        [
+            (2048, 1, 32, 128, 512, 128, 4, 64, 256, 4),
+            (2048, 2, 32, 128, 512, 128, 4, 64, 256, 4),
+            (4096, 1, 32, 128, 1024, 256, 4, 64, 384, 4),
+        ],
+        ids=["7B_B1_sq2048", "7B_B2_sq2048", "13B_B1_sq4096"],
+    )
+    @pytest.mark.parametrize("sparse_loss", [True, False], ids=["sparse", "dense"])
+    def test_per_token_vs_mean_reduction(
+        self, sq, b, np_, hn, n_comp, win_topk, idx_nh, idx_hd,
+        indexer_topk, ratio, sparse_loss, device, dsa_metrics,
+    ):
+        """loss(per_token) = loss(mean) * num_elements / loss_coeff * loss_coeff.
+
+        More precisely: per_token uses sum, mean uses mean over B*S_q rows.
+        So per_token_loss / mean_loss ≈ B * S_q (for all-valid rows).
+        """
+        kv_offset = sq
+        inputs = _make_fused_inputs(
+            sq, b, np_, hn, n_comp, win_topk, idx_nh, idx_hd,
+            indexer_topk, ratio, kv_offset, device,
+        )
+
+        loss_coeff = 1.0  # Use 1.0 so ratio is cleaner
+
+        # Run with mean reduction (default)
+        _, loss_mean = fused_indexer_sparse_attn(
+            inputs["query"], inputs["kv_full"], inputs["attn_sink"],
+            inputs["window_idxs"], inputs["q_indexer"], inputs["k_indexer"],
+            inputs["weights"], inputs["indexer_topk"], inputs["ratio"],
+            inputs["softmax_scale"], inputs["indexer_softmax_scale"],
+            loss_coeff, sparse_loss, inputs["kv_offset"],
+            calculate_per_token_loss=False,
+        )
+
+        # Run with per-token (sum) reduction
+        _, loss_per_token = fused_indexer_sparse_attn(
+            inputs["query"], inputs["kv_full"], inputs["attn_sink"],
+            inputs["window_idxs"], inputs["q_indexer"], inputs["k_indexer"],
+            inputs["weights"], inputs["indexer_topk"], inputs["ratio"],
+            inputs["softmax_scale"], inputs["indexer_softmax_scale"],
+            loss_coeff, sparse_loss, inputs["kv_offset"],
+            calculate_per_token_loss=True,
+        )
+
+        # Expected number of rows = B * S_q
+        n_rows = b * sq
+        expected_ratio = float(n_rows)
+        actual_ratio = loss_per_token.item() / max(loss_mean.item(), 1e-12)
+
+        # Allow small tolerance due to f32 summation order
+        rel_err = abs(actual_ratio - expected_ratio) / expected_ratio
+        assert rel_err < 0.01, (
+            f"per_token/mean ratio mismatch: got {actual_ratio:.2f}, "
+            f"expected {expected_ratio:.2f} (rel_err={rel_err:.4e})"
+        )
+
+        logger.info(
+            f"[sq={sq}, b={b}, sparse_loss={sparse_loss}] "
+            f"per_token={loss_per_token.item():.6f}, mean={loss_mean.item():.6f}, "
+            f"ratio={actual_ratio:.2f}, expected={expected_ratio:.0f}"
+        )
+        dsa_metrics.record_accuracy(
+            params={"sq": sq, "b": b, "sparse_loss": sparse_loss},
+            cos_sim=1.0 - rel_err, target="per_token_vs_mean",
+        )
+
+    # ------------------------------------------------------------------
+    # KL loss precision: fused vs PyTorch reference (sparse)
+    # ------------------------------------------------------------------
+
+    @pytest.mark.parametrize(
+        "sq,b,np_,hn,n_comp,win_topk,idx_nh,idx_hd,indexer_topk,ratio",
+        [
+            (2048, 1, 32, 128, 512, 128, 4, 64, 256, 4),
+            (2048, 2, 32, 128, 512, 128, 4, 64, 256, 4),
+            (4096, 1, 32, 128, 1024, 256, 4, 64, 384, 4),
+        ],
+        ids=["7B_B1_sq2048", "7B_B2_sq2048", "13B_B1_sq4096"],
+    )
+    @pytest.mark.parametrize(
+        "calculate_per_token_loss", [False, True], ids=["mean", "per_token"]
+    )
+    def test_kl_loss_sparse_vs_reference(
+        self, sq, b, np_, hn, n_comp, win_topk, idx_nh, idx_hd,
+        indexer_topk, ratio, calculate_per_token_loss, device, dsa_metrics,
+    ):
+        """Fused sparse KL loss matches PyTorch reference."""
+        kv_offset = sq
+        loss_coeff = 0.1
+        inputs = _make_fused_inputs(
+            sq, b, np_, hn, n_comp, win_topk, idx_nh, idx_hd,
+            indexer_topk, ratio, kv_offset, device,
+        )
+
+        # ===== DEBUG: comprehensive step-by-step diagnosis =====
+        from megatron.plugin.dsa_kernel.triton_dsa_kernels import (
+            _sbhd_to_bshd_indexer_inputs, _indexer_topk_bshd,
+        )
+        from megatron.plugin.dsa_kernel.triton_sparse_attn import triton_sparse_attn_forward
+        from megatron.plugin.dsa_kernel.triton_dsa_utils import compute_ratio_causal_mask
+        from megatron.core.transformer.experimental_attention_variant.dsa import (
+            fused_qk_topk_naive, _compute_index_scores,
+        )
+
+        effective_topk = min(inputs["indexer_topk"], n_comp)
+        q_idx_bshd, k_idx_bsd, w_bsh, w_bsh_scaled = _sbhd_to_bshd_indexer_inputs(
+            inputs["q_indexer"], inputs["k_indexer"],
+            inputs["weights"], inputs["indexer_softmax_scale"],
+        )
+        topk_indices_cmp, _, full_scores_fused = _indexer_topk_bshd(
+            q_idx_bshd, k_idx_bsd, w_bsh_scaled, effective_topk, ratio
+        )
+
+        print(f"\n[DEBUG] ===== STEP-BY-STEP DIAGNOSIS =====")
+        print(f"[DEBUG] shapes: sq={sq}, b={b}, np={np_}, hn={hn}, n_comp={n_comp}, "
+              f"effective_topk={effective_topk}, kv_offset={kv_offset}, ratio={ratio}")
+        print(f"[DEBUG] topk_indices_cmp: shape={topk_indices_cmp.shape}, "
+              f"min={topk_indices_cmp.min().item()}, max={topk_indices_cmp.max().item()}")
+        n_invalid = (topk_indices_cmp < 0).sum().item()
+        print(f"[DEBUG] invalid indices (< 0): {n_invalid} / {topk_indices_cmp.numel()}")
+
+        # ----- STEP A: Compare fused vs reference indexer scores -----
+        causal_mask = compute_ratio_causal_mask(
+            sq, n_comp, ratio, device, torch.float32
+        ).unsqueeze(0).expand(b, -1, -1)
+
+        # Reference scores from _compute_index_scores (SBHD format)
+        w_idx_ref = inputs["weights"].float() * inputs["indexer_softmax_scale"]
+        ref_index_scores = _compute_index_scores(
+            inputs["q_indexer"], w_idx_ref, inputs["k_indexer"]
+        )  # (b, sq, n_comp)
+        print(f"[DEBUG] ref_index_scores: shape={ref_index_scores.shape}, "
+              f"min={ref_index_scores.min().item():.6e}, max={ref_index_scores.max().item():.6e}")
+        print(f"[DEBUG] full_scores_fused: shape={full_scores_fused.shape}, "
+              f"min={full_scores_fused.min().item():.6e}, max={full_scores_fused.max().item():.6e}")
+
+        # Compare the two score computations
+        score_diff = (full_scores_fused - ref_index_scores).abs()
+        print(f"[DEBUG] indexer score diff (fused vs ref): "
+              f"max={score_diff.max().item():.6e}, mean={score_diff.mean().item():.6e}")
+
+        # ----- STEP B: Predict distribution comparison -----
+        # Fused predict: sparse_indexer_score_recompute over topk
+        predict_result = sparse_indexer_score_recompute(
+            q_idx_bshd, k_idx_bsd, w_bsh_scaled, topk_indices_cmp,
+            qhead_per_kv_head=idx_nh,
+        )
+        predict_fused = predict_result["predict"]  # (b, sq, topk)
+
+        # Reference predict: full index_scores + causal_mask + index_mask → softmax
+        ref_scores_masked = ref_index_scores + causal_mask
+        # Apply index_mask (sparse): mask non-topk to -inf
+        # Need to handle -1 in topk_indices_cmp for scatter
+        topk_safe = topk_indices_cmp.clone()
+        valid_topk_mask = topk_safe >= 0
+        topk_safe[~valid_topk_mask] = 0  # dummy position, will be re-masked
+        index_mask_correct = torch.full(
+            (b, sq, n_comp), float("-inf"), dtype=torch.float32, device=device
+        )
+        index_mask_correct.scatter_(-1, topk_safe.long(), 0.0)
+        # Fix: position 0 may have been incorrectly unmasked by invalid (-1→0) entries.
+        # Re-check: for each (b,s), if position 0 is NOT in the valid topk set, re-mask it.
+        pos0_in_valid = (topk_indices_cmp == 0).any(dim=-1)  # (b, sq)
+        index_mask_correct[:, :, 0] = torch.where(
+            pos0_in_valid, torch.zeros_like(index_mask_correct[:, :, 0]),
+            torch.full_like(index_mask_correct[:, :, 0], float("-inf"))
+        )
+        ref_scores_sparse = ref_scores_masked + index_mask_correct
+        # row_valid check
+        row_valid_ref = (causal_mask > float('-inf')).any(dim=-1)  # (b, sq)
+        idx_row_mask = row_valid_ref.view(b, sq, 1)
+        ref_scores_sparse = ref_scores_sparse.masked_fill(~idx_row_mask, 0.0)
+        predict_ref_full = torch.nn.functional.softmax(ref_scores_sparse, dim=-1)  # (b, sq, n_comp)
+        predict_ref_full = predict_ref_full * idx_row_mask.float()
+
+        # Gather reference predict at topk positions for comparison
+        predict_ref_at_topk = predict_ref_full[
+            torch.arange(b, device=device)[:, None, None],
+            torch.arange(sq, device=device)[None, :, None],
+            topk_safe.long(),
+        ]  # (b, sq, topk)
+        predict_ref_at_topk[~valid_topk_mask] = 0.0
+
+        predict_diff = (predict_fused - predict_ref_at_topk).abs()
+        print(f"[DEBUG] PREDICT fused: sum_per_row_mean={predict_fused.sum(-1).mean().item():.6f}, "
+              f"max={predict_fused.max().item():.6e}")
+        print(f"[DEBUG] PREDICT ref_at_topk: sum_per_row_mean={predict_ref_at_topk.sum(-1).mean().item():.6f}, "
+              f"max={predict_ref_at_topk.max().item():.6e}")
+        print(f"[DEBUG] PREDICT diff: max={predict_diff.max().item():.6e}, "
+              f"mean={predict_diff.mean().item():.6e}")
+
+        # ----- STEP C: Target distribution comparison -----
+        # Fused target: via lse_indexer from sparse attn forward
+        q_flat = inputs["query"].reshape(sq * b, np_, hn)
+        kv_flat = inputs["kv_full"].reshape((kv_offset + n_comp) * b, -1)
+        topk_indices_global = topk_indices_cmp.clone()
+        valid_cmp = topk_indices_global >= 0
+        topk_indices_global[valid_cmp] += kv_offset
+        combined_idxs = torch.cat([topk_indices_global, inputs["window_idxs"]], dim=-1)
+        total_topk = combined_idxs.shape[-1]
+        batch_ids = torch.arange(b, device=device, dtype=combined_idxs.dtype)
+        global_idxs = combined_idxs.clone()
+        valid_mask = global_idxs >= 0
+        global_idxs = torch.where(valid_mask, global_idxs * b + batch_ids.view(b, 1, 1), global_idxs)
+        global_idxs = global_idxs.permute(1, 0, 2).reshape(sq * b, total_topk)
+        global_idxs = global_idxs.unsqueeze(1)
+        global_idxs_expanded = global_idxs.expand(-1, np_, -1)
+
+        _, lse_full, lse_indexer_raw = triton_sparse_attn_forward(
+            q_flat, kv_flat, global_idxs_expanded, inputs["softmax_scale"], hn,
+            inputs["attn_sink"], indexer_topk=effective_topk,
+        )
+        lse_indexer_bsh = lse_indexer_raw.reshape(sq, b, np_).permute(1, 0, 2)  # (b, sq, np)
+
+        k_attn_bsd = inputs["kv_full"][:, :, :hn].permute(1, 0, 2)  # (b, skv, d)
+        q_attn_bshd = inputs["query"].permute(1, 0, 2, 3)  # (b, sq, np, hn)
+
+        # Shift valid indices by kv_offset, keep -1 as-is for invalid mask
+        topk_for_target = topk_indices_cmp.clone()
+        valid_cmp_target = topk_for_target >= 0
+        topk_for_target[valid_cmp_target] += kv_offset
+
+        target_result = sparse_attn_score_recompute(
+            q_attn_bshd, k_attn_bsd, lse_indexer_bsh, topk_for_target,
+            inputs["softmax_scale"], qhead_per_kv_head=np_,
+        )
+        target_fused = target_result["target"]  # (b, sq, topk)
+
+        # Reference target: direct softmax over topk attention scores
+        # q @ K_compressed_topk * scale, per head, then softmax, sum heads, L1 norm
+        compressed_kv = inputs["kv_full"][kv_offset:kv_offset + n_comp]  # (n_comp, b, hn)
+        key_for_ref = compressed_kv.unsqueeze(2).expand(-1, -1, np_, -1)  # (n_comp, b, np, hn)
+        # Compute full attention scores: [b*np, sq, n_comp]
+        q_ref = inputs["query"].permute(1, 2, 0, 3).reshape(b * np_, sq, hn).float()
+        k_ref = key_for_ref.permute(1, 2, 3, 0).reshape(b * np_, hn, n_comp).float()
+        attn_scores_full = torch.bmm(q_ref, k_ref) * inputs["softmax_scale"]
+        attn_scores_full = attn_scores_full.reshape(b, np_, sq, n_comp)  # (b, np, sq, n_comp)
+
+        # Apply causal_mask + index_mask
+        attn_scores_full = attn_scores_full + causal_mask.unsqueeze(1)  # (b, 1, sq, n_comp)
+        attn_scores_full = attn_scores_full + index_mask_correct.unsqueeze(1)  # sparse mask
+
+        # row_valid handling
+        attn_row_mask = row_valid_ref.view(b, 1, sq, 1)
+        attn_scores_full = attn_scores_full.masked_fill(~attn_row_mask, 0.0)
+
+        # Softmax per head
+        attn_probs_ref = torch.nn.functional.softmax(attn_scores_full, dim=-1)  # (b, np, sq, n_comp)
+        attn_probs_ref = attn_probs_ref * attn_row_mask.float()
+
+        # Sum heads, L1 normalize
+        attn_target_ref = attn_probs_ref.sum(dim=1)  # (b, sq, n_comp)
+        attn_target_ref = attn_target_ref / attn_target_ref.sum(dim=-1, keepdim=True).clamp(min=1e-10)
+
+        # Gather target at topk positions
+        target_ref_at_topk = attn_target_ref[
+            torch.arange(b, device=device)[:, None, None],
+            torch.arange(sq, device=device)[None, :, None],
+            topk_safe.long(),
+        ]
+        target_ref_at_topk[~valid_topk_mask] = 0.0
+
+        target_diff = (target_fused - target_ref_at_topk).abs()
+        print(f"[DEBUG] TARGET fused: sum_per_row_mean={target_fused.sum(-1).mean().item():.6f}, "
+              f"max={target_fused.max().item():.6e}")
+        print(f"[DEBUG] TARGET ref_at_topk: sum_per_row_mean={target_ref_at_topk.sum(-1).mean().item():.6f}, "
+              f"max={target_ref_at_topk.max().item():.6e}")
+        print(f"[DEBUG] TARGET diff: max={target_diff.max().item():.6e}, "
+              f"mean={target_diff.mean().item():.6e}, "
+              f"rel_max={target_diff.max().item() / max(target_ref_at_topk.abs().max().item(), 1e-10):.4e}")
+
+        # ----- STEP D: Diagnose lse_indexer vs direct softmax -----
+        # For fused target, the per-head probs are exp(score - lse_indexer)
+        # For reference target, they are softmax(scores_at_topk_only)
+        # These should be identical if lse_indexer = logsumexp(scores_at_topk)
+        # Let's check: recompute scores at topk positions and compare with lse_indexer
+        idx_for_gather = (topk_indices_cmp + kv_offset).long().clamp(min=0)  # (b, sq, topk)
+        batch_idx_d = torch.arange(b, device=device)[:, None, None]
+        k_gathered_f32 = k_attn_bsd.float()[batch_idx_d, idx_for_gather]  # (b, sq, topk, hn)
+        scores_at_topk = torch.einsum(
+            "bqhd,bqtd->bqht", q_attn_bshd.float(), k_gathered_f32
+        ) * inputs["softmax_scale"]  # (b, sq, np, topk)
+        # Mask invalid
+        scores_at_topk_masked = scores_at_topk.clone()
+        inv_mask_4d = (~valid_topk_mask).unsqueeze(2).expand_as(scores_at_topk)
+        scores_at_topk_masked[inv_mask_4d] = float("-inf")
+
+        # Direct logsumexp from f32 scores
+        lse_direct_f32 = torch.logsumexp(scores_at_topk_masked, dim=-1)  # (b, sq, np)
+        # Compare with lse_indexer from triton forward
+        lse_diff = (lse_indexer_bsh - lse_direct_f32).abs()
+        print(f"[DEBUG] LSE comparison (triton_fwd vs direct_f32):")
+        print(f"[DEBUG]   lse_indexer: mean={lse_indexer_bsh.mean().item():.4f}, "
+              f"min={lse_indexer_bsh.min().item():.4f}, max={lse_indexer_bsh.max().item():.4f}")
+        print(f"[DEBUG]   lse_direct:  mean={lse_direct_f32.mean().item():.4f}, "
+              f"min={lse_direct_f32.min().item():.4f}, max={lse_direct_f32.max().item():.4f}")
+        print(f"[DEBUG]   diff: max={lse_diff.max().item():.6e}, mean={lse_diff.mean().item():.6e}")
+
+        # Check what softmax probs look like from each LSE
+        probs_from_triton_lse = torch.exp(scores_at_topk_masked - lse_indexer_bsh.unsqueeze(-1))
+        probs_from_direct_lse = torch.exp(scores_at_topk_masked - lse_direct_f32.unsqueeze(-1))
+        print(f"[DEBUG] probs_from_triton_lse: max={probs_from_triton_lse.max().item():.6e}, "
+              f"sum_per_row_mean={probs_from_triton_lse.sum(-1).mean().item():.6f}")
+        print(f"[DEBUG] probs_from_direct_lse: max={probs_from_direct_lse.max().item():.6e}, "
+              f"sum_per_row_mean={probs_from_direct_lse.sum(-1).mean().item():.6f}")
+
+        # ----- STEP E: Compute KL from both paths for final comparison -----
+        # Manual fused-style KL
+        eps = torch.finfo(torch.float32).tiny
+        t_f = target_fused.clamp(min=eps)
+        p_f = predict_fused.clamp(min=eps)
+        kl_fused_rows = (t_f * (torch.log(t_f) - torch.log(p_f))).sum(dim=-1)
+        row_valid_fused = (topk_indices_cmp >= 0).any(dim=-1)
+        kl_fused_rows = torch.where(row_valid_fused, kl_fused_rows, torch.zeros_like(kl_fused_rows))
+        manual_loss = kl_fused_rows.mean() * loss_coeff
+
+        # Manual ref-style KL (same indices, same mask)
+        t_r = target_ref_at_topk.clamp(min=eps)
+        p_r = predict_ref_at_topk.clamp(min=eps)
+        kl_ref_rows = (t_r * (torch.log(t_r) - torch.log(p_r))).sum(dim=-1)
+        kl_ref_rows = torch.where(row_valid_fused, kl_ref_rows, torch.zeros_like(kl_ref_rows))
+        manual_ref_loss = kl_ref_rows.mean() * loss_coeff
+
+        print(f"[DEBUG] ----- KL DECOMPOSITION -----")
+        print(f"[DEBUG] manual_loss (fused target+predict): {manual_loss.item():.6e}")
+        print(f"[DEBUG] manual_ref_loss (ref target+predict): {manual_ref_loss.item():.6e}")
+
+        # Cross KL: fused target with ref predict
+        kl_cross1 = (t_f * (torch.log(t_f) - torch.log(p_r))).sum(dim=-1)
+        kl_cross1 = torch.where(row_valid_fused, kl_cross1, torch.zeros_like(kl_cross1))
+        print(f"[DEBUG] KL(fused_target || ref_predict): {kl_cross1.mean().item() * loss_coeff:.6e}")
+        # Cross KL: ref target with fused predict
+        kl_cross2 = (t_r * (torch.log(t_r) - torch.log(p_f))).sum(dim=-1)
+        kl_cross2 = torch.where(row_valid_fused, kl_cross2, torch.zeros_like(kl_cross2))
+        print(f"[DEBUG] KL(ref_target || fused_predict): {kl_cross2.mean().item() * loss_coeff:.6e}")
+
+        # Show worst rows
+        kl_diff_per_row = (kl_fused_rows - kl_ref_rows).abs()
+        worst_flat = kl_diff_per_row.reshape(-1).topk(5)
+        print(f"[DEBUG] top-5 worst row KL diffs: {worst_flat.values.tolist()}")
+        for idx in worst_flat.indices[:3]:
+            bi = idx.item() // sq
+            si = idx.item() % sq
+            print(f"[DEBUG]   row [{bi},{si}]: "
+                  f"fused_target={target_fused[bi,si,:8].tolist()}, "
+                  f"ref_target={target_ref_at_topk[bi,si,:8].tolist()}")
+            print(f"[DEBUG]            "
+                  f"fused_predict={predict_fused[bi,si,:8].tolist()}, "
+                  f"ref_predict={predict_ref_at_topk[bi,si,:8].tolist()}")
+
+        print(f"[DEBUG] fused loss will be printed after call below...")
+        # ===== END DEBUG =====
+
+        # Fused path
+        _, loss_fused = fused_indexer_sparse_attn(
+            inputs["query"], inputs["kv_full"], inputs["attn_sink"],
+            inputs["window_idxs"], inputs["q_indexer"], inputs["k_indexer"],
+            inputs["weights"], inputs["indexer_topk"], inputs["ratio"],
+            inputs["softmax_scale"], inputs["indexer_softmax_scale"],
+            loss_coeff, True, inputs["kv_offset"],
+            calculate_per_token_loss=calculate_per_token_loss,
+        )
+
+        # Reference
+        loss_ref = _compute_kl_loss_reference(
+            inputs, sparse_loss=True,
+            calculate_per_token_loss=calculate_per_token_loss,
+            loss_coeff=loss_coeff,
+        )
+
+        fused_val = loss_fused.item()
+        ref_val = loss_ref.item()
+        rel_err = abs(fused_val - ref_val) / max(abs(ref_val), 1e-8)
+
+        print(f"[DEBUG] === FINAL COMPARISON ===")
+        print(f"[DEBUG] loss_fused={fused_val:.6e}, loss_ref={ref_val:.6e}, manual_loss={manual_loss.item():.6e}")
+        print(f"[DEBUG] fused vs manual rel_err={abs(fused_val - manual_loss.item()) / max(abs(manual_loss.item()), 1e-8):.4e}")
+        print(f"[DEBUG] manual vs ref rel_err={abs(manual_loss.item() - ref_val) / max(abs(ref_val), 1e-8):.4e}")
+
+        logger.info(
+            f"[sq={sq}, b={b}, per_token={calculate_per_token_loss}] "
+            f"sparse KL: fused={fused_val:.6e}, ref={ref_val:.6e}, rel_err={rel_err:.4e}"
+        )
+
+        assert rel_err < 5e-3, (
+            f"Sparse KL loss mismatch: fused={fused_val:.6e}, ref={ref_val:.6e}, "
+            f"rel_err={rel_err:.4e}"
+        )
+        assert torch.isfinite(loss_fused), f"Fused loss is not finite: {fused_val}"
+
+        dsa_metrics.record_accuracy(
+            params={"sq": sq, "b": b, "per_token": calculate_per_token_loss},
+            cos_sim=1.0 - rel_err, target="kl_loss_sparse",
+        )
+
+    # ------------------------------------------------------------------
+    # KL loss precision: fused vs PyTorch reference (dense)
+    # ------------------------------------------------------------------
+
+    @pytest.mark.parametrize(
+        "sq,b,np_,hn,n_comp,win_topk,idx_nh,idx_hd,indexer_topk,ratio",
+        [
+            (2048, 1, 32, 128, 512, 128, 4, 64, 256, 4),
+            (2048, 2, 32, 128, 512, 128, 4, 64, 256, 4),
+            (4096, 1, 32, 128, 1024, 256, 4, 64, 384, 4),
+        ],
+        ids=["7B_B1_sq2048", "7B_B2_sq2048", "13B_B1_sq4096"],
+    )
+    @pytest.mark.parametrize(
+        "calculate_per_token_loss", [False, True], ids=["mean", "per_token"]
+    )
+    def test_kl_loss_dense_vs_reference(
+        self, sq, b, np_, hn, n_comp, win_topk, idx_nh, idx_hd,
+        indexer_topk, ratio, calculate_per_token_loss, device, dsa_metrics,
+    ):
+        """Fused dense KL loss matches PyTorch reference."""
+        kv_offset = sq
+        loss_coeff = 0.1
+        inputs = _make_fused_inputs(
+            sq, b, np_, hn, n_comp, win_topk, idx_nh, idx_hd,
+            indexer_topk, ratio, kv_offset, device,
+        )
+
+        # Fused path
+        _, loss_fused = fused_indexer_sparse_attn(
+            inputs["query"], inputs["kv_full"], inputs["attn_sink"],
+            inputs["window_idxs"], inputs["q_indexer"], inputs["k_indexer"],
+            inputs["weights"], inputs["indexer_topk"], inputs["ratio"],
+            inputs["softmax_scale"], inputs["indexer_softmax_scale"],
+            loss_coeff, False, inputs["kv_offset"],
+            calculate_per_token_loss=calculate_per_token_loss,
+        )
+
+        # Reference — uses full LSE from sparse attn forward (matches fused semantics)
+        loss_ref = _compute_kl_loss_reference_dense(
+            inputs,
+            calculate_per_token_loss=calculate_per_token_loss,
+            loss_coeff=loss_coeff,
+        )
+
+        fused_val = loss_fused.item()
+        ref_val = loss_ref.item()
+        rel_err = abs(fused_val - ref_val) / max(abs(ref_val), 1e-8)
+
+        logger.info(
+            f"[sq={sq}, b={b}, per_token={calculate_per_token_loss}] "
+            f"dense KL: fused={fused_val:.6e}, ref={ref_val:.6e}, rel_err={rel_err:.4e}"
+        )
+
+        assert rel_err < 5e-3, (
+            f"Dense KL loss mismatch: fused={fused_val:.6e}, ref={ref_val:.6e}, "
+            f"rel_err={rel_err:.4e}"
+        )
+        assert torch.isfinite(loss_fused), f"Fused loss is not finite: {fused_val}"
+
+        dsa_metrics.record_accuracy(
+            params={"sq": sq, "b": b, "per_token": calculate_per_token_loss},
+            cos_sim=1.0 - rel_err, target="kl_loss_dense",
+        )
+
+    # ------------------------------------------------------------------
+    # Per-token loss with gradient — ensure backward still works
+    # ------------------------------------------------------------------
+
+    @pytest.mark.parametrize(
+        "sq,b,np_,hn,n_comp,win_topk,idx_nh,idx_hd,indexer_topk,ratio",
+        [
+            (2048, 1, 32, 128, 512, 128, 4, 64, 256, 4),
+        ],
+    )
+    @pytest.mark.parametrize("sparse_loss", [True, False], ids=["sparse", "dense"])
+    def test_per_token_loss_backward_no_nan(
+        self, sq, b, np_, hn, n_comp, win_topk, idx_nh, idx_hd,
+        indexer_topk, ratio, sparse_loss, device,
+    ):
+        """Backward with calculate_per_token_loss=True produces no NaN/Inf."""
+        kv_offset = sq
+        inputs = _make_fused_inputs(
+            sq, b, np_, hn, n_comp, win_topk, idx_nh, idx_hd,
+            indexer_topk, ratio, kv_offset, device,
+        )
+
+        query = inputs["query"].clone().detach().requires_grad_(True)
+        kv_full = inputs["kv_full"].clone().detach().requires_grad_(True)
+        attn_sink = inputs["attn_sink"].clone().detach().requires_grad_(True)
+
+        out, loss = fused_indexer_sparse_attn(
+            query, kv_full, attn_sink, inputs["window_idxs"],
+            inputs["q_indexer"], inputs["k_indexer"], inputs["weights"],
+            inputs["indexer_topk"], inputs["ratio"],
+            inputs["softmax_scale"], inputs["indexer_softmax_scale"],
+            0.1, sparse_loss, inputs["kv_offset"],
+            calculate_per_token_loss=True,
+        )
+
+        scalar = out.float().sum() + loss
+        scalar.backward()
+
+        for name, param in [("query", query), ("kv_full", kv_full), ("attn_sink", attn_sink)]:
+            assert param.grad is not None, f"{name}.grad is None"
+            assert not torch.isnan(param.grad).any(), f"{name}.grad has NaN"
+            assert not torch.isinf(param.grad).any(), f"{name}.grad has Inf"
+
+        # Loss should be larger than mean version (since it's sum over B*S_q rows)
+        assert loss.item() > 0, f"Per-token loss should be positive, got {loss.item()}"
+        logger.info(
+            f"[sparse_loss={sparse_loss}] per_token_loss={loss.item():.6f}, "
+            f"grad_query_norm={query.grad.float().norm().item():.4e}"
         )
 
 
@@ -822,9 +1553,13 @@ class TestFusedIndexerSparseAttnPerformance:
                 )
                 q_attn_bshd = inputs["query"].permute(1, 0, 2, 3).contiguous()
                 k_attn_bsd = inputs["kv_full"][:, :, :d].permute(1, 0, 2).contiguous()
+                # Preserve -1 for invalid mask in sparse_attn_score_recompute
+                topk_for_target_perf = topk_indices_cmp.clone()
+                valid_perf = topk_for_target_perf >= 0
+                topk_for_target_perf[valid_perf] += kv_offset
                 target_result = sparse_attn_score_recompute(
                     q_attn_bshd, k_attn_bsd, lse_indexer_bsh,
-                    topk_indices_cmp + kv_offset,
+                    topk_for_target_perf,
                     inputs["softmax_scale"], qhead_per_kv_head=np_,
                 )
                 _loss = _kl_loss_from_target_predict(
@@ -1117,9 +1852,13 @@ class TestFusedIndexerSparseAttnPerformance:
                 q_attn_bshd = unfused_query.permute(1, 0, 2, 3).contiguous()
                 k_attn_bsd = unfused_kv[:, :, :d].permute(1, 0, 2).contiguous()
 
+                # Preserve -1 for invalid mask in sparse_attn_score_recompute
+                topk_for_target_e2e = topk_indices_cmp.clone()
+                valid_e2e = topk_for_target_e2e >= 0
+                topk_for_target_e2e[valid_e2e] += kv_offset
                 target_result = sparse_attn_score_recompute(
                     q_attn_bshd, k_attn_bsd, lse_indexer_bsh,
-                    topk_indices_cmp + kv_offset,
+                    topk_for_target_e2e,
                     inputs["softmax_scale"], qhead_per_kv_head=np_,
                 )
                 target = target_result["target"]
@@ -1239,34 +1978,28 @@ def _oom_guard():
 
 
 # ---------------------------------------------------------------------------
-# Triton dsa_sparse_attn wrapper (SBHD interface matching dsa_kernels.py)
+# Triton dsa_sparse_attn SBHD interface
+#
+# Now that csa.py uses _ensure_dsa_kernels() to lazily import the Triton
+# backend (dsa_sparse_attn_sbhd, build_flat_topk_idxs, etc.), tests that set
+# apply_dsa_kernel_fusion=True in the config no longer need monkey-patching.
+# The globals are populated during CSA construction.
 # ---------------------------------------------------------------------------
 
-
-def _triton_dsa_sparse_attn(
-    query, kv, attn_sink, topk_idxs, softmax_scale, topk_length=None, indexer_topk=0
-):
-    """SBHD wrapper around triton plugin's flat dsa_sparse_attn.
-
-    Matches the signature of ``dsa_kernels.dsa_sparse_attn`` so it can be
-    monkey-patched into csa.py for tests without FlashMLA/cuDNN.
-    """
-    sq, b, np_, d = query.shape
-    skv = kv.shape[0]
-    q_flat = query.reshape(sq * b, np_, d)
-    kv_flat = kv.reshape(skv * b, d)
-    # triton expects (total_Sq, H_kv, TopK); dsa_kernels produces (total_Sq, TopK)
-    if topk_idxs.dim() == 2:
-        topk_idxs = topk_idxs.unsqueeze(1)
-    out_flat, _lse, _ = _triton_dsa_sparse_attn_raw(
-        q_flat, kv_flat, topk_idxs, softmax_scale, d, attn_sink, topk_length, indexer_topk
-    )
-    d_v = out_flat.shape[-1]
-    return out_flat.reshape(sq, b, np_ * d_v)
+from megatron.plugin.dsa_kernel.triton_dsa_kernels import (
+    dsa_sparse_attn_sbhd as _triton_dsa_sparse_attn_sbhd,  # noqa: F401
+)
 
 
+# Patch targets for the csa.py module-level globals (used by _ensure_dsa_kernels).
+# These are needed only when apply_dsa_kernel_fusion was NOT set in the config
+# (so _ensure_dsa_kernels was never called) and you need to inject the Triton
+# implementations manually.
 _PATCH_DSA_SPARSE_ATTN = (
-    'megatron.core.transformer.experimental_attention_variant.csa.dsa_sparse_attn'
+    'megatron.core.transformer.experimental_attention_variant.csa._dsa_sparse_attn'
+)
+_PATCH_BUILD_FLAT_TOPK_IDXS = (
+    'megatron.core.transformer.experimental_attention_variant.csa._build_flat_topk_idxs_fn'
 )
 
 try:
@@ -1291,6 +2024,7 @@ def _make_test_mla_config(
     dsa_indexer_head_dim=64,
     dsa_indexer_loss_coeff=0.1,
     dsa_indexer_use_sparse_loss=True,
+    apply_dsa_kernel_fusion=True,
 ):
     """Helper to create MLATransformerConfig for module-level CSA tests."""
     qk_pos_emb_head_dim = 32
@@ -1321,6 +2055,7 @@ def _make_test_mla_config(
         dsa_indexer_topk=dsa_indexer_topk,
         dsa_indexer_loss_coeff=dsa_indexer_loss_coeff,
         dsa_indexer_use_sparse_loss=dsa_indexer_use_sparse_loss,
+        apply_dsa_kernel_fusion=apply_dsa_kernel_fusion,
     )
 
 
@@ -1394,13 +2129,11 @@ def _make_csa_inputs(sq, b, config, device="cuda"):
     return {"query": query, "key": key, "value": key.clone(), "x": x, "qr": qr}
 
 
-# Patch target for fused_indexer_sparse_attn in the csa module
-_PATCH_TARGET = (
-    'megatron.core.transformer.experimental_attention_variant.csa.fused_indexer_sparse_attn'
+# Patch target for fused_indexer_sparse_attn in the csa module (kept for reference;
+# not needed when apply_dsa_kernel_fusion=True is set in the config).
+_PATCH_FUSED_INDEXER = (
+    'megatron.core.transformer.experimental_attention_variant.csa._fused_indexer_sparse_attn'
 )
-
-# Reuse the already-imported triton fused_indexer_sparse_attn
-_triton_fused_indexer_sparse_attn = fused_indexer_sparse_attn
 
 
 def _hadamard_patches():
@@ -1424,6 +2157,7 @@ def _hadamard_patches():
         return stack
 
 
+@_skip_unless_sm90
 class TestCSAFusedVsUnfusedAccuracy:
     """Module-level accuracy: CompressedSparseAttention unfused path vs fused (triton).
 
@@ -1487,18 +2221,17 @@ class TestCSAFusedVsUnfusedAccuracy:
                     qr=inputs["qr"].clone(),
                 )
 
-            # --- Fused path (triton) ---
+            # --- Fused path (triton via _ensure_dsa_kernels) ---
             csa.apply_dsa_kernel_fusion = True
-            with patch(_PATCH_TARGET, _triton_fused_indexer_sparse_attn):
-                torch.manual_seed(7)
-                out_fused = csa(
-                    query=inputs["query"].clone(),
-                    key=inputs["key"].clone(),
-                    value=inputs["value"].clone(),
-                    attention_mask=None,
-                    x=inputs["x"].clone(),
-                    qr=inputs["qr"].clone(),
-                )
+            torch.manual_seed(7)
+            out_fused = csa(
+                query=inputs["query"].clone(),
+                key=inputs["key"].clone(),
+                value=inputs["value"].clone(),
+                attention_mask=None,
+                x=inputs["x"].clone(),
+                qr=inputs["qr"].clone(),
+            )
 
             # Compare
             out_f = out_fused.float()
@@ -1574,12 +2307,11 @@ class TestCSAFusedVsUnfusedAccuracy:
             csa.apply_dsa_kernel_fusion = True
             query_f = inputs["query"].clone().requires_grad_(True)
             key_f = inputs["key"].clone().requires_grad_(True)
-            with patch(_PATCH_TARGET, _triton_fused_indexer_sparse_attn):
-                out_f = csa(
-                    query=query_f, key=key_f, value=key_f.clone(),
-                    attention_mask=None, x=inputs["x"].clone(), qr=inputs["qr"].clone(),
-                )
-                out_f.sum().backward()
+            out_f = csa(
+                query=query_f, key=key_f, value=key_f.clone(),
+                attention_mask=None, x=inputs["x"].clone(), qr=inputs["qr"].clone(),
+            )
+            out_f.sum().backward()
             grad_q_fused = query_f.grad.float().clone()
             grad_k_fused = key_f.grad.float().clone()
 
@@ -1609,6 +2341,7 @@ class TestCSAFusedVsUnfusedAccuracy:
             )
 
 
+@_skip_unless_sm90
 class TestCSAFusedVsUnfusedPerformance:
     """Module-level performance: CompressedSparseAttention unfused vs fused (triton).
 
@@ -1711,8 +2444,7 @@ class TestCSAFusedVsUnfusedPerformance:
                 key_f.grad = None
                 csa.zero_grad()
 
-            with patch(_PATCH_TARGET, _triton_fused_indexer_sparse_attn):
-                time_fused = self._benchmark(run_fused)
+            time_fused = self._benchmark(run_fused)
 
             speedup = time_unfused / max(time_fused, 1e-6)
 
@@ -1800,12 +2532,11 @@ class TestCSAFusedVsUnfusedPerformance:
             key_f = inputs["key"].clone().requires_grad_(True)
 
             # Warmup
-            with patch(_PATCH_TARGET, _triton_fused_indexer_sparse_attn):
-                out = csa(
-                    query=query_f, key=key_f, value=key_f.clone(),
-                    attention_mask=None, x=inputs["x"], qr=inputs["qr"],
-                )
-                out.sum().backward()
+            out = csa(
+                query=query_f, key=key_f, value=key_f.clone(),
+                attention_mask=None, x=inputs["x"], qr=inputs["qr"],
+            )
+            out.sum().backward()
             query_f.grad = None
             key_f.grad = None
             csa.zero_grad()
@@ -1815,12 +2546,11 @@ class TestCSAFusedVsUnfusedPerformance:
             torch.cuda.synchronize()
             mem_before_fused = torch.cuda.memory_allocated(device)
 
-            with patch(_PATCH_TARGET, _triton_fused_indexer_sparse_attn):
-                out = csa(
-                    query=query_f, key=key_f, value=key_f.clone(),
-                    attention_mask=None, x=inputs["x"], qr=inputs["qr"],
-                )
-                out.sum().backward()
+            out = csa(
+                query=query_f, key=key_f, value=key_f.clone(),
+                attention_mask=None, x=inputs["x"], qr=inputs["qr"],
+            )
+            out.sum().backward()
             torch.cuda.synchronize()
             mem_fused_peak = torch.cuda.max_memory_allocated(device) - mem_before_fused
 
@@ -1844,6 +2574,7 @@ class TestCSAFusedVsUnfusedPerformance:
 # ---------------------------------------------------------------------------
 
 
+@_skip_unless_sm90
 class TestCSANoIndexerFusedVsUnfused:
     """E2E accuracy: CompressedSparseAttention with no indexer (ratio=0 or ratio=128).
 
@@ -1909,18 +2640,17 @@ class TestCSANoIndexerFusedVsUnfused:
                     qr=inputs["qr"].clone(),
                 )
 
-            # --- Fused path (triton dsa_sparse_attn) ---
+            # --- Fused path (triton dsa_sparse_attn via _ensure_dsa_kernels) ---
             csa.apply_dsa_kernel_fusion = True
-            with patch(_PATCH_DSA_SPARSE_ATTN, _triton_dsa_sparse_attn):
-                torch.manual_seed(7)
-                out_fused = csa(
-                    query=inputs["query"].clone(),
-                    key=inputs["key"].clone(),
-                    value=inputs["value"].clone(),
-                    attention_mask=None,
-                    x=inputs["x"].clone(),
-                    qr=inputs["qr"].clone(),
-                )
+            torch.manual_seed(7)
+            out_fused = csa(
+                query=inputs["query"].clone(),
+                key=inputs["key"].clone(),
+                value=inputs["value"].clone(),
+                attention_mask=None,
+                x=inputs["x"].clone(),
+                qr=inputs["qr"].clone(),
+            )
 
             # Compare
             out_f = out_fused.float()
@@ -1994,18 +2724,17 @@ class TestCSANoIndexerFusedVsUnfused:
 
             csa.zero_grad()
 
-            # --- Fused path with grad (triton dsa_sparse_attn) ---
+            # --- Fused path with grad (triton dsa_sparse_attn via _ensure_dsa_kernels) ---
             csa.apply_dsa_kernel_fusion = True
             query_f = inputs["query"].clone().requires_grad_(True)
             key_f = inputs["key"].clone().requires_grad_(True)
-            with patch(_PATCH_DSA_SPARSE_ATTN, _triton_dsa_sparse_attn):
-                out_f = csa(
-                    query=query_f, key=key_f, value=key_f.clone(),
-                    attention_mask=None, x=inputs["x"].clone(), qr=inputs["qr"].clone(),
-                )
-                torch.cuda.synchronize()
-                out_f.sum().backward()
-                torch.cuda.synchronize()
+            out_f = csa(
+                query=query_f, key=key_f, value=key_f.clone(),
+                attention_mask=None, x=inputs["x"].clone(), qr=inputs["qr"].clone(),
+            )
+            torch.cuda.synchronize()
+            out_f.sum().backward()
+            torch.cuda.synchronize()
             grad_q_fused = query_f.grad.float().clone()
             grad_k_fused = key_f.grad.float().clone()
 
@@ -2055,6 +2784,7 @@ class TestCSANoIndexerFusedVsUnfused:
 # ---------------------------------------------------------------------------
 
 
+@_skip_unless_sm90
 class TestCSANoIndexerPerformance:
     """E2E performance: CompressedSparseAttention no-indexer path.
 
@@ -2140,7 +2870,7 @@ class TestCSANoIndexerPerformance:
             with _oom_guard():
                 time_unfused = self._benchmark(run_unfused)
 
-            # --- Fused benchmark (triton dsa_sparse_attn) ---
+            # --- Fused benchmark (triton dsa_sparse_attn via _ensure_dsa_kernels) ---
             csa.apply_dsa_kernel_fusion = True
             query_f = inputs["query"].clone().requires_grad_(True)
             key_f = inputs["key"].clone().requires_grad_(True)
@@ -2155,8 +2885,7 @@ class TestCSANoIndexerPerformance:
                 key_f.grad = None
                 csa.zero_grad()
 
-            with patch(_PATCH_DSA_SPARSE_ATTN, _triton_dsa_sparse_attn):
-                time_fused = self._benchmark(run_fused)
+            time_fused = self._benchmark(run_fused)
 
             speedup = time_unfused / max(time_fused, 1e-6)
 
@@ -2241,12 +2970,11 @@ class TestCSANoIndexerPerformance:
             key_f = inputs["key"].clone().requires_grad_(True)
 
             # Warmup
-            with patch(_PATCH_DSA_SPARSE_ATTN, _triton_dsa_sparse_attn):
-                out = csa(
-                    query=query_f, key=key_f, value=key_f.clone(),
-                    attention_mask=None, x=inputs["x"], qr=inputs["qr"],
-                )
-                out.sum().backward()
+            out = csa(
+                query=query_f, key=key_f, value=key_f.clone(),
+                attention_mask=None, x=inputs["x"], qr=inputs["qr"],
+            )
+            out.sum().backward()
             query_f.grad = None
             key_f.grad = None
             csa.zero_grad()
@@ -2256,12 +2984,11 @@ class TestCSANoIndexerPerformance:
             torch.cuda.synchronize()
             mem_before = torch.cuda.memory_allocated(device)
 
-            with patch(_PATCH_DSA_SPARSE_ATTN, _triton_dsa_sparse_attn):
-                out = csa(
-                    query=query_f, key=key_f, value=key_f.clone(),
-                    attention_mask=None, x=inputs["x"], qr=inputs["qr"],
-                )
-                out.sum().backward()
+            out = csa(
+                query=query_f, key=key_f, value=key_f.clone(),
+                attention_mask=None, x=inputs["x"], qr=inputs["qr"],
+            )
+            out.sum().backward()
             torch.cuda.synchronize()
             mem_fused_peak = torch.cuda.max_memory_allocated(device) - mem_before
 

--- a/tests/unit_tests/plugin/dsa_kernel/test_fused_dsa.py
+++ b/tests/unit_tests/plugin/dsa_kernel/test_fused_dsa.py
@@ -7,6 +7,11 @@ Validates that ``fused_indexer_sparse_attn`` from the Triton plugin produces
 numerically equivalent attention output to ``unfused_compressed_sparse_attn``
 from ``megatron.core.transformer.experimental_attention_variant.csa``.
 
+Test parameters are configured for training-realistic workloads:
+- Sequence length >= 2048 (typical training context)
+- TopK > 256 (large sparse attention windows)
+- Number of heads >= 32 (full-model multi-head attention)
+
 The fused path:
 1. Scores + top-K selection via indexer (q_indexer, k_indexer, weights)
 2. Combines compressed top-K indices with window indices
@@ -16,12 +21,13 @@ The fused path:
 The unfused path takes pre-computed indices and runs only the sparse attention.
 We compare the attention output (not the loss) between them.
 
-Run with: pytest tests/unit_tests/plugin/dsa_kernel/test_fused_indexer_sparse_attn.py -v -s
+Run with: pytest tests/unit_tests/plugin/dsa_kernel/test_fused_dsa.py -v -s
 Requires: CUDA GPU with Triton support.
 """
 
 from __future__ import annotations
 
+import logging
 import math
 import time
 from typing import Tuple
@@ -32,6 +38,13 @@ from torch import Tensor
 
 # Skip entire module if CUDA is not available
 pytestmark = pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+
+# ---------------------------------------------------------------------------
+# Logging setup — use `pytest -s --log-cli-level=INFO` for detailed output,
+# or `--log-cli-level=WARNING` to suppress per-test metric prints.
+# ---------------------------------------------------------------------------
+
+logger = logging.getLogger(__name__)
 
 # ---------------------------------------------------------------------------
 # Imports
@@ -229,29 +242,25 @@ class TestFusedIndexerSparseAttnAccuracy:
     @pytest.mark.parametrize(
         "sq,b,np_,hn,n_comp,win_topk,idx_nh,idx_hd,indexer_topk,ratio",
         [
-            # Small shapes — tighter tolerance
-            (32, 1, 4, 128, 16, 8, 2, 64, 8, 4),
-            (32, 2, 4, 128, 32, 16, 2, 64, 16, 4),
-            # Medium shapes
-            (64, 2, 4, 128, 64, 32, 2, 64, 32, 4),
-            (128, 1, 8, 128, 32, 16, 4, 64, 16, 4),
-            # Larger topk (closer to production)
-            (64, 1, 4, 128, 128, 32, 2, 64, 64, 4),
-            (128, 1, 4, 128, 256, 64, 2, 64, 128, 4),
+            # Training-scale shapes: seq>=2048, topk>256, heads>=32
+            (2048, 1, 32, 128, 512, 128, 4, 64, 256, 4),
+            (2048, 2, 32, 128, 512, 128, 4, 64, 256, 4),
+            (4096, 1, 32, 128, 1024, 256, 4, 64, 384, 4),
+            (2048, 1, 64, 128, 512, 128, 4, 64, 512, 4),
+            (8192, 1, 32, 128, 2048, 256, 4, 64, 512, 4),
         ],
         ids=[
-            "small_B1",
-            "small_B2",
-            "medium_B2",
-            "medium_8heads",
-            "large_topk64",
-            "large_topk128",
+            "7B_B1_sq2048_topk256",
+            "7B_B2_sq2048_topk256",
+            "13B_B1_sq4096_topk384",
+            "70B_B1_sq2048_topk512",
+            "longctx_B1_sq8192_topk512",
         ],
     )
     @pytest.mark.parametrize("sparse_loss", [True, False], ids=["sparse", "dense"])
     def test_output_accuracy(
         self, sq, b, np_, hn, n_comp, win_topk, idx_nh, idx_hd,
-        indexer_topk, ratio, sparse_loss, device,
+        indexer_topk, ratio, sparse_loss, device, dsa_metrics,
     ):
         """Fused attention output matches unfused path (both with attn_sink)."""
         kv_offset = sq  # original tokens occupy [0, sq)
@@ -295,10 +304,15 @@ class TestFusedIndexerSparseAttnAccuracy:
         assert torch.isfinite(indexer_loss), f"Indexer loss is not finite: {indexer_loss.item()}"
         assert indexer_loss.item() >= 0, f"Indexer loss is negative: {indexer_loss.item()}"
 
+        dsa_metrics.record_accuracy(
+            params={"sq": sq, "b": b, "np": np_, "topk": indexer_topk, "sparse_loss": sparse_loss},
+            cos_sim=cos_sim, max_diff=max_diff, mean_diff=mean_diff,
+        )
+
     @pytest.mark.parametrize(
         "sq,b,np_,hn,n_comp,win_topk,idx_nh,idx_hd,indexer_topk,ratio",
         [
-            (64, 2, 4, 128, 64, 32, 2, 64, 32, 4),
+            (2048, 1, 32, 128, 512, 128, 4, 64, 256, 4),
         ],
     )
     def test_loss_nonzero(
@@ -326,7 +340,7 @@ class TestFusedIndexerSparseAttnAccuracy:
     @pytest.mark.parametrize(
         "sq,b,np_,hn,n_comp,win_topk,idx_nh,idx_hd,indexer_topk,ratio",
         [
-            (32, 2, 4, 128, 32, 16, 2, 64, 16, 4),
+            (2048, 1, 32, 128, 512, 128, 4, 64, 256, 4),
         ],
     )
     def test_deterministic(
@@ -349,7 +363,7 @@ class TestFusedIndexerSparseAttnAccuracy:
     @pytest.mark.parametrize(
         "sq,b,np_,hn,n_comp,win_topk,idx_nh,idx_hd,indexer_topk,ratio",
         [
-            (32, 1, 4, 128, 16, 8, 2, 64, 8, 4),
+            (2048, 1, 32, 128, 512, 128, 4, 64, 256, 4),
         ],
     )
     def test_loss_coeff_scaling(
@@ -469,24 +483,22 @@ class TestFusedIndexerSparseAttnBackward:
     @pytest.mark.parametrize(
         "sq,b,np_,hn,n_comp,win_topk,idx_nh,idx_hd,indexer_topk,ratio",
         [
-            (32, 1, 4, 128, 16, 8, 2, 64, 8, 4),
-            (32, 2, 4, 128, 32, 16, 2, 64, 16, 4),
-            (64, 2, 4, 128, 64, 32, 2, 64, 32, 4),
-            (128, 1, 8, 128, 32, 16, 4, 64, 16, 4),
-            (64, 1, 4, 128, 128, 32, 2, 64, 64, 4),
+            (2048, 1, 32, 128, 512, 128, 4, 64, 256, 4),
+            (2048, 2, 32, 128, 512, 128, 4, 64, 256, 4),
+            (4096, 1, 32, 128, 1024, 256, 4, 64, 384, 4),
+            (2048, 1, 64, 128, 512, 128, 4, 64, 512, 4),
         ],
         ids=[
-            "small_B1",
-            "small_B2",
-            "medium_B2",
-            "medium_8heads",
-            "large_topk64",
+            "7B_B1_sq2048_topk256",
+            "7B_B2_sq2048_topk256",
+            "13B_B1_sq4096_topk384",
+            "70B_B1_sq2048_topk512",
         ],
     )
     @pytest.mark.parametrize("sparse_loss", [True, False], ids=["sparse", "dense"])
     def test_grad_query_accuracy(
         self, sq, b, np_, hn, n_comp, win_topk, idx_nh, idx_hd,
-        indexer_topk, ratio, sparse_loss, device,
+        indexer_topk, ratio, sparse_loss, device, dsa_metrics,
     ):
         """Gradient w.r.t. query matches unfused reference."""
         kv_offset = sq
@@ -516,30 +528,34 @@ class TestFusedIndexerSparseAttnBackward:
             f"grad_query cosine similarity too low: {cos_sim:.6f} "
             f"(max_diff={max_diff:.4e}, mean_diff={mean_diff:.4e})"
         )
-        print(
-            f"\n  grad_query: cos_sim={cos_sim:.6f}, "
-            f"max_diff={max_diff:.4e}, mean_diff={mean_diff:.4e}"
+        logger.info(f"grad_query: cos_sim={cos_sim:.6f}")
+        logger.debug(
+            f"grad_query detail: max_diff={max_diff:.4e}, mean_diff={mean_diff:.4e}"
+        )
+        dsa_metrics.record_accuracy(
+            params={"sq": sq, "b": b, "np": np_, "topk": indexer_topk, "sparse_loss": sparse_loss},
+            cos_sim=cos_sim, max_diff=max_diff, mean_diff=mean_diff, target="grad_query",
         )
 
     @pytest.mark.parametrize(
         "sq,b,np_,hn,n_comp,win_topk,idx_nh,idx_hd,indexer_topk,ratio",
         [
-            (32, 1, 4, 128, 16, 8, 2, 64, 8, 4),
-            (32, 2, 4, 128, 32, 16, 2, 64, 16, 4),
-            (64, 2, 4, 128, 64, 32, 2, 64, 32, 4),
-            (128, 1, 8, 128, 32, 16, 4, 64, 16, 4),
+            (2048, 1, 32, 128, 512, 128, 4, 64, 256, 4),
+            (2048, 2, 32, 128, 512, 128, 4, 64, 256, 4),
+            (4096, 1, 32, 128, 1024, 256, 4, 64, 384, 4),
+            (2048, 1, 64, 128, 512, 128, 4, 64, 512, 4),
         ],
         ids=[
-            "small_B1",
-            "small_B2",
-            "medium_B2",
-            "medium_8heads",
+            "7B_B1_sq2048_topk256",
+            "7B_B2_sq2048_topk256",
+            "13B_B1_sq4096_topk384",
+            "70B_B1_sq2048_topk512",
         ],
     )
     @pytest.mark.parametrize("sparse_loss", [True, False], ids=["sparse", "dense"])
     def test_grad_kv_accuracy(
         self, sq, b, np_, hn, n_comp, win_topk, idx_nh, idx_hd,
-        indexer_topk, ratio, sparse_loss, device,
+        indexer_topk, ratio, sparse_loss, device, dsa_metrics,
     ):
         """Gradient w.r.t. kv_full matches unfused reference."""
         kv_offset = sq
@@ -567,27 +583,31 @@ class TestFusedIndexerSparseAttnBackward:
             f"grad_kv_full cosine similarity too low: {cos_sim:.6f} "
             f"(max_diff={max_diff:.4e}, mean_diff={mean_diff:.4e})"
         )
-        print(
-            f"\n  grad_kv_full: cos_sim={cos_sim:.6f}, "
-            f"max_diff={max_diff:.4e}, mean_diff={mean_diff:.4e}"
+        logger.info(f"grad_kv_full: cos_sim={cos_sim:.6f}")
+        logger.debug(
+            f"grad_kv_full detail: max_diff={max_diff:.4e}, mean_diff={mean_diff:.4e}"
+        )
+        dsa_metrics.record_accuracy(
+            params={"sq": sq, "b": b, "np": np_, "topk": indexer_topk, "sparse_loss": sparse_loss},
+            cos_sim=cos_sim, max_diff=max_diff, mean_diff=mean_diff, target="grad_kv",
         )
 
     @pytest.mark.parametrize(
         "sq,b,np_,hn,n_comp,win_topk,idx_nh,idx_hd,indexer_topk,ratio",
         [
-            (32, 1, 4, 128, 16, 8, 2, 64, 8, 4),
-            (64, 2, 4, 128, 64, 32, 2, 64, 32, 4),
-            (128, 1, 8, 128, 32, 16, 4, 64, 16, 4),
+            (2048, 1, 32, 128, 512, 128, 4, 64, 256, 4),
+            (4096, 1, 32, 128, 1024, 256, 4, 64, 384, 4),
+            (2048, 1, 64, 128, 512, 128, 4, 64, 512, 4),
         ],
         ids=[
-            "small_B1",
-            "medium_B2",
-            "medium_8heads",
+            "7B_B1_sq2048_topk256",
+            "13B_B1_sq4096_topk384",
+            "70B_B1_sq2048_topk512",
         ],
     )
     def test_grad_attn_sink_accuracy(
         self, sq, b, np_, hn, n_comp, win_topk, idx_nh, idx_hd,
-        indexer_topk, ratio, device,
+        indexer_topk, ratio, device, dsa_metrics,
     ):
         """Gradient w.r.t. attn_sink matches unfused reference."""
         kv_offset = sq
@@ -616,18 +636,22 @@ class TestFusedIndexerSparseAttnBackward:
             f"grad_attn_sink cosine similarity too low: {cos_sim:.6f} "
             f"(max_diff={max_diff:.4e}, mean_diff={mean_diff:.4e})"
         )
-        print(
-            f"\n  grad_attn_sink: cos_sim={cos_sim:.6f}, "
-            f"max_diff={max_diff:.4e}, mean_diff={mean_diff:.4e}"
+        logger.info(f"grad_attn_sink: cos_sim={cos_sim:.6f}")
+        logger.debug(
+            f"grad_attn_sink detail: max_diff={max_diff:.4e}, mean_diff={mean_diff:.4e}"
+        )
+        dsa_metrics.record_accuracy(
+            params={"sq": sq, "b": b, "np": np_, "topk": indexer_topk},
+            cos_sim=cos_sim, max_diff=max_diff, mean_diff=mean_diff, target="grad_attn_sink",
         )
 
     @pytest.mark.parametrize(
         "sq,b,np_,hn,n_comp,win_topk,idx_nh,idx_hd,indexer_topk,ratio",
         [
-            (32, 1, 4, 128, 16, 8, 2, 64, 8, 4),
-            (64, 2, 4, 128, 64, 32, 2, 64, 32, 4),
+            (2048, 1, 32, 128, 512, 128, 4, 64, 256, 4),
+            (4096, 1, 32, 128, 1024, 256, 4, 64, 384, 4),
         ],
-        ids=["small", "medium"],
+        ids=["7B_sq2048", "13B_sq4096"],
     )
     def test_backward_no_nan_inf(
         self, sq, b, np_, hn, n_comp, win_topk, idx_nh, idx_hd,
@@ -688,27 +712,25 @@ class TestFusedIndexerSparseAttnPerformance:
     @pytest.mark.parametrize(
         "sq,b,np_,hn,n_comp,win_topk,idx_nh,idx_hd,indexer_topk,ratio",
         [
-            # Production-scale shapes with large topk
-            (512, 1, 16, 128, 128, 64, 4, 64, 64, 4),
-            (512, 2, 16, 128, 256, 64, 4, 64, 128, 4),
-            (1024, 1, 16, 128, 256, 128, 4, 64, 128, 4),
-            (1024, 1, 16, 128, 512, 128, 4, 64, 256, 4),
-            (2048, 1, 8, 128, 512, 128, 4, 64, 256, 4),
-            (2048, 1, 8, 128, 512, 128, 4, 64, 512, 4),
+            # Training-scale shapes: seq>=2048, topk>256, heads>=32
+            (2048, 1, 32, 128, 512, 128, 4, 64, 256, 4),
+            (2048, 2, 32, 128, 512, 128, 4, 64, 256, 4),
+            (4096, 1, 32, 128, 1024, 256, 4, 64, 384, 4),
+            (2048, 1, 64, 128, 512, 128, 4, 64, 512, 4),
+            (8192, 1, 32, 128, 2048, 256, 4, 64, 512, 4),
         ],
         ids=[
-            "sq512_b1_topk64",
-            "sq512_b2_topk128",
-            "sq1024_b1_topk128",
-            "sq1024_b1_topk256",
-            "sq2048_b1_topk256",
-            "sq2048_b1_topk512",
+            "7B_B1_sq2048_topk256",
+            "7B_B2_sq2048_topk256",
+            "13B_B1_sq4096_topk384",
+            "70B_B1_sq2048_topk512",
+            "longctx_B1_sq8192_topk512",
         ],
     )
     @pytest.mark.parametrize("sparse_loss", [True, False], ids=["sparse", "dense"])
     def test_performance_forward(
         self, sq, b, np_, hn, n_comp, win_topk, idx_nh, idx_hd,
-        indexer_topk, ratio, sparse_loss, device,
+        indexer_topk, ratio, sparse_loss, device, dsa_metrics,
     ):
         """Measure forward performance: fused Triton vs unfused CSA + indexer loss."""
         kv_offset = sq
@@ -835,13 +857,16 @@ class TestFusedIndexerSparseAttnPerformance:
 
         speedup = time_unfused / max(time_fused, 1e-6)
 
-        print(
-            f"\n  [sq={sq}, b={b}, np={np_}, topk={indexer_topk}, "
-            f"win={win_topk}, sparse_loss={sparse_loss}]"
+        logger.info(
+            f"[sq={sq}, b={b}, np={np_}, topk={indexer_topk}, win={win_topk}, "
+            f"sparse_loss={sparse_loss}] "
+            f"fused={time_fused:.3f}ms, unfused={time_unfused:.3f}ms, "
+            f"speedup={speedup:.2f}x"
         )
-        print(f"    Fused (Triton):  {time_fused:.3f} ms")
-        print(f"    Unfused (CSA):   {time_unfused:.3f} ms")
-        print(f"    Speedup:         {speedup:.2f}x")
+        dsa_metrics.record_performance(
+            params={"sq": sq, "b": b, "np": np_, "topk": indexer_topk, "sparse_loss": sparse_loss},
+            fused_ms=time_fused, unfused_ms=time_unfused, speedup=speedup, label="fwd",
+        )
 
         # The fused path should not be catastrophically slower
         # (it may be slower at very small shapes due to kernel launch overhead)
@@ -852,19 +877,19 @@ class TestFusedIndexerSparseAttnPerformance:
     @pytest.mark.parametrize(
         "sq,b,np_,hn,n_comp,win_topk,idx_nh,idx_hd,indexer_topk,ratio",
         [
-            (512, 1, 16, 128, 128, 64, 4, 64, 64, 4),
-            (1024, 1, 16, 128, 256, 128, 4, 64, 128, 4),
-            (2048, 1, 8, 128, 512, 128, 4, 64, 256, 4),
+            (2048, 1, 32, 128, 512, 128, 4, 64, 256, 4),
+            (4096, 1, 32, 128, 1024, 256, 4, 64, 384, 4),
+            (2048, 1, 64, 128, 512, 128, 4, 64, 512, 4),
         ],
         ids=[
-            "sq512_topk64",
-            "sq1024_topk128",
-            "sq2048_topk256",
+            "7B_sq2048_topk256",
+            "13B_sq4096_topk384",
+            "70B_sq2048_topk512",
         ],
     )
     def test_performance_backward(
         self, sq, b, np_, hn, n_comp, win_topk, idx_nh, idx_hd,
-        indexer_topk, ratio, device,
+        indexer_topk, ratio, device, dsa_metrics,
     ):
         """Measure backward pass performance for the fused path."""
         kv_offset = sq
@@ -893,20 +918,24 @@ class TestFusedIndexerSparseAttnPerformance:
 
         time_bwd = self._benchmark(run_fwd_bwd, warmup=5, iters=20)
 
-        print(
-            f"\n  [sq={sq}, b={b}, np={np_}, topk={indexer_topk}, win={win_topk}]"
+        logger.info(
+            f"[sq={sq}, b={b}, np={np_}, topk={indexer_topk}, win={win_topk}] "
+            f"fwd+bwd={time_bwd:.3f}ms"
         )
-        print(f"    Fwd+Bwd (Triton): {time_bwd:.3f} ms")
+        dsa_metrics.record_performance(
+            params={"sq": sq, "b": b, "np": np_, "topk": indexer_topk},
+            fused_ms=time_bwd, unfused_ms=time_bwd, speedup=1.0, label="bwd",
+        )
 
     @pytest.mark.parametrize(
         "sq,b,np_,hn,n_comp,win_topk,idx_nh,idx_hd,indexer_topk,ratio",
         [
-            (1024, 1, 16, 128, 256, 128, 4, 64, 128, 4),
+            (2048, 1, 32, 128, 512, 128, 4, 64, 256, 4),
         ],
     )
     def test_peak_memory(
         self, sq, b, np_, hn, n_comp, win_topk, idx_nh, idx_hd,
-        indexer_topk, ratio, device,
+        indexer_topk, ratio, device, dsa_metrics,
     ):
         """Measure peak GPU memory usage for fused vs unfused paths."""
         kv_offset = sq
@@ -932,31 +961,36 @@ class TestFusedIndexerSparseAttnPerformance:
         torch.cuda.synchronize()
         mem_unfused_peak = torch.cuda.max_memory_allocated(device) - mem_before
 
-        print(
-            f"\n  [sq={sq}, b={b}, np={np_}, topk={indexer_topk}]"
+        logger.info(
+            f"[sq={sq}, b={b}, np={np_}, topk={indexer_topk}] "
+            f"fused={mem_fused_peak / 1024**2:.1f}MB, "
+            f"unfused={mem_unfused_peak / 1024**2:.1f}MB"
         )
-        print(f"    Fused peak memory:   {mem_fused_peak / 1024**2:.1f} MB")
-        print(f"    Unfused peak memory: {mem_unfused_peak / 1024**2:.1f} MB")
+        dsa_metrics.record_memory(
+            params={"sq": sq, "b": b, "np": np_, "topk": indexer_topk},
+            fused_mb=mem_fused_peak / 1024**2, unfused_mb=mem_unfused_peak / 1024**2,
+            ratio=mem_unfused_peak / max(mem_fused_peak, 1),
+        )
 
     @pytest.mark.parametrize(
         "sq,b,np_,hn,n_comp,win_topk,idx_nh,idx_hd,indexer_topk,ratio",
         [
-            (512, 1, 16, 128, 128, 64, 4, 64, 64, 4),
-            (512, 2, 16, 128, 256, 64, 4, 64, 128, 4),
-            (1024, 1, 16, 128, 256, 128, 4, 64, 128, 4),
-            (2048, 1, 8, 128, 512, 128, 4, 64, 256, 4),
+            (2048, 1, 32, 128, 512, 128, 4, 64, 256, 4),
+            (2048, 2, 32, 128, 512, 128, 4, 64, 256, 4),
+            (4096, 1, 32, 128, 1024, 256, 4, 64, 384, 4),
+            (2048, 1, 64, 128, 512, 128, 4, 64, 512, 4),
         ],
         ids=[
-            "sq512_b1_topk64",
-            "sq512_b2_topk128",
-            "sq1024_b1_topk128",
-            "sq2048_b1_topk256",
+            "7B_B1_sq2048_topk256",
+            "7B_B2_sq2048_topk256",
+            "13B_B1_sq4096_topk384",
+            "70B_B1_sq2048_topk512",
         ],
     )
     @pytest.mark.parametrize("sparse_loss", [True, False], ids=["sparse", "dense"])
     def test_performance_end_to_end(
         self, sq, b, np_, hn, n_comp, win_topk, idx_nh, idx_hd,
-        indexer_topk, ratio, sparse_loss, device,
+        indexer_topk, ratio, sparse_loss, device, dsa_metrics,
     ):
         """End-to-end (forward + backward) performance: fused Triton vs unfused CSA."""
         kv_offset = sq
@@ -1155,19 +1189,23 @@ class TestFusedIndexerSparseAttnPerformance:
         time_unfused = self._benchmark(run_unfused_e2e, warmup=5, iters=20)
         speedup = time_unfused / max(time_fused, 1e-6)
 
-        print(
-            f"\n  [sq={sq}, b={b}, np={np_}, topk={indexer_topk}, "
-            f"win={win_topk}, sparse_loss={sparse_loss}]"
+        logger.info(
+            f"[sq={sq}, b={b}, np={np_}, topk={indexer_topk}, win={win_topk}, "
+            f"sparse_loss={sparse_loss}] "
+            f"fused_e2e={time_fused:.3f}ms, unfused_e2e={time_unfused:.3f}ms, "
+            f"speedup={speedup:.2f}x"
         )
-        print(f"    Fused E2E (Triton):  {time_fused:.3f} ms")
-        print(f"    Unfused E2E (CSA):   {time_unfused:.3f} ms")
-        print(f"    E2E Speedup:         {speedup:.2f}x")
+        dsa_metrics.record_performance(
+            params={"sq": sq, "b": b, "np": np_, "topk": indexer_topk, "sparse_loss": sparse_loss},
+            fused_ms=time_fused, unfused_ms=time_unfused, speedup=speedup, label="e2e",
+        )
 
 
 # ---------------------------------------------------------------------------
 # Module-level tests: CompressedSparseAttention unfused vs fused (triton)
 # ---------------------------------------------------------------------------
 
+from contextlib import contextmanager
 from unittest.mock import patch
 
 from megatron.core.transformer.experimental_attention_variant.csa import (
@@ -1179,7 +1217,57 @@ from megatron.core.transformer.experimental_attention_variant.csa import (
     CSAIndexerSubmodules,
 )
 from megatron.core.transformer.transformer_config import MLATransformerConfig
+from megatron.plugin.dsa_kernel.triton_dsa_kernels import (
+    dsa_sparse_attn as _triton_dsa_sparse_attn_raw,
+)
 from tests.unit_tests.test_utilities import Utils
+
+
+# ---------------------------------------------------------------------------
+# OOM guard — unfused path can OOM at large sequence lengths
+# ---------------------------------------------------------------------------
+
+
+@contextmanager
+def _oom_guard():
+    """Convert CUDA OOM into pytest.skip — unfused path is memory-hungry at 4k+."""
+    try:
+        yield
+    except torch.cuda.OutOfMemoryError:
+        torch.cuda.empty_cache()
+        pytest.skip("CUDA OOM on unfused path at this sequence length")
+
+
+# ---------------------------------------------------------------------------
+# Triton dsa_sparse_attn wrapper (SBHD interface matching dsa_kernels.py)
+# ---------------------------------------------------------------------------
+
+
+def _triton_dsa_sparse_attn(
+    query, kv, attn_sink, topk_idxs, softmax_scale, topk_length=None, indexer_topk=0
+):
+    """SBHD wrapper around triton plugin's flat dsa_sparse_attn.
+
+    Matches the signature of ``dsa_kernels.dsa_sparse_attn`` so it can be
+    monkey-patched into csa.py for tests without FlashMLA/cuDNN.
+    """
+    sq, b, np_, d = query.shape
+    skv = kv.shape[0]
+    q_flat = query.reshape(sq * b, np_, d)
+    kv_flat = kv.reshape(skv * b, d)
+    # triton expects (total_Sq, H_kv, TopK); dsa_kernels produces (total_Sq, TopK)
+    if topk_idxs.dim() == 2:
+        topk_idxs = topk_idxs.unsqueeze(1)
+    out_flat, _lse, _ = _triton_dsa_sparse_attn_raw(
+        q_flat, kv_flat, topk_idxs, softmax_scale, d, attn_sink, topk_length, indexer_topk
+    )
+    d_v = out_flat.shape[-1]
+    return out_flat.reshape(sq, b, np_ * d_v)
+
+
+_PATCH_DSA_SPARSE_ATTN = (
+    'megatron.core.transformer.experimental_attention_variant.csa.dsa_sparse_attn'
+)
 
 try:
     from fast_hadamard_transform import hadamard_transform as _hadamard_transform
@@ -1358,16 +1446,16 @@ class TestCSAFusedVsUnfusedAccuracy:
     @pytest.mark.parametrize(
         "sq,b,num_heads,v_head_dim,window_size,indexer_topk",
         [
-            (64, 1, 8, 128, 16, 16),
-            (128, 1, 8, 128, 32, 32),
-            (256, 2, 8, 128, 64, 64),
+            (2048, 1, 32, 128, 128, 256),
+            (4096, 1, 32, 128, 256, 384),
+            (2048, 1, 64, 128, 128, 512),
         ],
-        ids=["sq64_topk16", "sq128_topk32", "sq256_topk64"],
+        ids=["7B_sq2048_topk256", "13B_sq4096_topk384", "70B_sq2048_topk512"],
     )
     @pytest.mark.parametrize("sparse_loss", [True, False], ids=["sparse", "dense"])
     def test_output_accuracy(
         self, sq, b, num_heads, v_head_dim, window_size, indexer_topk,
-        sparse_loss, device,
+        sparse_loss, device, dsa_metrics,
     ):
         """Fused (triton) output matches unfused CSA path at module level."""
         with _hadamard_patches():
@@ -1388,15 +1476,16 @@ class TestCSAFusedVsUnfusedAccuracy:
 
             # --- Unfused path ---
             csa.apply_dsa_kernel_fusion = False
-            torch.manual_seed(7)
-            out_unfused = csa(
-                query=inputs["query"].clone(),
-                key=inputs["key"].clone(),
-                value=inputs["value"].clone(),
-                attention_mask=None,
-                x=inputs["x"].clone(),
-                qr=inputs["qr"].clone(),
-            )
+            with _oom_guard():
+                torch.manual_seed(7)
+                out_unfused = csa(
+                    query=inputs["query"].clone(),
+                    key=inputs["key"].clone(),
+                    value=inputs["value"].clone(),
+                    attention_mask=None,
+                    x=inputs["x"].clone(),
+                    qr=inputs["qr"].clone(),
+                )
 
             # --- Fused path (triton) ---
             csa.apply_dsa_kernel_fusion = True
@@ -1424,26 +1513,30 @@ class TestCSAFusedVsUnfusedAccuracy:
             max_diff = abs_diff.max().item()
             mean_diff = abs_diff.mean().item()
 
-            print(
-                f"\n  [sq={sq}, b={b}, np={num_heads}, topk={indexer_topk}, "
-                f"sparse_loss={sparse_loss}]"
+            logger.info(
+                f"[sq={sq}, b={b}, np={num_heads}, topk={indexer_topk}, "
+                f"sparse_loss={sparse_loss}] cos_sim={cos_sim:.6f}"
             )
-            print(f"    cos_sim={cos_sim:.6f}, max_diff={max_diff:.4e}, mean_diff={mean_diff:.4e}")
+            logger.debug(f"  max_diff={max_diff:.4e}, mean_diff={mean_diff:.4e}")
 
             assert cos_sim > 0.95, (
                 f"Module-level output mismatch: cos_sim={cos_sim:.6f}"
+            )
+            dsa_metrics.record_accuracy(
+                params={"sq": sq, "b": b, "np": num_heads, "topk": indexer_topk, "sparse_loss": sparse_loss},
+                cos_sim=cos_sim, max_diff=max_diff, mean_diff=mean_diff, target="module_output",
             )
 
     @pytest.mark.parametrize(
         "sq,b,num_heads,v_head_dim,window_size,indexer_topk",
         [
-            (128, 1, 8, 128, 32, 32),
+            (2048, 1, 32, 128, 128, 256),
         ],
     )
     @pytest.mark.parametrize("sparse_loss", [True, False], ids=["sparse", "dense"])
     def test_grad_accuracy(
         self, sq, b, num_heads, v_head_dim, window_size, indexer_topk,
-        sparse_loss, device,
+        sparse_loss, device, dsa_metrics,
     ):
         """Gradients from fused (triton) path match unfused CSA path."""
         with _hadamard_patches():
@@ -1466,11 +1559,12 @@ class TestCSAFusedVsUnfusedAccuracy:
             csa.apply_dsa_kernel_fusion = False
             query_u = inputs["query"].clone().requires_grad_(True)
             key_u = inputs["key"].clone().requires_grad_(True)
-            out_u = csa(
-                query=query_u, key=key_u, value=key_u.clone(),
-                attention_mask=None, x=inputs["x"].clone(), qr=inputs["qr"].clone(),
-            )
-            out_u.sum().backward()
+            with _oom_guard():
+                out_u = csa(
+                    query=query_u, key=key_u, value=key_u.clone(),
+                    attention_mask=None, x=inputs["x"].clone(), qr=inputs["qr"].clone(),
+                )
+                out_u.sum().backward()
             grad_q_unfused = query_u.grad.float().clone()
             grad_k_unfused = key_u.grad.float().clone()
 
@@ -1500,13 +1594,19 @@ class TestCSAFusedVsUnfusedAccuracy:
                 grad_k_unfused.reshape(-1).unsqueeze(0),
             ).item()
 
-            print(
-                f"\n  grad_query cos_sim={cos_q:.6f}, "
-                f"grad_key cos_sim={cos_k:.6f}"
-            )
+            logger.info(f"grad_query cos_sim={cos_q:.6f}, grad_key cos_sim={cos_k:.6f}")
 
             assert cos_q > 0.90, f"grad_query cos_sim too low: {cos_q:.6f}"
             assert cos_k > 0.90, f"grad_key cos_sim too low: {cos_k:.6f}"
+
+            dsa_metrics.record_accuracy(
+                params={"sq": sq, "b": b, "np": num_heads, "topk": indexer_topk, "sparse_loss": sparse_loss},
+                cos_sim=cos_q, target="module_grad_query",
+            )
+            dsa_metrics.record_accuracy(
+                params={"sq": sq, "b": b, "np": num_heads, "topk": indexer_topk, "sparse_loss": sparse_loss},
+                cos_sim=cos_k, target="module_grad_key",
+            )
 
 
 class TestCSAFusedVsUnfusedPerformance:
@@ -1549,16 +1649,16 @@ class TestCSAFusedVsUnfusedPerformance:
     @pytest.mark.parametrize(
         "sq,b,num_heads,v_head_dim,window_size,indexer_topk",
         [
-            (512, 1, 16, 128, 64, 64),
-            (1024, 1, 16, 128, 128, 128),
-            (2048, 1, 8, 128, 128, 256),
+            (2048, 1, 32, 128, 128, 256),
+            (4096, 1, 32, 128, 256, 384),
+            (2048, 1, 64, 128, 128, 512),
         ],
-        ids=["sq512_topk64", "sq1024_topk128", "sq2048_topk256"],
+        ids=["7B_sq2048_topk256", "13B_sq4096_topk384", "70B_sq2048_topk512"],
     )
     @pytest.mark.parametrize("sparse_loss", [True, False], ids=["sparse", "dense"])
     def test_e2e_performance(
         self, sq, b, num_heads, v_head_dim, window_size, indexer_topk,
-        sparse_loss, device,
+        sparse_loss, device, dsa_metrics,
     ):
         """End-to-end (forward + backward) module-level performance comparison."""
         with _hadamard_patches():
@@ -1593,7 +1693,8 @@ class TestCSAFusedVsUnfusedPerformance:
                 key_u.grad = None
                 csa.zero_grad()
 
-            time_unfused = self._benchmark(run_unfused)
+            with _oom_guard():
+                time_unfused = self._benchmark(run_unfused)
 
             # --- Fused benchmark (triton) ---
             csa.apply_dsa_kernel_fusion = True
@@ -1615,27 +1716,31 @@ class TestCSAFusedVsUnfusedPerformance:
 
             speedup = time_unfused / max(time_fused, 1e-6)
 
-            print(
-                f"\n  [sq={sq}, b={b}, np={num_heads}, topk={indexer_topk}, "
-                f"win={window_size}, sparse_loss={sparse_loss}]"
+            logger.info(
+                f"[sq={sq}, b={b}, np={num_heads}, topk={indexer_topk}, "
+                f"win={window_size}, sparse_loss={sparse_loss}] "
+                f"unfused={time_unfused:.3f}ms, fused={time_fused:.3f}ms, "
+                f"speedup={speedup:.2f}x"
             )
-            print(f"    Unfused CSA E2E:    {time_unfused:.3f} ms")
-            print(f"    Fused Triton E2E:   {time_fused:.3f} ms")
-            print(f"    Speedup:            {speedup:.2f}x")
+
+            dsa_metrics.record_performance(
+                params={"sq": sq, "b": b, "np": num_heads, "topk": indexer_topk, "win": window_size, "sparse_loss": sparse_loss},
+                fused_ms=time_fused, unfused_ms=time_unfused, speedup=speedup, label="module_e2e",
+            )
 
     @pytest.mark.parametrize(
         "sq,b,num_heads,v_head_dim,window_size,indexer_topk",
         [
-            (512, 1, 16, 128, 64, 64),
-            (1024, 1, 16, 128, 128, 128),
-            (2048, 1, 8, 128, 128, 256),
+            (2048, 1, 32, 128, 128, 256),
+            (4096, 1, 32, 128, 256, 384),
+            (2048, 1, 64, 128, 128, 512),
         ],
-        ids=["sq512_topk64", "sq1024_topk128", "sq2048_topk256"],
+        ids=["7B_sq2048_topk256", "13B_sq4096_topk384", "70B_sq2048_topk512"],
     )
     @pytest.mark.parametrize("sparse_loss", [True, False], ids=["sparse", "dense"])
     def test_e2e_memory(
         self, sq, b, num_heads, v_head_dim, window_size, indexer_topk,
-        sparse_loss, device,
+        sparse_loss, device, dsa_metrics,
     ):
         """Peak GPU memory comparison: fused vs unfused E2E (forward + backward)."""
         with _hadamard_patches():
@@ -1660,28 +1765,29 @@ class TestCSAFusedVsUnfusedPerformance:
             query_u = inputs["query"].clone().requires_grad_(True)
             key_u = inputs["key"].clone().requires_grad_(True)
 
-            # Warmup
-            out = csa(
-                query=query_u, key=key_u, value=key_u.clone(),
-                attention_mask=None, x=inputs["x"], qr=inputs["qr"],
-            )
-            out.sum().backward()
-            query_u.grad = None
-            key_u.grad = None
-            csa.zero_grad()
-            torch.cuda.synchronize()
+            with _oom_guard():
+                # Warmup
+                out = csa(
+                    query=query_u, key=key_u, value=key_u.clone(),
+                    attention_mask=None, x=inputs["x"], qr=inputs["qr"],
+                )
+                out.sum().backward()
+                query_u.grad = None
+                key_u.grad = None
+                csa.zero_grad()
+                torch.cuda.synchronize()
 
-            torch.cuda.reset_peak_memory_stats(device)
-            torch.cuda.synchronize()
-            mem_before_unfused = torch.cuda.memory_allocated(device)
+                torch.cuda.reset_peak_memory_stats(device)
+                torch.cuda.synchronize()
+                mem_before_unfused = torch.cuda.memory_allocated(device)
 
-            out = csa(
-                query=query_u, key=key_u, value=key_u.clone(),
-                attention_mask=None, x=inputs["x"], qr=inputs["qr"],
-            )
-            out.sum().backward()
-            torch.cuda.synchronize()
-            mem_unfused_peak = torch.cuda.max_memory_allocated(device) - mem_before_unfused
+                out = csa(
+                    query=query_u, key=key_u, value=key_u.clone(),
+                    attention_mask=None, x=inputs["x"], qr=inputs["qr"],
+                )
+                out.sum().backward()
+                torch.cuda.synchronize()
+                mem_unfused_peak = torch.cuda.max_memory_allocated(device) - mem_before_unfused
 
             query_u.grad = None
             key_u.grad = None
@@ -1720,10 +1826,652 @@ class TestCSAFusedVsUnfusedPerformance:
 
             ratio = mem_unfused_peak / max(mem_fused_peak, 1)
 
-            print(
-                f"\n  [sq={sq}, b={b}, np={num_heads}, topk={indexer_topk}, "
-                f"win={window_size}, sparse_loss={sparse_loss}]"
+            logger.info(
+                f"[sq={sq}, b={b}, np={num_heads}, topk={indexer_topk}, "
+                f"win={window_size}, sparse_loss={sparse_loss}] "
+                f"unfused={mem_unfused_peak / 1024**2:.1f}MB, "
+                f"fused={mem_fused_peak / 1024**2:.1f}MB, ratio={ratio:.2f}x"
             )
-            print(f"    Unfused peak memory: {mem_unfused_peak / 1024**2:.1f} MB")
-            print(f"    Fused peak memory:   {mem_fused_peak / 1024**2:.1f} MB")
-            print(f"    Memory ratio:        {ratio:.2f}x")
+
+            dsa_metrics.record_memory(
+                params={"sq": sq, "b": b, "np": num_heads, "topk": indexer_topk, "win": window_size, "sparse_loss": sparse_loss},
+                fused_mb=mem_fused_peak / 1024**2, unfused_mb=mem_unfused_peak / 1024**2, ratio=ratio,
+            )
+
+
+# ---------------------------------------------------------------------------
+# No-indexer tests: compress_ratio=0 (window-only) and compress_ratio=128
+# ---------------------------------------------------------------------------
+
+
+class TestCSANoIndexerFusedVsUnfused:
+    """E2E accuracy: CompressedSparseAttention with no indexer (ratio=0 or ratio=128).
+
+    Tests the _forward_fused_no_indexer path vs _forward_unfused_csa.
+    - ratio=0:   window-only attention, no compressor, no indexer.
+    - ratio=128: attend-all-compressed, compressor built but no indexer.
+
+    Both paths rely on dsa_sparse_attn (patched with triton) for the fused side
+    and unfused_compressed_sparse_attn for the unfused side.
+    """
+
+    @pytest.fixture(scope='class', autouse=True)
+    def setup_class(self, request):
+        Utils.initialize_model_parallel(
+            tensor_model_parallel_size=1, pipeline_model_parallel_size=1
+        )
+        yield
+        Utils.destroy_model_parallel()
+
+    @pytest.fixture
+    def device(self):
+        return torch.device("cuda:0")
+
+    @pytest.mark.parametrize(
+        "compress_ratio,sq,b,num_heads,v_head_dim,window_size",
+        [
+            (0,   2048, 1, 32, 128, 128),
+            (0,   4096, 1, 32, 128, 256),
+            (128, 2048, 1, 32, 128, 128),
+            (128, 4096, 1, 32, 128, 256),
+        ],
+        ids=["win_only_2k", "win_only_4k", "ratio128_2k", "ratio128_4k"],
+    )
+    def test_output_accuracy_no_indexer(
+        self, compress_ratio, sq, b, num_heads, v_head_dim, window_size, device, dsa_metrics,
+    ):
+        """Fused (triton) output matches unfused CSA path for no-indexer configs."""
+        with _hadamard_patches():
+            config = _make_test_mla_config(
+                num_attention_heads=num_heads,
+                v_head_dim=v_head_dim,
+                csa_window_size=window_size,
+                dsa_indexer_topk=64,
+                dsa_indexer_loss_coeff=0.0,
+            )
+
+            torch.manual_seed(42)
+            csa = _build_csa_module(config, compress_ratio=compress_ratio)
+            csa.train()
+
+            inputs = _make_csa_inputs(sq, b, config, device)
+
+            # --- Unfused path ---
+            csa.apply_dsa_kernel_fusion = False
+            with _oom_guard():
+                torch.manual_seed(7)
+                out_unfused = csa(
+                    query=inputs["query"].clone(),
+                    key=inputs["key"].clone(),
+                    value=inputs["value"].clone(),
+                    attention_mask=None,
+                    x=inputs["x"].clone(),
+                    qr=inputs["qr"].clone(),
+                )
+
+            # --- Fused path (triton dsa_sparse_attn) ---
+            csa.apply_dsa_kernel_fusion = True
+            with patch(_PATCH_DSA_SPARSE_ATTN, _triton_dsa_sparse_attn):
+                torch.manual_seed(7)
+                out_fused = csa(
+                    query=inputs["query"].clone(),
+                    key=inputs["key"].clone(),
+                    value=inputs["value"].clone(),
+                    attention_mask=None,
+                    x=inputs["x"].clone(),
+                    qr=inputs["qr"].clone(),
+                )
+
+            # Compare
+            out_f = out_fused.float()
+            out_u = out_unfused.float()
+
+            cos_sim = torch.nn.functional.cosine_similarity(
+                out_f.reshape(-1).unsqueeze(0),
+                out_u.reshape(-1).unsqueeze(0),
+            ).item()
+
+            abs_diff = (out_f - out_u).abs()
+            max_diff = abs_diff.max().item()
+            mean_diff = abs_diff.mean().item()
+
+            logger.info(
+                f"[ratio={compress_ratio}, sq={sq}, b={b}, np={num_heads}, "
+                f"win={window_size}] cos_sim={cos_sim:.6f}"
+            )
+            logger.debug(f"  max_diff={max_diff:.4e}, mean_diff={mean_diff:.4e}")
+
+            assert cos_sim > 0.95, (
+                f"No-indexer output mismatch: cos_sim={cos_sim:.6f}"
+            )
+
+            dsa_metrics.record_accuracy(
+                params={"ratio": compress_ratio, "sq": sq, "b": b, "np": num_heads, "win": window_size},
+                cos_sim=cos_sim, max_diff=max_diff, mean_diff=mean_diff, target="no_indexer_output",
+            )
+
+    @pytest.mark.parametrize(
+        "compress_ratio,sq,b,num_heads,v_head_dim,window_size",
+        [
+            (0,   2048, 1, 32, 128, 128),
+            (0,   4096, 1, 32, 128, 256),
+            (128, 2048, 1, 32, 128, 128),
+            (128, 4096, 1, 32, 128, 256),
+        ],
+        ids=["win_only_2k", "win_only_4k", "ratio128_2k", "ratio128_4k"],
+    )
+    def test_grad_accuracy_no_indexer(
+        self, compress_ratio, sq, b, num_heads, v_head_dim, window_size, device, dsa_metrics,
+    ):
+        """Gradients from fused (triton) path match unfused CSA path for no-indexer configs."""
+        with _hadamard_patches():
+            config = _make_test_mla_config(
+                num_attention_heads=num_heads,
+                v_head_dim=v_head_dim,
+                csa_window_size=window_size,
+                dsa_indexer_topk=64,
+                dsa_indexer_loss_coeff=0.0,
+            )
+
+            torch.manual_seed(42)
+            csa = _build_csa_module(config, compress_ratio=compress_ratio)
+            csa.train()
+
+            inputs = _make_csa_inputs(sq, b, config, device)
+
+            # --- Unfused path with grad ---
+            csa.apply_dsa_kernel_fusion = False
+            query_u = inputs["query"].clone().requires_grad_(True)
+            key_u = inputs["key"].clone().requires_grad_(True)
+            with _oom_guard():
+                out_u = csa(
+                    query=query_u, key=key_u, value=key_u.clone(),
+                    attention_mask=None, x=inputs["x"].clone(), qr=inputs["qr"].clone(),
+                )
+                out_u.sum().backward()
+            grad_q_unfused = query_u.grad.float().clone()
+            grad_k_unfused = key_u.grad.float().clone()
+
+            csa.zero_grad()
+
+            # --- Fused path with grad (triton dsa_sparse_attn) ---
+            csa.apply_dsa_kernel_fusion = True
+            query_f = inputs["query"].clone().requires_grad_(True)
+            key_f = inputs["key"].clone().requires_grad_(True)
+            with patch(_PATCH_DSA_SPARSE_ATTN, _triton_dsa_sparse_attn):
+                out_f = csa(
+                    query=query_f, key=key_f, value=key_f.clone(),
+                    attention_mask=None, x=inputs["x"].clone(), qr=inputs["qr"].clone(),
+                )
+                torch.cuda.synchronize()
+                out_f.sum().backward()
+                torch.cuda.synchronize()
+            grad_q_fused = query_f.grad.float().clone()
+            grad_k_fused = key_f.grad.float().clone()
+
+            # Debug: check for NaN/Inf/zero in fused gradients
+            logger.debug(f"grad_q_fused: nan={torch.isnan(grad_q_fused).any().item()}, "
+                  f"inf={torch.isinf(grad_q_fused).any().item()}, "
+                  f"all_zero={(grad_q_fused == 0).all().item()}, "
+                  f"norm={grad_q_fused.norm().item():.4e}")
+            logger.debug(f"grad_k_fused: nan={torch.isnan(grad_k_fused).any().item()}, "
+                  f"inf={torch.isinf(grad_k_fused).any().item()}, "
+                  f"all_zero={(grad_k_fused == 0).all().item()}, "
+                  f"norm={grad_k_fused.norm().item():.4e}")
+            logger.debug(f"grad_q_unfused: norm={grad_q_unfused.norm().item():.4e}")
+            logger.debug(f"grad_k_unfused: norm={grad_k_unfused.norm().item():.4e}")
+
+            # Compare grad_query
+            cos_q = torch.nn.functional.cosine_similarity(
+                grad_q_fused.reshape(-1).unsqueeze(0),
+                grad_q_unfused.reshape(-1).unsqueeze(0),
+            ).item()
+            # Compare grad_key
+            cos_k = torch.nn.functional.cosine_similarity(
+                grad_k_fused.reshape(-1).unsqueeze(0),
+                grad_k_unfused.reshape(-1).unsqueeze(0),
+            ).item()
+
+            logger.info(
+                f"[ratio={compress_ratio}, sq={sq}, np={num_heads}, win={window_size}] "
+                f"grad_query cos_sim={cos_q:.6f}, grad_key cos_sim={cos_k:.6f}"
+            )
+
+            assert cos_q > 0.90, f"grad_query cos_sim too low: {cos_q:.6f}"
+            assert cos_k > 0.90, f"grad_key cos_sim too low: {cos_k:.6f}"
+
+            dsa_metrics.record_accuracy(
+                params={"ratio": compress_ratio, "sq": sq, "np": num_heads, "win": window_size},
+                cos_sim=cos_q, target="no_indexer_grad_query",
+            )
+            dsa_metrics.record_accuracy(
+                params={"ratio": compress_ratio, "sq": sq, "np": num_heads, "win": window_size},
+                cos_sim=cos_k, target="no_indexer_grad_key",
+            )
+
+
+# ---------------------------------------------------------------------------
+# No-indexer end-to-end performance tests
+# ---------------------------------------------------------------------------
+
+
+class TestCSANoIndexerPerformance:
+    """E2E performance: CompressedSparseAttention no-indexer path.
+
+    Measures forward+backward timing for the fused (triton dsa_sparse_attn)
+    path vs the unfused CSA path when no indexer is used (ratio=0 or ratio=128).
+    """
+
+    @pytest.fixture(scope='class', autouse=True)
+    def setup_class(self, request):
+        Utils.initialize_model_parallel(
+            tensor_model_parallel_size=1, pipeline_model_parallel_size=1
+        )
+        yield
+        Utils.destroy_model_parallel()
+
+    @pytest.fixture
+    def device(self):
+        return torch.device("cuda:0")
+
+    @staticmethod
+    def _benchmark(fn, warmup: int = 5, iters: int = 20) -> float:
+        """Benchmark a CUDA function. Returns median elapsed ms."""
+        for _ in range(warmup):
+            fn()
+        torch.cuda.synchronize()
+
+        times = []
+        for _ in range(iters):
+            torch.cuda.synchronize()
+            t0 = time.perf_counter()
+            fn()
+            torch.cuda.synchronize()
+            t1 = time.perf_counter()
+            times.append((t1 - t0) * 1000)
+
+        times.sort()
+        return times[len(times) // 2]
+
+    @pytest.mark.parametrize(
+        "compress_ratio,sq,b,num_heads,v_head_dim,window_size",
+        [
+            (0,   2048, 1, 32, 128, 128),
+            (0,   4096, 1, 32, 128, 256),
+            (128, 2048, 1, 32, 128, 128),
+            (128, 4096, 1, 32, 128, 256),
+        ],
+        ids=["win_only_2k", "win_only_4k", "ratio128_2k", "ratio128_4k"],
+    )
+    def test_e2e_performance_no_indexer(
+        self, compress_ratio, sq, b, num_heads, v_head_dim, window_size, device, dsa_metrics,
+    ):
+        """Forward+backward performance: fused triton vs unfused CSA (no indexer)."""
+        with _hadamard_patches():
+            config = _make_test_mla_config(
+                num_attention_heads=num_heads,
+                v_head_dim=v_head_dim,
+                csa_window_size=window_size,
+                dsa_indexer_topk=64,
+                dsa_indexer_loss_coeff=0.0,
+            )
+
+            torch.manual_seed(42)
+            csa = _build_csa_module(config, compress_ratio=compress_ratio)
+            csa.train()
+
+            inputs = _make_csa_inputs(sq, b, config, device)
+
+            # --- Unfused benchmark ---
+            csa.apply_dsa_kernel_fusion = False
+            query_u = inputs["query"].clone().requires_grad_(True)
+            key_u = inputs["key"].clone().requires_grad_(True)
+
+            def run_unfused():
+                out = csa(
+                    query=query_u, key=key_u, value=key_u.clone(),
+                    attention_mask=None, x=inputs["x"], qr=inputs["qr"],
+                )
+                out.sum().backward()
+                query_u.grad = None
+                key_u.grad = None
+                csa.zero_grad()
+
+            with _oom_guard():
+                time_unfused = self._benchmark(run_unfused)
+
+            # --- Fused benchmark (triton dsa_sparse_attn) ---
+            csa.apply_dsa_kernel_fusion = True
+            query_f = inputs["query"].clone().requires_grad_(True)
+            key_f = inputs["key"].clone().requires_grad_(True)
+
+            def run_fused():
+                out = csa(
+                    query=query_f, key=key_f, value=key_f.clone(),
+                    attention_mask=None, x=inputs["x"], qr=inputs["qr"],
+                )
+                out.sum().backward()
+                query_f.grad = None
+                key_f.grad = None
+                csa.zero_grad()
+
+            with patch(_PATCH_DSA_SPARSE_ATTN, _triton_dsa_sparse_attn):
+                time_fused = self._benchmark(run_fused)
+
+            speedup = time_unfused / max(time_fused, 1e-6)
+
+            logger.info(
+                f"[ratio={compress_ratio}, sq={sq}, b={b}, np={num_heads}, "
+                f"win={window_size}] "
+                f"unfused={time_unfused:.3f}ms, fused={time_fused:.3f}ms, "
+                f"speedup={speedup:.2f}x"
+            )
+
+            dsa_metrics.record_performance(
+                params={"ratio": compress_ratio, "sq": sq, "b": b, "np": num_heads, "win": window_size},
+                fused_ms=time_fused, unfused_ms=time_unfused, speedup=speedup, label="no_indexer_e2e",
+            )
+
+    @pytest.mark.parametrize(
+        "compress_ratio,sq,b,num_heads,v_head_dim,window_size",
+        [
+            (0,   2048, 1, 32, 128, 128),
+            (0,   4096, 1, 32, 128, 256),
+            (128, 2048, 1, 32, 128, 128),
+            (128, 4096, 1, 32, 128, 256),
+        ],
+        ids=["win_only_2k", "win_only_4k", "ratio128_2k", "ratio128_4k"],
+    )
+    def test_e2e_memory_no_indexer(
+        self, compress_ratio, sq, b, num_heads, v_head_dim, window_size, device, dsa_metrics,
+    ):
+        """Peak GPU memory: fused triton vs unfused CSA (no indexer)."""
+        with _hadamard_patches():
+            config = _make_test_mla_config(
+                num_attention_heads=num_heads,
+                v_head_dim=v_head_dim,
+                csa_window_size=window_size,
+                dsa_indexer_topk=64,
+                dsa_indexer_loss_coeff=0.0,
+            )
+
+            torch.manual_seed(42)
+            csa = _build_csa_module(config, compress_ratio=compress_ratio)
+            csa.train()
+
+            inputs = _make_csa_inputs(sq, b, config, device)
+
+            # --- Unfused memory measurement ---
+            csa.apply_dsa_kernel_fusion = False
+            query_u = inputs["query"].clone().requires_grad_(True)
+            key_u = inputs["key"].clone().requires_grad_(True)
+
+            with _oom_guard():
+                # Warmup
+                out = csa(
+                    query=query_u, key=key_u, value=key_u.clone(),
+                    attention_mask=None, x=inputs["x"], qr=inputs["qr"],
+                )
+                out.sum().backward()
+                query_u.grad = None
+                key_u.grad = None
+                csa.zero_grad()
+                torch.cuda.synchronize()
+
+                torch.cuda.reset_peak_memory_stats(device)
+                torch.cuda.synchronize()
+                mem_before = torch.cuda.memory_allocated(device)
+
+                out = csa(
+                    query=query_u, key=key_u, value=key_u.clone(),
+                    attention_mask=None, x=inputs["x"], qr=inputs["qr"],
+                )
+                out.sum().backward()
+                torch.cuda.synchronize()
+                mem_unfused_peak = torch.cuda.max_memory_allocated(device) - mem_before
+
+            query_u.grad = None
+            key_u.grad = None
+            csa.zero_grad()
+            torch.cuda.empty_cache()
+
+            # --- Fused memory measurement ---
+            csa.apply_dsa_kernel_fusion = True
+            query_f = inputs["query"].clone().requires_grad_(True)
+            key_f = inputs["key"].clone().requires_grad_(True)
+
+            # Warmup
+            with patch(_PATCH_DSA_SPARSE_ATTN, _triton_dsa_sparse_attn):
+                out = csa(
+                    query=query_f, key=key_f, value=key_f.clone(),
+                    attention_mask=None, x=inputs["x"], qr=inputs["qr"],
+                )
+                out.sum().backward()
+            query_f.grad = None
+            key_f.grad = None
+            csa.zero_grad()
+            torch.cuda.synchronize()
+
+            torch.cuda.reset_peak_memory_stats(device)
+            torch.cuda.synchronize()
+            mem_before = torch.cuda.memory_allocated(device)
+
+            with patch(_PATCH_DSA_SPARSE_ATTN, _triton_dsa_sparse_attn):
+                out = csa(
+                    query=query_f, key=key_f, value=key_f.clone(),
+                    attention_mask=None, x=inputs["x"], qr=inputs["qr"],
+                )
+                out.sum().backward()
+            torch.cuda.synchronize()
+            mem_fused_peak = torch.cuda.max_memory_allocated(device) - mem_before
+
+            ratio = mem_unfused_peak / max(mem_fused_peak, 1)
+
+            logger.info(
+                f"[ratio={compress_ratio}, sq={sq}, b={b}, np={num_heads}, "
+                f"win={window_size}] "
+                f"unfused={mem_unfused_peak / 1024**2:.1f}MB, "
+                f"fused={mem_fused_peak / 1024**2:.1f}MB, ratio={ratio:.2f}x"
+            )
+
+            dsa_metrics.record_memory(
+                params={"ratio": compress_ratio, "sq": sq, "b": b, "np": num_heads, "win": window_size},
+                fused_mb=mem_fused_peak / 1024**2, unfused_mb=mem_unfused_peak / 1024**2, ratio=ratio,
+            )
+
+
+# ---------------------------------------------------------------------------
+# Kernel-level backward accuracy: _DSASparseAttnFunc (dsa_sparse_attn)
+# ---------------------------------------------------------------------------
+
+
+class TestDSASparseAttnBackward:
+    """Kernel-level backward accuracy for dsa_sparse_attn (_DSASparseAttnFunc).
+
+    Verifies gradient correctness for both backward dispatch paths:
+    - BMM backward: triggered when TopK <= 512 (forward used PyTorch BMM)
+    - Triton backward: triggered when TopK > 512 (forward used Triton kernel)
+
+    Reference: unfused_compressed_sparse_attn (fully materialized PyTorch autograd).
+    """
+
+    @pytest.fixture
+    def device(self):
+        return torch.device("cuda:0")
+
+    @staticmethod
+    def _make_inputs(
+        total_sq: int, total_skv: int, np_: int, d: int, topk: int,
+        device: torch.device, seed: int = 42,
+    ) -> dict:
+        """Generate random inputs for direct dsa_sparse_attn testing."""
+        torch.manual_seed(seed)
+
+        query = torch.randn(total_sq, np_, d, device=device, dtype=torch.bfloat16)
+        kv = torch.randn(total_skv, d, device=device, dtype=torch.bfloat16)
+        attn_sink = torch.randn(np_, device=device, dtype=torch.float32) * 0.1
+        softmax_scale = 1.0 / math.sqrt(d)
+
+        # Generate random valid indices in [0, total_skv), with some -1 for
+        # early positions (simulating causal masking)
+        topk_idxs = torch.randint(0, total_skv, (total_sq, topk), device=device, dtype=torch.int32)
+        # Mark ~10% as invalid
+        invalid_mask = torch.rand(total_sq, topk, device=device) < 0.1
+        topk_idxs[invalid_mask] = -1
+        # First row: only 1 valid position (stress test for edge cases)
+        topk_idxs[0, 1:] = -1
+
+        return {
+            "query": query,
+            "kv": kv,
+            "attn_sink": attn_sink,
+            "softmax_scale": softmax_scale,
+            "topk_idxs": topk_idxs,
+        }
+
+    @staticmethod
+    def _run_fused(inputs: dict) -> dict:
+        """Run dsa_sparse_attn (fused kernel) with grad."""
+        query = inputs["query"].clone().detach().requires_grad_(True)
+        kv = inputs["kv"].clone().detach().requires_grad_(True)
+        attn_sink = inputs["attn_sink"].clone().detach().requires_grad_(True)
+
+        # topk_idxs is (total_sq, topk) → unsqueeze to (total_sq, 1, topk)
+        topk_idxs = inputs["topk_idxs"].unsqueeze(1)
+
+        out, lse, _ = _triton_dsa_sparse_attn_raw(
+            query, kv, topk_idxs, inputs["softmax_scale"],
+            d_v=query.shape[-1], attn_sink=attn_sink,
+        )
+        out.float().sum().backward()
+
+        return {
+            "output": out,
+            "grad_query": query.grad,
+            "grad_kv": kv.grad,
+            "grad_attn_sink": attn_sink.grad,
+        }
+
+    @staticmethod
+    def _run_unfused(inputs: dict) -> dict:
+        """Run unfused_compressed_sparse_attn (reference) with grad."""
+        total_sq, np_, d = inputs["query"].shape
+        total_skv = inputs["kv"].shape[0]
+
+        # unfused expects: query (sq, b, np, d), kv_full (n_kv, b, d), indices (b, sq, topk)
+        # Our inputs have b=1 implicit, so unsqueeze the batch dim.
+        query = inputs["query"].unsqueeze(1).clone().detach().requires_grad_(True)  # (sq, 1, np, d)
+        kv = inputs["kv"].unsqueeze(1).clone().detach().requires_grad_(True)  # (skv, 1, d)
+        attn_sink = inputs["attn_sink"].clone().detach().requires_grad_(True)
+
+        # topk_idxs: (total_sq, topk) → (b=1, sq, topk)
+        topk_idxs = inputs["topk_idxs"].unsqueeze(0)
+
+        out = unfused_compressed_sparse_attn(
+            query, kv, attn_sink, topk_idxs, inputs["softmax_scale"],
+        )
+        out.float().sum().backward()
+
+        return {
+            "output": out,
+            "grad_query": query.grad.squeeze(1),  # (sq, np, d)
+            "grad_kv": kv.grad.squeeze(1),  # (skv, d)
+            "grad_attn_sink": attn_sink.grad,
+        }
+
+    @pytest.mark.parametrize(
+        "total_sq,total_skv,np_,d,topk",
+        [
+            # BMM backward path: TopK <= 512
+            (2048, 2048, 32, 128, 128),
+            (2048, 2048, 32, 128, 256),
+            (4096, 4096, 32, 128, 256),
+            (2048, 2048, 64, 128, 128),
+            # Triton backward path: TopK > 512
+            (2048, 2048, 32, 128, 640),
+            (2048, 4096, 32, 128, 768),
+        ],
+        ids=[
+            "bmm_bwd_topk128",
+            "bmm_bwd_topk256",
+            "bmm_bwd_topk256_sq4k",
+            "bmm_bwd_topk128_np64",
+            "triton_bwd_topk640",
+            "triton_bwd_topk768",
+        ],
+    )
+    def test_grad_query_accuracy(self, total_sq, total_skv, np_, d, topk, device, dsa_metrics):
+        """Gradient w.r.t. query matches unfused reference for both bwd paths."""
+        inputs = self._make_inputs(total_sq, total_skv, np_, d, topk, device)
+
+        fused_res = self._run_fused(inputs)
+        unfused_res = self._run_unfused(inputs)
+
+        g_fused = fused_res["grad_query"].float()
+        g_unfused = unfused_res["grad_query"].float()
+
+        # Check no NaN/Inf
+        assert not torch.isnan(g_fused).any(), "grad_query has NaN"
+        assert not torch.isinf(g_fused).any(), "grad_query has Inf"
+
+        cos_sim = torch.nn.functional.cosine_similarity(
+            g_fused.reshape(-1).unsqueeze(0),
+            g_unfused.reshape(-1).unsqueeze(0),
+        ).item()
+
+        logger.info(
+            f"[sq={total_sq}, skv={total_skv}, np={np_}, topk={topk}] "
+            f"grad_query cos_sim={cos_sim:.6f}"
+        )
+        assert cos_sim > 0.95, f"grad_query cosine similarity too low: {cos_sim:.6f}"
+
+        dsa_metrics.record_accuracy(
+            params={"sq": total_sq, "skv": total_skv, "np": np_, "topk": topk},
+            cos_sim=cos_sim, target="kernel_grad_query",
+        )
+
+    @pytest.mark.parametrize(
+        "total_sq,total_skv,np_,d,topk",
+        [
+            # BMM backward path: TopK <= 512
+            (2048, 2048, 32, 128, 128),
+            (2048, 2048, 32, 128, 256),
+            # Triton backward path: TopK > 512
+            (2048, 2048, 32, 128, 640),
+        ],
+        ids=[
+            "bmm_bwd_topk128",
+            "bmm_bwd_topk256",
+            "triton_bwd_topk640",
+        ],
+    )
+    def test_grad_kv_accuracy(self, total_sq, total_skv, np_, d, topk, device, dsa_metrics):
+        """Gradient w.r.t. kv matches unfused reference for both bwd paths."""
+        inputs = self._make_inputs(total_sq, total_skv, np_, d, topk, device)
+
+        fused_res = self._run_fused(inputs)
+        unfused_res = self._run_unfused(inputs)
+
+        g_fused = fused_res["grad_kv"].float()
+        g_unfused = unfused_res["grad_kv"].float()
+
+        # Check no NaN/Inf
+        assert not torch.isnan(g_fused).any(), "grad_kv has NaN"
+        assert not torch.isinf(g_fused).any(), "grad_kv has Inf"
+
+        cos_sim = torch.nn.functional.cosine_similarity(
+            g_fused.reshape(-1).unsqueeze(0),
+            g_unfused.reshape(-1).unsqueeze(0),
+        ).item()
+
+        logger.info(
+            f"[sq={total_sq}, skv={total_skv}, np={np_}, topk={topk}] "
+            f"grad_kv cos_sim={cos_sim:.6f}"
+        )
+        assert cos_sim > 0.95, f"grad_kv cosine similarity too low: {cos_sim:.6f}"
+
+        dsa_metrics.record_accuracy(
+            params={"sq": total_sq, "skv": total_skv, "np": np_, "topk": topk},
+            cos_sim=cos_sim, target="kernel_grad_kv",
+        )
+

--- a/tests/unit_tests/plugin/dsa_kernel/test_fused_dsa.py
+++ b/tests/unit_tests/plugin/dsa_kernel/test_fused_dsa.py
@@ -719,13 +719,13 @@ class TestKLLossAccuracy:
             q_idx_bshd, k_idx_bsd, w_bsh_scaled, effective_topk, ratio
         )
 
-        print(f"\n[DEBUG] ===== STEP-BY-STEP DIAGNOSIS =====")
-        print(f"[DEBUG] shapes: sq={sq}, b={b}, np={np_}, hn={hn}, n_comp={n_comp}, "
+        logger.debug(f"===== STEP-BY-STEP DIAGNOSIS =====")
+        logger.debug(f"shapes: sq={sq}, b={b}, np={np_}, hn={hn}, n_comp={n_comp}, "
               f"effective_topk={effective_topk}, kv_offset={kv_offset}, ratio={ratio}")
-        print(f"[DEBUG] topk_indices_cmp: shape={topk_indices_cmp.shape}, "
+        logger.debug(f"topk_indices_cmp: shape={topk_indices_cmp.shape}, "
               f"min={topk_indices_cmp.min().item()}, max={topk_indices_cmp.max().item()}")
         n_invalid = (topk_indices_cmp < 0).sum().item()
-        print(f"[DEBUG] invalid indices (< 0): {n_invalid} / {topk_indices_cmp.numel()}")
+        logger.debug(f"invalid indices (< 0): {n_invalid} / {topk_indices_cmp.numel()}")
 
         # ----- STEP A: Compare fused vs reference indexer scores -----
         causal_mask = compute_ratio_causal_mask(
@@ -737,14 +737,14 @@ class TestKLLossAccuracy:
         ref_index_scores = _compute_index_scores(
             inputs["q_indexer"], w_idx_ref, inputs["k_indexer"]
         )  # (b, sq, n_comp)
-        print(f"[DEBUG] ref_index_scores: shape={ref_index_scores.shape}, "
+        logger.debug(f"ref_index_scores: shape={ref_index_scores.shape}, "
               f"min={ref_index_scores.min().item():.6e}, max={ref_index_scores.max().item():.6e}")
-        print(f"[DEBUG] full_scores_fused: shape={full_scores_fused.shape}, "
+        logger.debug(f"full_scores_fused: shape={full_scores_fused.shape}, "
               f"min={full_scores_fused.min().item():.6e}, max={full_scores_fused.max().item():.6e}")
 
         # Compare the two score computations
         score_diff = (full_scores_fused - ref_index_scores).abs()
-        print(f"[DEBUG] indexer score diff (fused vs ref): "
+        logger.debug(f"indexer score diff (fused vs ref): "
               f"max={score_diff.max().item():.6e}, mean={score_diff.mean().item():.6e}")
 
         # ----- STEP B: Predict distribution comparison -----
@@ -790,11 +790,11 @@ class TestKLLossAccuracy:
         predict_ref_at_topk[~valid_topk_mask] = 0.0
 
         predict_diff = (predict_fused - predict_ref_at_topk).abs()
-        print(f"[DEBUG] PREDICT fused: sum_per_row_mean={predict_fused.sum(-1).mean().item():.6f}, "
+        logger.debug(f"PREDICT fused: sum_per_row_mean={predict_fused.sum(-1).mean().item():.6f}, "
               f"max={predict_fused.max().item():.6e}")
-        print(f"[DEBUG] PREDICT ref_at_topk: sum_per_row_mean={predict_ref_at_topk.sum(-1).mean().item():.6f}, "
+        logger.debug(f"PREDICT ref_at_topk: sum_per_row_mean={predict_ref_at_topk.sum(-1).mean().item():.6f}, "
               f"max={predict_ref_at_topk.max().item():.6e}")
-        print(f"[DEBUG] PREDICT diff: max={predict_diff.max().item():.6e}, "
+        logger.debug(f"PREDICT diff: max={predict_diff.max().item():.6e}, "
               f"mean={predict_diff.mean().item():.6e}")
 
         # ----- STEP C: Target distribution comparison -----
@@ -869,11 +869,11 @@ class TestKLLossAccuracy:
         target_ref_at_topk[~valid_topk_mask] = 0.0
 
         target_diff = (target_fused - target_ref_at_topk).abs()
-        print(f"[DEBUG] TARGET fused: sum_per_row_mean={target_fused.sum(-1).mean().item():.6f}, "
+        logger.debug(f"TARGET fused: sum_per_row_mean={target_fused.sum(-1).mean().item():.6f}, "
               f"max={target_fused.max().item():.6e}")
-        print(f"[DEBUG] TARGET ref_at_topk: sum_per_row_mean={target_ref_at_topk.sum(-1).mean().item():.6f}, "
+        logger.debug(f"TARGET ref_at_topk: sum_per_row_mean={target_ref_at_topk.sum(-1).mean().item():.6f}, "
               f"max={target_ref_at_topk.max().item():.6e}")
-        print(f"[DEBUG] TARGET diff: max={target_diff.max().item():.6e}, "
+        logger.debug(f"TARGET diff: max={target_diff.max().item():.6e}, "
               f"mean={target_diff.mean().item():.6e}, "
               f"rel_max={target_diff.max().item() / max(target_ref_at_topk.abs().max().item(), 1e-10):.4e}")
 
@@ -897,19 +897,19 @@ class TestKLLossAccuracy:
         lse_direct_f32 = torch.logsumexp(scores_at_topk_masked, dim=-1)  # (b, sq, np)
         # Compare with lse_indexer from triton forward
         lse_diff = (lse_indexer_bsh - lse_direct_f32).abs()
-        print(f"[DEBUG] LSE comparison (triton_fwd vs direct_f32):")
-        print(f"[DEBUG]   lse_indexer: mean={lse_indexer_bsh.mean().item():.4f}, "
+        logger.debug(f"LSE comparison (triton_fwd vs direct_f32):")
+        logger.debug(f"  lse_indexer: mean={lse_indexer_bsh.mean().item():.4f}, "
               f"min={lse_indexer_bsh.min().item():.4f}, max={lse_indexer_bsh.max().item():.4f}")
-        print(f"[DEBUG]   lse_direct:  mean={lse_direct_f32.mean().item():.4f}, "
+        logger.debug(f"  lse_direct:  mean={lse_direct_f32.mean().item():.4f}, "
               f"min={lse_direct_f32.min().item():.4f}, max={lse_direct_f32.max().item():.4f}")
-        print(f"[DEBUG]   diff: max={lse_diff.max().item():.6e}, mean={lse_diff.mean().item():.6e}")
+        logger.debug(f"  diff: max={lse_diff.max().item():.6e}, mean={lse_diff.mean().item():.6e}")
 
         # Check what softmax probs look like from each LSE
         probs_from_triton_lse = torch.exp(scores_at_topk_masked - lse_indexer_bsh.unsqueeze(-1))
         probs_from_direct_lse = torch.exp(scores_at_topk_masked - lse_direct_f32.unsqueeze(-1))
-        print(f"[DEBUG] probs_from_triton_lse: max={probs_from_triton_lse.max().item():.6e}, "
+        logger.debug(f"probs_from_triton_lse: max={probs_from_triton_lse.max().item():.6e}, "
               f"sum_per_row_mean={probs_from_triton_lse.sum(-1).mean().item():.6f}")
-        print(f"[DEBUG] probs_from_direct_lse: max={probs_from_direct_lse.max().item():.6e}, "
+        logger.debug(f"probs_from_direct_lse: max={probs_from_direct_lse.max().item():.6e}, "
               f"sum_per_row_mean={probs_from_direct_lse.sum(-1).mean().item():.6f}")
 
         # ----- STEP E: Compute KL from both paths for final comparison -----
@@ -929,34 +929,34 @@ class TestKLLossAccuracy:
         kl_ref_rows = torch.where(row_valid_fused, kl_ref_rows, torch.zeros_like(kl_ref_rows))
         manual_ref_loss = kl_ref_rows.mean() * loss_coeff
 
-        print(f"[DEBUG] ----- KL DECOMPOSITION -----")
-        print(f"[DEBUG] manual_loss (fused target+predict): {manual_loss.item():.6e}")
-        print(f"[DEBUG] manual_ref_loss (ref target+predict): {manual_ref_loss.item():.6e}")
+        logger.debug(f"----- KL DECOMPOSITION -----")
+        logger.debug(f"manual_loss (fused target+predict): {manual_loss.item():.6e}")
+        logger.debug(f"manual_ref_loss (ref target+predict): {manual_ref_loss.item():.6e}")
 
         # Cross KL: fused target with ref predict
         kl_cross1 = (t_f * (torch.log(t_f) - torch.log(p_r))).sum(dim=-1)
         kl_cross1 = torch.where(row_valid_fused, kl_cross1, torch.zeros_like(kl_cross1))
-        print(f"[DEBUG] KL(fused_target || ref_predict): {kl_cross1.mean().item() * loss_coeff:.6e}")
+        logger.debug(f"KL(fused_target || ref_predict): {kl_cross1.mean().item() * loss_coeff:.6e}")
         # Cross KL: ref target with fused predict
         kl_cross2 = (t_r * (torch.log(t_r) - torch.log(p_f))).sum(dim=-1)
         kl_cross2 = torch.where(row_valid_fused, kl_cross2, torch.zeros_like(kl_cross2))
-        print(f"[DEBUG] KL(ref_target || fused_predict): {kl_cross2.mean().item() * loss_coeff:.6e}")
+        logger.debug(f"KL(ref_target || fused_predict): {kl_cross2.mean().item() * loss_coeff:.6e}")
 
         # Show worst rows
         kl_diff_per_row = (kl_fused_rows - kl_ref_rows).abs()
         worst_flat = kl_diff_per_row.reshape(-1).topk(5)
-        print(f"[DEBUG] top-5 worst row KL diffs: {worst_flat.values.tolist()}")
+        logger.debug(f"top-5 worst row KL diffs: {worst_flat.values.tolist()}")
         for idx in worst_flat.indices[:3]:
             bi = idx.item() // sq
             si = idx.item() % sq
-            print(f"[DEBUG]   row [{bi},{si}]: "
+            logger.debug(f"  row [{bi},{si}]: "
                   f"fused_target={target_fused[bi,si,:8].tolist()}, "
                   f"ref_target={target_ref_at_topk[bi,si,:8].tolist()}")
-            print(f"[DEBUG]            "
+            logger.debug(f"           "
                   f"fused_predict={predict_fused[bi,si,:8].tolist()}, "
                   f"ref_predict={predict_ref_at_topk[bi,si,:8].tolist()}")
 
-        print(f"[DEBUG] fused loss will be printed after call below...")
+        logger.debug(f"fused loss will be printed after call below...")
         # ===== END DEBUG =====
 
         # Fused path
@@ -980,10 +980,10 @@ class TestKLLossAccuracy:
         ref_val = loss_ref.item()
         rel_err = abs(fused_val - ref_val) / max(abs(ref_val), 1e-8)
 
-        print(f"[DEBUG] === FINAL COMPARISON ===")
-        print(f"[DEBUG] loss_fused={fused_val:.6e}, loss_ref={ref_val:.6e}, manual_loss={manual_loss.item():.6e}")
-        print(f"[DEBUG] fused vs manual rel_err={abs(fused_val - manual_loss.item()) / max(abs(manual_loss.item()), 1e-8):.4e}")
-        print(f"[DEBUG] manual vs ref rel_err={abs(manual_loss.item() - ref_val) / max(abs(ref_val), 1e-8):.4e}")
+        logger.debug(f"=== FINAL COMPARISON ===")
+        logger.debug(f"loss_fused={fused_val:.6e}, loss_ref={ref_val:.6e}, manual_loss={manual_loss.item():.6e}")
+        logger.debug(f"fused vs manual rel_err={abs(fused_val - manual_loss.item()) / max(abs(manual_loss.item()), 1e-8):.4e}")
+        logger.debug(f"manual vs ref rel_err={abs(manual_loss.item() - ref_val) / max(abs(ref_val), 1e-8):.4e}")
 
         logger.info(
             f"[sq={sq}, b={b}, per_token={calculate_per_token_loss}] "
@@ -1408,6 +1408,7 @@ class TestFusedIndexerSparseAttnBackward:
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.perf
 class TestFusedIndexerSparseAttnPerformance:
     """Performance benchmarks: Fused Triton path vs unfused PyTorch CSA path.
 
@@ -2342,6 +2343,214 @@ class TestCSAFusedVsUnfusedAccuracy:
 
 
 @_skip_unless_sm90
+class TestDSAIndexerLossAutoScaler:
+    """Verify DSAIndexerLossAutoScaler correctly propagates gradients in training.
+
+    DSAIndexerLossAutoScaler attaches the indexer KL loss to the attention output
+    without altering the forward value. In backward:
+    - grad w.r.t. output passes through unchanged.
+    - grad w.r.t. indexer_loss = ones_like(loss) * main_loss_backward_scale.
+
+    This test validates the complete gradient flow through the CSA module when
+    the AutoScaler is active (indexer_loss_coeff > 0, training mode).
+    """
+
+    @pytest.fixture(scope='class', autouse=True)
+    def setup_class(self, request):
+        Utils.initialize_model_parallel(
+            tensor_model_parallel_size=1, pipeline_model_parallel_size=1
+        )
+        yield
+        Utils.destroy_model_parallel()
+
+    @pytest.fixture
+    def device(self):
+        return torch.device("cuda:0")
+
+    def test_forward_identity(self, device):
+        """AutoScaler does not modify the forward output value."""
+        from megatron.core.transformer.experimental_attention_variant.dsa import (
+            DSAIndexerLossAutoScaler,
+        )
+
+        output = torch.randn(128, 2, 4096, dtype=torch.bfloat16, device=device)
+        loss = torch.tensor(0.05, device=device, requires_grad=True)
+        output.requires_grad_(True)
+
+        result = DSAIndexerLossAutoScaler.apply(output, loss)
+
+        assert torch.equal(result, output), "AutoScaler altered forward output"
+
+    def test_grad_output_passthrough(self, device):
+        """Gradient w.r.t. output passes through unchanged."""
+        from megatron.core.transformer.experimental_attention_variant.dsa import (
+            DSAIndexerLossAutoScaler,
+        )
+
+        output = torch.randn(64, 1, 2048, dtype=torch.float32, device=device, requires_grad=True)
+        loss = torch.tensor(0.1, device=device, requires_grad=True)
+
+        result = DSAIndexerLossAutoScaler.apply(output, loss)
+        grad_upstream = torch.randn_like(result)
+        result.backward(grad_upstream)
+
+        assert torch.equal(output.grad, grad_upstream), (
+            "AutoScaler modified grad w.r.t. output"
+        )
+
+    def test_grad_loss_scaled(self, device):
+        """Gradient w.r.t. indexer_loss equals ones * main_loss_backward_scale."""
+        from megatron.core.transformer.experimental_attention_variant.dsa import (
+            DSAIndexerLossAutoScaler,
+        )
+
+        output = torch.randn(64, 1, 2048, dtype=torch.float32, device=device, requires_grad=True)
+        loss = torch.tensor(0.1, device=device, requires_grad=True)
+
+        # Set a known scale
+        scale = torch.tensor(2.5, device=device)
+        DSAIndexerLossAutoScaler.set_loss_scale(scale)
+
+        result = DSAIndexerLossAutoScaler.apply(output, loss)
+        grad_upstream = torch.randn_like(result)
+        result.backward(grad_upstream)
+
+        expected_loss_grad = torch.ones_like(loss) * 2.5
+        assert torch.allclose(loss.grad, expected_loss_grad), (
+            f"Loss grad mismatch: got {loss.grad.item()}, expected {expected_loss_grad.item()}"
+        )
+
+        # Reset to default for other tests
+        DSAIndexerLossAutoScaler.main_loss_backward_scale = None
+
+    @pytest.mark.parametrize(
+        "sq,b,num_heads,v_head_dim,window_size,indexer_topk",
+        [
+            (2048, 1, 32, 128, 128, 256),
+        ],
+    )
+    @pytest.mark.parametrize("sparse_loss", [True, False], ids=["sparse", "dense"])
+    def test_e2e_grad_with_autoscaler(
+        self, sq, b, num_heads, v_head_dim, window_size, indexer_topk,
+        sparse_loss, device, dsa_metrics,
+    ):
+        """End-to-end: AutoScaler in CSA module allows indexer params to receive gradients.
+
+        Verifies that:
+        1. CSA output has gradients flowing back to query (attention path).
+        2. Indexer parameters receive non-zero gradients (loss path via AutoScaler).
+        3. Fused and unfused paths produce consistent gradient magnitudes.
+        """
+        from megatron.core.transformer.experimental_attention_variant.dsa import (
+            DSAIndexerLossAutoScaler,
+        )
+
+        with _hadamard_patches():
+            config = _make_test_mla_config(
+                num_attention_heads=num_heads,
+                v_head_dim=v_head_dim,
+                csa_window_size=window_size,
+                dsa_indexer_topk=indexer_topk,
+                dsa_indexer_loss_coeff=0.1,
+                dsa_indexer_use_sparse_loss=sparse_loss,
+            )
+
+            torch.manual_seed(42)
+            csa = _build_csa_module(config, compress_ratio=4)
+            csa.train()
+
+            # Set a known scale for deterministic gradient checking
+            DSAIndexerLossAutoScaler.set_loss_scale(torch.tensor(1.0, device=device))
+
+            inputs = _make_csa_inputs(sq, b, config, device)
+
+            # --- Fused path ---
+            csa.apply_dsa_kernel_fusion = True
+            query_fused = inputs["query"].clone().requires_grad_(True)
+            torch.manual_seed(7)
+            out_fused = csa(
+                query=query_fused,
+                key=inputs["key"].clone(),
+                value=inputs["value"].clone(),
+                attention_mask=None,
+                x=inputs["x"].clone(),
+                qr=inputs["qr"].clone(),
+            )
+            grad_out = torch.randn_like(out_fused)
+            out_fused.backward(grad_out)
+
+            # Attention path: query should receive gradient
+            assert query_fused.grad is not None, "query has no gradient (fused)"
+            assert not torch.isnan(query_fused.grad).any(), "query grad has NaN (fused)"
+            grad_query_fused_norm = query_fused.grad.float().norm().item()
+
+            # Indexer path: indexer params should receive gradient via AutoScaler
+            indexer_grads_fused = {}
+            for name, p in csa.indexer.named_parameters():
+                if p.grad is not None:
+                    indexer_grads_fused[name] = p.grad.float().norm().item()
+            assert len(indexer_grads_fused) > 0, (
+                "No indexer parameter received gradient (fused). "
+                "AutoScaler may not be propagating loss backward."
+            )
+
+            # --- Unfused path ---
+            csa.zero_grad()
+            csa.apply_dsa_kernel_fusion = False
+            query_unfused = inputs["query"].clone().requires_grad_(True)
+            with _oom_guard():
+                torch.manual_seed(7)
+                out_unfused = csa(
+                    query=query_unfused,
+                    key=inputs["key"].clone(),
+                    value=inputs["value"].clone(),
+                    attention_mask=None,
+                    x=inputs["x"].clone(),
+                    qr=inputs["qr"].clone(),
+                )
+                out_unfused.backward(grad_out)
+
+            assert query_unfused.grad is not None, "query has no gradient (unfused)"
+            grad_query_unfused_norm = query_unfused.grad.float().norm().item()
+
+            indexer_grads_unfused = {}
+            for name, p in csa.indexer.named_parameters():
+                if p.grad is not None:
+                    indexer_grads_unfused[name] = p.grad.float().norm().item()
+            assert len(indexer_grads_unfused) > 0, (
+                "No indexer parameter received gradient (unfused). "
+            )
+
+            # Gradient magnitude should be in the same ballpark
+            ratio_q = grad_query_fused_norm / max(grad_query_unfused_norm, 1e-12)
+            logger.info(
+                f"[sparse_loss={sparse_loss}] query grad norm ratio "
+                f"(fused/unfused) = {ratio_q:.4f}"
+            )
+            assert 0.5 < ratio_q < 2.0, (
+                f"Query grad norm diverged: fused={grad_query_fused_norm:.4e}, "
+                f"unfused={grad_query_unfused_norm:.4e}"
+            )
+
+            # Indexer grad norms should both be non-trivial
+            for name in indexer_grads_fused:
+                if name in indexer_grads_unfused:
+                    logger.info(
+                        f"  indexer.{name}: fused={indexer_grads_fused[name]:.4e}, "
+                        f"unfused={indexer_grads_unfused[name]:.4e}"
+                    )
+
+            dsa_metrics.record_accuracy(
+                params={"sq": sq, "np": num_heads, "topk": indexer_topk, "sparse_loss": sparse_loss},
+                cos_sim=ratio_q, target="autoscaler_grad_ratio",
+            )
+
+            # Cleanup
+            DSAIndexerLossAutoScaler.main_loss_backward_scale = None
+
+
+@_skip_unless_sm90
+@pytest.mark.perf
 class TestCSAFusedVsUnfusedPerformance:
     """Module-level performance: CompressedSparseAttention unfused vs fused (triton).
 
@@ -2785,6 +2994,7 @@ class TestCSANoIndexerFusedVsUnfused:
 
 
 @_skip_unless_sm90
+@pytest.mark.perf
 class TestCSANoIndexerPerformance:
     """E2E performance: CompressedSparseAttention no-indexer path.
 

--- a/tests/unit_tests/plugin/dsa_kernel/test_fused_dsa.py
+++ b/tests/unit_tests/plugin/dsa_kernel/test_fused_dsa.py
@@ -545,6 +545,15 @@ class TestFusedIndexerSparseAttnBackward:
             cos_sim=cos_sim, max_diff=max_diff, mean_diff=mean_diff, target="grad_query",
         )
 
+        # Grad norm check
+        norm_fused = g_fused.norm().item()
+        norm_unfused = g_unfused.norm().item()
+        norm_ratio = norm_fused / max(norm_unfused, 1e-12)
+        assert 0.8 < norm_ratio < 1.2, (
+            f"grad_query norm ratio out of range: fused={norm_fused:.4e}, "
+            f"unfused={norm_unfused:.4e}, ratio={norm_ratio:.4f}"
+        )
+
     @pytest.mark.parametrize(
         "sq,b,np_,hn,n_comp,win_topk,idx_nh,idx_hd,indexer_topk,ratio",
         [
@@ -600,6 +609,15 @@ class TestFusedIndexerSparseAttnBackward:
             cos_sim=cos_sim, max_diff=max_diff, mean_diff=mean_diff, target="grad_kv",
         )
 
+        # Grad norm check
+        norm_fused = g_fused.norm().item()
+        norm_unfused = g_unfused.norm().item()
+        norm_ratio = norm_fused / max(norm_unfused, 1e-12)
+        assert 0.8 < norm_ratio < 1.2, (
+            f"grad_kv_full norm ratio out of range: fused={norm_fused:.4e}, "
+            f"unfused={norm_unfused:.4e}, ratio={norm_ratio:.4f}"
+        )
+
     @pytest.mark.parametrize(
         "sq,b,np_,hn,n_comp,win_topk,idx_nh,idx_hd,indexer_topk,ratio",
         [
@@ -651,6 +669,15 @@ class TestFusedIndexerSparseAttnBackward:
         dsa_metrics.record_accuracy(
             params={"sq": sq, "b": b, "np": np_, "topk": indexer_topk},
             cos_sim=cos_sim, max_diff=max_diff, mean_diff=mean_diff, target="grad_attn_sink",
+        )
+
+        # Grad norm check
+        norm_fused = g_fused.norm().item()
+        norm_unfused = g_unfused.norm().item()
+        norm_ratio = norm_fused / max(norm_unfused, 1e-12)
+        assert 0.5 < norm_ratio < 2.0, (
+            f"grad_attn_sink norm ratio out of range: fused={norm_fused:.4e}, "
+            f"unfused={norm_unfused:.4e}, ratio={norm_ratio:.4f}"
         )
 
     @pytest.mark.parametrize(
@@ -738,6 +765,7 @@ class TestFusedIndexerSparseAttnPerformance:
             "13B_B1_sq4096_topk512",
             "13B_B1_sq4096_topk1024",
             "longctx_B1_sq8192_topk512",
+            
         ],
     )
     @pytest.mark.parametrize("sparse_loss", [True, False], ids=["sparse", "dense"])
@@ -2647,6 +2675,15 @@ class TestDSASparseAttnBackward:
         )
         assert cos_sim > 0.95, f"grad_query cosine similarity too low: {cos_sim:.6f}"
 
+        # Grad norm check
+        norm_fused = g_fused.norm().item()
+        norm_unfused = g_unfused.norm().item()
+        norm_ratio = norm_fused / max(norm_unfused, 1e-12)
+        assert 0.8 < norm_ratio < 1.2, (
+            f"kernel grad_query norm ratio out of range: fused={norm_fused:.4e}, "
+            f"unfused={norm_unfused:.4e}, ratio={norm_ratio:.4f}"
+        )
+
         dsa_metrics.record_accuracy(
             params={"sq": total_sq, "skv": total_skv, "np": np_, "topk": topk},
             cos_sim=cos_sim, target="kernel_grad_query",
@@ -2691,6 +2728,15 @@ class TestDSASparseAttnBackward:
             f"grad_kv cos_sim={cos_sim:.6f}"
         )
         assert cos_sim > 0.95, f"grad_kv cosine similarity too low: {cos_sim:.6f}"
+
+        # Grad norm check
+        norm_fused = g_fused.norm().item()
+        norm_unfused = g_unfused.norm().item()
+        norm_ratio = norm_fused / max(norm_unfused, 1e-12)
+        assert 0.8 < norm_ratio < 1.2, (
+            f"kernel grad_kv norm ratio out of range: fused={norm_fused:.4e}, "
+            f"unfused={norm_unfused:.4e}, ratio={norm_ratio:.4f}"
+        )
 
         dsa_metrics.record_accuracy(
             params={"sq": total_sq, "skv": total_skv, "np": np_, "topk": topk},
@@ -2753,6 +2799,9 @@ class TestIndexerGradAccuracy:
             "grad_q_indexer": q_indexer.grad,
             "grad_k_indexer": k_indexer.grad,
             "grad_weights": weights.grad,
+            "grad_q_norm": q_indexer.grad.norm().item() if q_indexer.grad is not None else None,
+            "grad_k_norm": k_indexer.grad.norm().item() if k_indexer.grad is not None else None,
+            "grad_w_norm": weights.grad.norm().item() if weights.grad is not None else None,
         }
 
     @staticmethod
@@ -2830,6 +2879,9 @@ class TestIndexerGradAccuracy:
             "grad_q_indexer": q_indexer.grad,
             "grad_k_indexer": k_indexer.grad,
             "grad_weights": weights_for_unfused.grad,
+            "grad_q_norm": q_indexer.grad.norm().item() if q_indexer.grad is not None else None,
+            "grad_k_norm": k_indexer.grad.norm().item() if k_indexer.grad is not None else None,
+            "grad_w_norm": weights_for_unfused.grad.norm().item() if weights_for_unfused.grad is not None else None,
         }
 
     @pytest.mark.parametrize(
@@ -2864,6 +2916,8 @@ class TestIndexerGradAccuracy:
 
         g_fused = fused_res["grad_q_indexer"].float()
         g_unfused = unfused_res["grad_q_indexer"].float()
+        q_grad_norm_fused = g_fused.norm().item()
+        q_grad_norm_unfused = g_unfused.norm().item()
 
         cos_sim = torch.nn.functional.cosine_similarity(
             g_fused.reshape(-1).unsqueeze(0),
@@ -2886,6 +2940,15 @@ class TestIndexerGradAccuracy:
         dsa_metrics.record_accuracy(
             params={"sq": sq, "b": b, "np": np_, "topk": indexer_topk, "sparse_loss": sparse_loss},
             cos_sim=cos_sim, max_diff=max_diff, mean_diff=mean_diff, target="grad_q_indexer",
+        )
+
+        grad_norm_diff = abs(q_grad_norm_fused - q_grad_norm_unfused)
+        assert grad_norm_diff < 1e-3, (
+            f"grad_q_indexer norm mismatch: fused={q_grad_norm_fused:.6f}, unfused={q_grad_norm_unfused:.6f}, diff={grad_norm_diff:.4e}"
+        )
+        logger.info(
+            f"[sq={sq}, b={b}, topk={indexer_topk}, sparse_loss={sparse_loss}] "
+            f"grad_q_indexer norm: fused={q_grad_norm_fused:.6f}, unfused={q_grad_norm_unfused:.6f}, diff={grad_norm_diff:.4e}"
         )
 
     @pytest.mark.parametrize(
@@ -2920,6 +2983,8 @@ class TestIndexerGradAccuracy:
 
         g_fused = fused_res["grad_k_indexer"].float()
         g_unfused = unfused_res["grad_k_indexer"].float()
+        k_grad_norm_fused = g_fused.norm().item()
+        k_grad_norm_unfused = g_unfused.norm().item()
 
         cos_sim = torch.nn.functional.cosine_similarity(
             g_fused.reshape(-1).unsqueeze(0),
@@ -2942,6 +3007,15 @@ class TestIndexerGradAccuracy:
         dsa_metrics.record_accuracy(
             params={"sq": sq, "b": b, "np": np_, "topk": indexer_topk, "sparse_loss": sparse_loss},
             cos_sim=cos_sim, max_diff=max_diff, mean_diff=mean_diff, target="grad_k_indexer",
+        )
+
+        grad_norm_diff = abs(k_grad_norm_fused - k_grad_norm_unfused)
+        assert grad_norm_diff < 1e-3, (
+            f"grad_k_indexer norm mismatch: fused={k_grad_norm_fused:.6f}, unfused={k_grad_norm_unfused:.6f}, diff={grad_norm_diff:.4e}"
+        )
+        logger.info(
+            f"[sq={sq}, b={b}, topk={indexer_topk}, sparse_loss={sparse_loss}] "
+            f"grad_k_indexer norm: fused={k_grad_norm_fused:.6f}, unfused={k_grad_norm_unfused:.6f}, diff={grad_norm_diff:.4e}"
         )
 
     @pytest.mark.parametrize(
@@ -2982,6 +3056,16 @@ class TestIndexerGradAccuracy:
 
         g_fused = fused_res["grad_weights"].float()
         g_unfused = unfused_res["grad_weights"].float()
+        grad_norm_fused = fused_res["grad_w_norm"]
+        grad_norm_unfused = unfused_res["grad_w_norm"]
+
+        # The fused path computes ∂L/∂w_raw (scale applied to Q@K scores),
+        # while the unfused reference computes ∂L/∂w_scaled (scale embedded in weights).
+        # Convert unfused to the same parameterization for comparison:
+        # ∂L/∂w_raw = ∂L/∂w_scaled * indexer_softmax_scale
+        scale = inputs["indexer_softmax_scale"]
+        g_unfused = g_unfused * scale
+        grad_norm_unfused = g_unfused.norm().item()
 
         cos_sim = torch.nn.functional.cosine_similarity(
             g_fused.reshape(-1).unsqueeze(0),
@@ -3004,6 +3088,17 @@ class TestIndexerGradAccuracy:
         dsa_metrics.record_accuracy(
             params={"sq": sq, "b": b, "np": np_, "topk": indexer_topk, "sparse_loss": sparse_loss},
             cos_sim=cos_sim, max_diff=max_diff, mean_diff=mean_diff, target="grad_weights",
+        )
+
+        # After accounting for parameterization, norms should be close
+        grad_norm_diff = abs(grad_norm_fused - grad_norm_unfused)
+        assert grad_norm_diff < 1e-3, (
+            f"grad_weights norm mismatch: fused={grad_norm_fused:.6f}, "
+            f"unfused(adjusted)={grad_norm_unfused:.6f}, diff={grad_norm_diff:.4e}"
+        )
+        logger.info(
+            f"[sq={sq}, b={b}, topk={indexer_topk}, sparse_loss={sparse_loss}] "
+            f"grad_weights norm: fused={grad_norm_fused:.6f}, unfused(adj)={grad_norm_unfused:.6f}, diff={grad_norm_diff:.4e}"
         )
 
 

--- a/tests/unit_tests/plugin/dsa_kernel/test_fused_dsa.py
+++ b/tests/unit_tests/plugin/dsa_kernel/test_fused_dsa.py
@@ -59,6 +59,8 @@ logger = logging.getLogger(__name__)
 # ---------------------------------------------------------------------------
 
 from megatron.plugin.dsa_kernel.triton_dsa_kernels import (
+    build_flat_topk_idxs,
+    dsa_sparse_attn_sbhd as _triton_dsa_sparse_attn_sbhd,
     fused_indexer_sparse_attn,
     _sbhd_to_bshd_indexer_inputs,
     _indexer_topk_bshd,
@@ -70,9 +72,15 @@ from megatron.plugin.dsa_kernel.triton_indexer_kernels import (
     sparse_attn_score_recompute,
     dense_indexer_score_recompute,
     dense_attn_score_recompute,
+    fused_sparse_indexer_loss_and_backward,
+)
+from megatron.plugin.dsa_kernel.triton_dsa_utils import (
+    compute_ratio_causal_mask,
+    topk_with_causal_mask,
 )
 from megatron.core.transformer.experimental_attention_variant.csa import (
     unfused_compressed_sparse_attn,
+    get_compress_topk_idxs,
     get_window_topk_idxs,
 )
 
@@ -487,6 +495,48 @@ class TestFusedIndexerSparseAttnBackward:
             "grad_kv_full": kv_full.grad,
             "grad_attn_sink": attn_sink.grad,
         }
+
+    @pytest.mark.parametrize("sparse_loss", [True, False])
+    def test_backward_preserves_output_saved_for_di(self, device, sparse_loss):
+        """Indexer-fused backward must tolerate downstream output mutation."""
+        inputs = _make_fused_inputs(
+            128, 1, 16, 64, 32, 16, 4, 64, 16, 4, 128, device
+        )
+        grad_output = torch.randn(
+            128, 1, 16 * 64, device=device, dtype=torch.bfloat16
+        )
+
+        def run(mutate_output: bool):
+            query = inputs["query"].clone().detach().requires_grad_(True)
+            kv = inputs["kv_full"].clone().detach().requires_grad_(True)
+            sink = inputs["attn_sink"].clone().detach().requires_grad_(True)
+            out, _ = fused_indexer_sparse_attn(
+                query,
+                kv,
+                sink,
+                inputs["window_idxs"],
+                inputs["q_indexer"],
+                inputs["k_indexer"],
+                inputs["weights"],
+                inputs["indexer_topk"],
+                inputs["ratio"],
+                inputs["softmax_scale"],
+                inputs["indexer_softmax_scale"],
+                0.0,
+                sparse_loss,
+                inputs["kv_offset"],
+                False,
+            )
+            if mutate_output:
+                out.data.copy_(torch.randn_like(out))
+            out.backward(grad_output)
+            return query.grad, kv.grad, sink.grad
+
+        reference = run(mutate_output=False)
+        mutated = run(mutate_output=True)
+        torch.testing.assert_close(mutated[0], reference[0], rtol=0, atol=0)
+        torch.testing.assert_close(mutated[1], reference[1], rtol=1e-3, atol=1e-3)
+        torch.testing.assert_close(mutated[2], reference[2], rtol=0, atol=0)
 
     @pytest.mark.parametrize(
         "sq,b,np_,hn,n_comp,win_topk,idx_nh,idx_hd,indexer_topk,ratio",
@@ -2629,6 +2679,39 @@ class TestDSASparseAttnBackward:
             "grad_attn_sink": attn_sink.grad,
         }
 
+    def test_backward_preserves_output_saved_for_di(self, device):
+        """Downstream in-place output mutation must not corrupt backward Di."""
+        inputs = self._make_inputs(64, 96, 16, 64, 32, device)
+        grad_output = torch.randn(
+            64, 16, 64, device=device, dtype=torch.bfloat16
+        )
+
+        def run(mutate_output: bool):
+            query = inputs["query"].clone().detach().requires_grad_(True)
+            kv = inputs["kv"].clone().detach().requires_grad_(True)
+            sink = inputs["attn_sink"].clone().detach().requires_grad_(True)
+            out, _, _ = _triton_dsa_sparse_attn_raw(
+                query,
+                kv,
+                inputs["topk_idxs"].unsqueeze(1),
+                inputs["softmax_scale"],
+                d_v=query.shape[-1],
+                attn_sink=sink,
+            )
+            if mutate_output:
+                # Models the downstream fused inverse-RoPE kernel, which writes
+                # through the output pointer without updating PyTorch's version
+                # counter.
+                out.data.copy_(torch.randn_like(out))
+            out.backward(grad_output)
+            return query.grad, kv.grad, sink.grad
+
+        reference = run(mutate_output=False)
+        mutated = run(mutate_output=True)
+        torch.testing.assert_close(mutated[0], reference[0], rtol=0, atol=0)
+        torch.testing.assert_close(mutated[1], reference[1], rtol=1e-3, atol=1e-3)
+        torch.testing.assert_close(mutated[2], reference[2], rtol=0, atol=0)
+
     @pytest.mark.parametrize(
         "total_sq,total_skv,np_,d,topk",
         [
@@ -2744,9 +2827,385 @@ class TestDSASparseAttnBackward:
         )
 
 
+class TestRatio128NoIndexerParity:
+    """Exercise the deterministic ratio=128 path used by alternating CSA layers."""
+
+    def test_ratio128_compressed_mask_boundaries(self):
+        device = torch.device("cuda")
+        ratio, sq, b, offset = 128, 2048, 2, 2048
+        indices = get_compress_topk_idxs(ratio, b, sq, offset, device)
+
+        assert indices.shape == (b, sq, sq // ratio)
+        for q in (0, 126, 127, 128, 254, 255, 256, sq - 1):
+            expected_count = (q + 1) // ratio
+            row = indices[0, q]
+            valid = row[row >= 0]
+
+            assert valid.numel() == expected_count, (
+                f"q={q}: expected {expected_count} completed compressed blocks, "
+                f"got {valid.numel()}"
+            )
+            torch.testing.assert_close(
+                valid,
+                torch.arange(
+                    offset,
+                    offset + expected_count,
+                    device=device,
+                    dtype=valid.dtype,
+                ),
+                rtol=0,
+                atol=0,
+            )
+
+    def test_ratio128_fused_unfused_forward_backward(self):
+        torch.manual_seed(20260730)
+        device = torch.device("cuda")
+
+        # A pretraining-shaped causal layout with deterministic compressed KV:
+        # 2048 original tokens, 16 completed ratio=128 blocks and a 128-token
+        # local window. Batch 1 keeps the materialized unfused reference
+        # comfortably below H100 memory limits.
+        sq, b, num_heads, d = 2048, 1, 32, 128
+        ratio, window_size = 128, 128
+        n_compressed = sq // ratio
+        offset = sq
+        scale = d**-0.5
+
+        query_base = torch.randn(
+            sq, b, num_heads, d, device=device, dtype=torch.bfloat16,
+        )
+        kv_base = torch.randn(
+            sq + n_compressed, b, d, device=device, dtype=torch.bfloat16,
+        )
+        sink_base = torch.randn(
+            num_heads, device=device, dtype=torch.float32,
+        ) * 0.1
+
+        window = get_window_topk_idxs(window_size, b, sq, device)
+        compressed = get_compress_topk_idxs(ratio, b, sq, offset, device)
+        combined = torch.cat((window, compressed), dim=-1).int()
+        flat_indices, _ = build_flat_topk_idxs(
+            window,
+            compressed,
+            batch_size=b,
+            seqlen_kv=sq + n_compressed,
+        )
+
+        query_u = query_base.clone().requires_grad_(True)
+        kv_u = kv_base.clone().requires_grad_(True)
+        sink_u = sink_base.clone().requires_grad_(True)
+        output_u = unfused_compressed_sparse_attn(
+            query_u,
+            kv_u,
+            sink_u,
+            combined,
+            scale,
+        )
+
+        query_f = query_base.clone().requires_grad_(True)
+        kv_f = kv_base.clone().requires_grad_(True)
+        sink_f = sink_base.clone().requires_grad_(True)
+        output_f = _triton_dsa_sparse_attn_sbhd(
+            query_f,
+            kv_f,
+            sink_f,
+            flat_indices,
+            scale,
+        )
+
+        grad_output = torch.randn_like(output_u)
+        output_u.backward(grad_output)
+        output_f.backward(grad_output)
+
+        def metrics(actual, reference):
+            actual = actual.float().reshape(-1)
+            reference = reference.float().reshape(-1)
+            relative_l2 = (
+                torch.linalg.vector_norm(actual - reference)
+                / torch.linalg.vector_norm(reference).clamp_min(1e-30)
+            ).item()
+            cosine = torch.nn.functional.cosine_similarity(
+                actual.unsqueeze(0),
+                reference.unsqueeze(0),
+            ).item()
+            norm_ratio = (
+                torch.linalg.vector_norm(actual)
+                / torch.linalg.vector_norm(reference).clamp_min(1e-30)
+            ).item()
+            return relative_l2, cosine, norm_ratio
+
+        output_metrics = metrics(output_f, output_u)
+        dq_metrics = metrics(query_f.grad, query_u.grad)
+        dkv_metrics = metrics(kv_f.grad, kv_u.grad)
+
+        logger.info(
+            "ratio128 parity: output(rel=%.6e cos=%.8f ratio=%.6f), "
+            "dQ(rel=%.6e cos=%.8f ratio=%.6f), "
+            "dKV(rel=%.6e cos=%.8f ratio=%.6f)",
+            *output_metrics,
+            *dq_metrics,
+            *dkv_metrics,
+        )
+
+        assert output_metrics[0] < 5e-3
+        assert output_metrics[1] > 0.999
+        assert dq_metrics[1] > 0.99
+        assert 0.95 < dq_metrics[2] < 1.05
+        assert dkv_metrics[1] > 0.99
+        assert 0.95 < dkv_metrics[2] < 1.05
+
+
 # ---------------------------------------------------------------------------
 # Indexer gradient accuracy: fused (triton plugin) vs unfused (Megatron core)
 # ---------------------------------------------------------------------------
+
+
+class TestRatioCausalMaskParity:
+    """Match the fused compressed-KV causal contract to the CSA reference."""
+
+    @staticmethod
+    def _unfused_reference_mask(
+        sq: int, sk: int, ratio: int, device: torch.device
+    ) -> Tensor:
+        # Keep this expression structurally identical to CSA._forward_unfused:
+        # compressed index k is valid iff k < (one_based_query_position // ratio).
+        compressed_indices = torch.arange(sk, device=device).unsqueeze(0).expand(sq, -1)
+        positions = torch.arange(1, sq + 1, device=device).unsqueeze(1)
+        return torch.where(
+            compressed_indices >= positions // ratio,
+            float("-inf"),
+            0.0,
+        )
+
+    @pytest.mark.parametrize(
+        "sq,sk,ratio",
+        [
+            (2048, 512, 4),
+            (4096, 1024, 4),
+        ],
+        ids=["pretrain_seq2k_ratio4", "pretrain_seq4k_ratio4"],
+    )
+    def test_compute_ratio_causal_mask_matches_unfused(self, sq, sk, ratio):
+        device = torch.device("cuda:0")
+        actual = compute_ratio_causal_mask(sq, sk, ratio, device)
+        expected = self._unfused_reference_mask(sq, sk, ratio, device)
+
+        assert torch.equal(actual, expected), (
+            f"ratio causal mask mismatch for sq={sq}, sk={sk}, ratio={ratio}; "
+            "fused must use the same floor-based compressed-token availability "
+            "as CSA._forward_unfused"
+        )
+
+    def test_pretrain_ratio4_valid_counts_at_compression_boundaries(self):
+        """Validate representative boundaries in a 4K pretraining sequence."""
+        device = torch.device("cuda:0")
+        sq, sk, ratio = 4096, 1024, 4
+        mask = compute_ratio_causal_mask(sq, sk, ratio, device)
+        actual_counts = torch.isfinite(mask).sum(dim=-1)
+        positions = torch.arange(1, sq + 1, device=device)
+        expected_counts = (positions // ratio).clamp(max=sk).to(actual_counts.dtype)
+
+        assert torch.equal(actual_counts, expected_counts), (
+            "4K ratio-4 causal availability differs from unfused CSA; "
+            f"first mismatching query positions: "
+            f"{torch.nonzero(actual_counts != expected_counts).flatten()[:16].tolist()}"
+        )
+
+        # Explicitly document the beginning, an interior compression boundary,
+        # and the final query position of the production sequence.
+        boundary_queries = torch.tensor(
+            [0, 1, 2, 3, 4, 1022, 1023, 1024, 4094, 4095],
+            device=device,
+        )
+        assert torch.equal(
+            actual_counts[boundary_queries],
+            expected_counts[boundary_queries],
+        )
+
+    def test_pretrain_topk_never_selects_future_compressed_tokens(self):
+        """Stress production top-k=256 with future positions ranked highest."""
+        device = torch.device("cuda:0")
+        sq, sk, ratio, topk = 4096, 1024, 4, 256
+
+        # Scores increase monotonically with compressed position, so every
+        # not-yet-available position outranks all causally valid positions.
+        # Correct masking must still restrict selection to k < (q+1)//ratio.
+        scores = (
+            torch.arange(sk, device=device, dtype=torch.float32)
+            .view(1, 1, sk)
+            .expand(1, sq, sk)
+        )
+        topk_indices, topk_length = topk_with_causal_mask(
+            scores, k=topk, ratio=ratio
+        )
+
+        valid_count_per_query = (
+            torch.arange(1, sq + 1, device=device, dtype=torch.int32) // ratio
+        ).clamp(max=sk)
+        expected_length = valid_count_per_query.clamp(max=topk).view(1, sq)
+        assert torch.equal(topk_length, expected_length)
+
+        valid_count = valid_count_per_query.view(1, sq, 1)
+        selected_is_valid = (topk_indices < valid_count) | (topk_indices == -1)
+        assert selected_is_valid.all(), (
+            "top-k selected a compressed token before the unfused CSA causal "
+            "contract makes it available"
+        )
+
+
+class TestSparseIndexerExtremeProbability:
+    """Stress sparse indexer KL semantics after predict probabilities become tiny.
+
+    The selected top-k is fixed to ``[0, 1]`` so these tests isolate the loss
+    and backward formulas from top-k selection and causal-mask differences.
+    """
+
+    @staticmethod
+    def _make_inputs(gap: float, device: torch.device) -> dict:
+        # Indexer logits are [gap + 1, 1], while the attention target logits
+        # are [1, gap + 1].  Both pre-ReLU indexer scores are strictly
+        # positive, avoiding the undefined derivative at ReLU(0).
+        high = (gap + 1.0) / 2.0
+        low = 0.5
+        q_idx = torch.tensor(
+            [[[[1.0, 1.0]]]], device=device, dtype=torch.bfloat16
+        )
+        k_idx = torch.tensor(
+            [[[high, high], [low, low]]], device=device, dtype=torch.bfloat16
+        )
+        weights = torch.ones((1, 1, 1), device=device, dtype=torch.bfloat16)
+
+        q_attn = torch.tensor(
+            [[[[1.0, 1.0]]]], device=device, dtype=torch.bfloat16
+        )
+        k_attn = torch.tensor(
+            [[[low, low], [high, high]]], device=device, dtype=torch.bfloat16
+        )
+        attn_logits = torch.einsum(
+            "bqhd,bkd->bqhk", q_attn.float(), k_attn.float()
+        )
+        lse = torch.logsumexp(attn_logits, dim=-1)
+
+        return {
+            "q_idx": q_idx,
+            "k_idx": k_idx,
+            "weights": weights,
+            "topk": torch.tensor([[[0, 1]]], device=device, dtype=torch.int32),
+            "q_attn": q_attn,
+            "k_attn": k_attn,
+            "lse": lse,
+        }
+
+    @staticmethod
+    def _run_fused(inputs: dict) -> dict:
+        loss, grad_q, grad_k, grad_w = fused_sparse_indexer_loss_and_backward(
+            inputs["q_idx"],
+            inputs["k_idx"],
+            inputs["weights"],
+            inputs["topk"],
+            inputs["q_attn"],
+            inputs["k_attn"],
+            inputs["lse"],
+            indexer_softmax_scale=1.0,
+            softmax_scale=1.0,
+            loss_coeff=1.0,
+            calculate_per_token_loss=False,
+            idx_nh=1,
+            kv_offset=0,
+        )
+        return {"loss": loss, "q": grad_q, "k": grad_k, "w": grad_w}
+
+    @staticmethod
+    def _run_autograd_reference(inputs: dict, epsilon: float) -> dict:
+        q = inputs["q_idx"].clone().requires_grad_(True)
+        k = inputs["k_idx"].clone().requires_grad_(True)
+        w = inputs["weights"].clone().requires_grad_(True)
+
+        per_head = torch.einsum("bqhd,bkd->bqhk", q.float(), k.float())
+        logits = (torch.relu(per_head) * w.float().unsqueeze(-1)).sum(dim=2)
+        predict = torch.softmax(logits, dim=-1)
+
+        attn_logits = torch.einsum(
+            "bqhd,bkd->bqhk",
+            inputs["q_attn"].float(),
+            inputs["k_attn"].float(),
+        )
+        target = torch.softmax(attn_logits, dim=-1).sum(dim=2)
+        target = target / target.sum(dim=-1, keepdim=True)
+
+        if epsilon == 0.0:
+            tiny = torch.finfo(torch.float32).tiny
+            t = target.clamp(min=tiny)
+            p = predict.clamp(min=tiny)
+            loss = (t * (torch.log(t) - torch.log(p))).sum(dim=-1).mean()
+        else:
+            # This is the sparse KL expression used by compute_dsa_indexer_loss.
+            loss = (
+                target
+                * (
+                    torch.log(target + epsilon)
+                    - torch.log(predict + epsilon)
+                )
+            ).sum(dim=-1).mean()
+
+        loss.backward()
+        return {
+            "loss": loss.detach(),
+            "q": q.grad.detach(),
+            "k": k.grad.detach(),
+            "w": w.grad.detach(),
+            "predict_min": predict.min().detach(),
+        }
+
+    @pytest.mark.parametrize("gap", [0.0, 10.0, 20.0, 30.0, 50.0])
+    def test_fused_manual_backward_matches_reference_formula(self, gap):
+        """The fused loss/backward must match the epsilon-smoothed reference."""
+        inputs = self._make_inputs(gap, torch.device("cuda:0"))
+        actual = self._run_fused(inputs)
+        expected = self._run_autograd_reference(inputs, epsilon=1e-10)
+
+        assert torch.allclose(actual["loss"], expected["loss"], atol=2e-4, rtol=2e-4)
+        for name in ("q", "k", "w"):
+            assert torch.allclose(
+                actual[name].float(),
+                expected[name].float(),
+                atol=2e-2,
+                rtol=3e-2,
+            ), (
+                f"gap={gap}: fused manual grad_{name} does not match the "
+                f"epsilon-smoothed unfused reference"
+            )
+
+    def test_extreme_probability_matches_unfused_epsilon_semantics(self):
+        """Guard parity after predict falls below the 1e-10 smoothing scale."""
+        inputs = self._make_inputs(30.0, torch.device("cuda:0"))
+        fused = self._run_fused(inputs)
+        unfused = self._run_autograd_reference(inputs, epsilon=1e-10)
+
+        fused_norm = fused["k"].float().norm()
+        unfused_norm = unfused["k"].float().norm()
+        norm_ratio = fused_norm / unfused_norm.clamp_min(1e-30)
+        loss_delta = (fused["loss"] - unfused["loss"]).abs()
+
+        logger.info(
+            "extreme sparse KL parity: predict_min=%.3e fused_loss=%.6f "
+            "unfused_loss=%.6f grad_k_norm_ratio=%.6f",
+            unfused["predict_min"].item(),
+            fused["loss"].item(),
+            unfused["loss"].item(),
+            norm_ratio.item(),
+        )
+
+        assert unfused["predict_min"] < 1e-10
+        assert loss_delta < 2e-4
+        assert 0.97 < norm_ratio < 1.03
+        for name in ("q", "k", "w"):
+            assert torch.allclose(
+                fused[name].float(),
+                unfused[name].float(),
+                atol=2e-2,
+                rtol=3e-2,
+            ), f"extreme-probability grad_{name} parity failed"
 
 
 class TestIndexerGradAccuracy:
@@ -3680,4 +4139,3 @@ class TestFusedBackwardIntegration:
             f"dq_norm={query.grad.float().norm().item():.4e}, "
             f"dkv_norm={kv.grad.float().norm().item():.4e}"
         )
-


### PR DESCRIPTION
# Description

Add fused dsa kernel for sm90. Remove dependency of cuDNN, FlashMLA and sm100+.

此工作获得以下项目资助：北京市科技计划项目，面向国产智能处理器计算平台的大模型并行训练框架研究，项目编号 Z251100008125033
## Type of change

- [ ✅] New feature (non-breaking change which adds functionality)
- [ ] Infra/Build change (changes to CI/CD workflows or build scripts)
- [ ] Code refactoring
- [ ] Documentation change
- [ ] Bug fix
- [ ] Breaking change

## Changes
1. Add fused_dsa_kernel files in megatron/plugin/dsa_kernel.
2. Add fused_dsa_test file in tests/unit_test/plugin/dsa_kernel.
3. Add router between sm90(triton and pytorch) or sm100+(cuDNN and FlashMLA) for fused kernel in csa.py. 
4. 🚀 Add SM 90 optimization. Change triton grid to be use WGMMA.

## Checklist

- [ ] I have read and followed the contributing guidelines
- [ ] The functionality is complete
- [ ] I have commented my code, particularly in coverage report uploading steps
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added/updated tests that prove my feature works
- [ ] New and existing unit tests pass locally

## Test Result on H800
Generated: 2026-07-23 16:47:22

### Accuracy

| test_class | test_name | target | sq | b | np | topk | sparse_loss | ratio | win | skv | cos_sim | max_diff | mean_diff | status |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| TestFusedIndexerSparseAttnAccuracy | test_output_accuracy[sparse-7B_B1_sq2048_topk256] | output | 2048 | 1 | 32 | 256 | True |  |  |  | 1.000000 | 7.8125e-03 | 1.3359e-05 | PASS |
| TestFusedIndexerSparseAttnAccuracy | test_output_accuracy[sparse-7B_B2_sq2048_topk256] | output | 2048 | 2 | 32 | 256 | True |  |  |  | 1.000000 | 7.8125e-03 | 1.3485e-05 | PASS |
| TestFusedIndexerSparseAttnAccuracy | test_output_accuracy[sparse-13B_B1_sq4096_topk384] | output | 4096 | 1 | 32 | 384 | True |  |  |  | 1.000000 | 7.8125e-03 | 1.0461e-05 | PASS |
| TestFusedIndexerSparseAttnAccuracy | test_output_accuracy[sparse-70B_B1_sq2048_topk512] | output | 2048 | 1 | 64 | 512 | True |  |  |  | 1.000000 | 7.8125e-03 | 1.2812e-05 | PASS |
| TestFusedIndexerSparseAttnAccuracy | test_output_accuracy[sparse-longctx_B1_sq8192_topk512] | output | 8192 | 1 | 32 | 512 | True |  |  |  | 1.000000 | 7.8125e-03 | 9.3390e-06 | PASS |
| TestFusedIndexerSparseAttnAccuracy | test_output_accuracy[dense-7B_B1_sq2048_topk256] | output | 2048 | 1 | 32 | 256 | False |  |  |  | 1.000000 | 7.8125e-03 | 1.3359e-05 | PASS |
| TestFusedIndexerSparseAttnAccuracy | test_output_accuracy[dense-7B_B2_sq2048_topk256] | output | 2048 | 2 | 32 | 256 | False |  |  |  | 1.000000 | 7.8125e-03 | 1.3485e-05 | PASS |
| TestFusedIndexerSparseAttnAccuracy | test_output_accuracy[dense-13B_B1_sq4096_topk384] | output | 4096 | 1 | 32 | 384 | False |  |  |  | 1.000000 | 7.8125e-03 | 1.0461e-05 | PASS |
| TestFusedIndexerSparseAttnAccuracy | test_output_accuracy[dense-70B_B1_sq2048_topk512] | output | 2048 | 1 | 64 | 512 | False |  |  |  | 1.000000 | 7.8125e-03 | 1.2812e-05 | PASS |
| TestFusedIndexerSparseAttnAccuracy | test_output_accuracy[dense-longctx_B1_sq8192_topk512] | output | 8192 | 1 | 32 | 512 | False |  |  |  | 1.000000 | 7.8125e-03 | 9.3390e-06 | PASS |
| TestFusedIndexerSparseAttnBackward | test_grad_query_accuracy[sparse-7B_B1_sq2048_topk256] | grad_query | 2048 | 1 | 32 | 256 | True |  |  |  | 0.999992 | 2.3438e-02 | 2.9477e-04 | PASS |
| TestFusedIndexerSparseAttnBackward | test_grad_query_accuracy[sparse-7B_B2_sq2048_topk256] | grad_query | 2048 | 2 | 32 | 256 | True |  |  |  | 0.999992 | 2.3438e-02 | 3.0626e-04 | PASS |
| TestFusedIndexerSparseAttnBackward | test_grad_query_accuracy[sparse-13B_B1_sq4096_topk384] | grad_query | 4096 | 1 | 32 | 384 | True |  |  |  | 0.999993 | 2.3438e-02 | 2.4112e-04 | PASS |
| TestFusedIndexerSparseAttnBackward | test_grad_query_accuracy[sparse-70B_B1_sq2048_topk512] | grad_query | 2048 | 1 | 64 | 512 | True |  |  |  | 0.999992 | 1.9531e-02 | 2.8157e-04 | PASS |
| TestFusedIndexerSparseAttnBackward | test_grad_query_accuracy[dense-7B_B1_sq2048_topk256] | grad_query | 2048 | 1 | 32 | 256 | False |  |  |  | 0.999992 | 2.3438e-02 | 2.9477e-04 | PASS |
| TestFusedIndexerSparseAttnBackward | test_grad_query_accuracy[dense-7B_B2_sq2048_topk256] | grad_query | 2048 | 2 | 32 | 256 | False |  |  |  | 0.999992 | 2.3438e-02 | 3.0626e-04 | PASS |
| TestFusedIndexerSparseAttnBackward | test_grad_query_accuracy[dense-13B_B1_sq4096_topk384] | grad_query | 4096 | 1 | 32 | 384 | False |  |  |  | 0.999993 | 2.3438e-02 | 2.4112e-04 | PASS |
| TestFusedIndexerSparseAttnBackward | test_grad_query_accuracy[dense-70B_B1_sq2048_topk512] | grad_query | 2048 | 1 | 64 | 512 | False |  |  |  | 0.999992 | 1.9531e-02 | 2.8157e-04 | PASS |
| TestFusedIndexerSparseAttnBackward | test_grad_kv_accuracy[sparse-7B_B1_sq2048_topk256] | grad_kv | 2048 | 1 | 32 | 256 | True |  |  |  | 1.000000 | 2.0000e+00 | 3.7498e-03 | PASS |
| TestFusedIndexerSparseAttnBackward | test_grad_kv_accuracy[sparse-7B_B2_sq2048_topk256] | grad_kv | 2048 | 2 | 32 | 256 | True |  |  |  | 1.000000 | 2.0000e+00 | 3.6829e-03 | PASS |
| TestFusedIndexerSparseAttnBackward | test_grad_kv_accuracy[sparse-13B_B1_sq4096_topk384] | grad_kv | 4096 | 1 | 32 | 384 | True |  |  |  | 1.000000 | 2.0000e+00 | 3.1600e-03 | PASS |
| TestFusedIndexerSparseAttnBackward | test_grad_kv_accuracy[sparse-70B_B1_sq2048_topk512] | grad_kv | 2048 | 1 | 64 | 512 | True |  |  |  | 1.000000 | 4.0000e+00 | 6.4384e-03 | PASS |
| TestFusedIndexerSparseAttnBackward | test_grad_kv_accuracy[dense-7B_B1_sq2048_topk256] | grad_kv | 2048 | 1 | 32 | 256 | False |  |  |  | 1.000000 | 2.0000e+00 | 3.7500e-03 | PASS |
| TestFusedIndexerSparseAttnBackward | test_grad_kv_accuracy[dense-7B_B2_sq2048_topk256] | grad_kv | 2048 | 2 | 32 | 256 | False |  |  |  | 1.000000 | 2.0000e+00 | 3.6829e-03 | PASS |
| TestFusedIndexerSparseAttnBackward | test_grad_kv_accuracy[dense-13B_B1_sq4096_topk384] | grad_kv | 4096 | 1 | 32 | 384 | False |  |  |  | 1.000000 | 2.0000e+00 | 3.1600e-03 | PASS |
| TestFusedIndexerSparseAttnBackward | test_grad_kv_accuracy[dense-70B_B1_sq2048_topk512] | grad_kv | 2048 | 1 | 64 | 512 | False |  |  |  | 1.000000 | 4.0000e+00 | 6.4447e-03 | PASS |
| TestFusedIndexerSparseAttnBackward | test_grad_attn_sink_accuracy[7B_B1_sq2048_topk256] | grad_attn_sink | 2048 | 1 | 32 | 256 |  |  |  |  | 0.999999 | 9.0747e-03 | 2.9883e-03 | PASS |
| TestFusedIndexerSparseAttnBackward | test_grad_attn_sink_accuracy[13B_B1_sq4096_topk384] | grad_attn_sink | 4096 | 1 | 32 | 384 |  |  |  |  | 1.000000 | 1.5473e-02 | 3.3031e-03 | PASS |
| TestFusedIndexerSparseAttnBackward | test_grad_attn_sink_accuracy[70B_B1_sq2048_topk512] | grad_attn_sink | 2048 | 1 | 64 | 512 |  |  |  |  | 0.999999 | 1.0878e-02 | 3.5503e-03 | PASS |
| TestCSAFusedVsUnfusedAccuracy | test_output_accuracy[sparse-7B_sq2048_topk256] | module_output | 2048 | 1 | 32 | 256 | True |  |  |  | 0.991966 | 3.0537e+00 | 3.0236e-03 | PASS |
| TestCSAFusedVsUnfusedAccuracy | test_output_accuracy[sparse-13B_sq4096_topk384] | module_output | 4096 | 1 | 32 | 384 | True |  |  |  | 0.994825 | 3.0156e+00 | 1.5983e-03 | PASS |
| TestCSAFusedVsUnfusedAccuracy | test_output_accuracy[sparse-70B_sq2048_topk512] | module_output | 2048 | 1 | 64 | 512 | True |  |  |  | 0.991015 | 3.0156e+00 | 2.7717e-03 | PASS |
| TestCSAFusedVsUnfusedAccuracy | test_output_accuracy[dense-7B_sq2048_topk256] | module_output | 2048 | 1 | 32 | 256 | False |  |  |  | 0.991966 | 3.0537e+00 | 3.0236e-03 | PASS |
| TestCSAFusedVsUnfusedAccuracy | test_output_accuracy[dense-13B_sq4096_topk384] | module_output | 4096 | 1 | 32 | 384 | False |  |  |  | 0.994825 | 3.0156e+00 | 1.5983e-03 | PASS |
| TestCSAFusedVsUnfusedAccuracy | test_output_accuracy[dense-70B_sq2048_topk512] | module_output | 2048 | 1 | 64 | 512 | False |  |  |  | 0.991015 | 3.0156e+00 | 2.7717e-03 | PASS |
| TestCSAFusedVsUnfusedAccuracy | test_grad_accuracy[sparse-2048-1-32-128-128-256] | module_grad_query | 2048 | 1 | 32 | 256 | True |  |  |  | 0.996879 | - | - | PASS |
| TestCSAFusedVsUnfusedAccuracy | test_grad_accuracy[sparse-2048-1-32-128-128-256] | module_grad_key | 2048 | 1 | 32 | 256 | True |  |  |  | 0.999793 | - | - | PASS |
| TestCSAFusedVsUnfusedAccuracy | test_grad_accuracy[dense-2048-1-32-128-128-256] | module_grad_query | 2048 | 1 | 32 | 256 | False |  |  |  | 0.996879 | - | - | PASS |
| TestCSAFusedVsUnfusedAccuracy | test_grad_accuracy[dense-2048-1-32-128-128-256] | module_grad_key | 2048 | 1 | 32 | 256 | False |  |  |  | 0.999793 | - | - | PASS |
| TestDSAIndexerLossAutoScaler | test_e2e_grad_with_autoscaler[sparse-2048-1-32-128-128-256] | autoscaler_grad_ratio | 2048 |  | 32 | 256 | True |  |  |  | 0.999057 | - | - | PASS |
| TestDSAIndexerLossAutoScaler | test_e2e_grad_with_autoscaler[dense-2048-1-32-128-128-256] | autoscaler_grad_ratio | 2048 |  | 32 | 256 | False |  |  |  | 0.999057 | - | - | PASS |
| TestCSANoIndexerFusedVsUnfused | test_output_accuracy_no_indexer[win_only_2k] | no_indexer_output | 2048 | 1 | 32 |  |  | 0 | 128 |  | 1.000000 | 7.8125e-03 | 1.9366e-05 | PASS |
| TestCSANoIndexerFusedVsUnfused | test_output_accuracy_no_indexer[win_only_4k] | no_indexer_output | 4096 | 1 | 32 |  |  | 0 | 256 |  | 1.000000 | 7.8125e-03 | 1.4523e-05 | PASS |
| TestCSANoIndexerFusedVsUnfused | test_output_accuracy_no_indexer[ratio128_2k] | no_indexer_output | 2048 | 1 | 32 |  |  | 128 | 128 |  | 1.000000 | 7.8125e-03 | 1.8411e-05 | PASS |
| TestCSANoIndexerFusedVsUnfused | test_output_accuracy_no_indexer[ratio128_4k] | no_indexer_output | 4096 | 1 | 32 |  |  | 128 | 256 |  | 1.000000 | 7.8125e-03 | 1.3916e-05 | PASS |
| TestCSANoIndexerFusedVsUnfused | test_grad_accuracy_no_indexer[win_only_2k] | no_indexer_grad_query | 2048 |  | 32 |  |  | 0 | 128 |  | 0.999999 | - | - | PASS |
| TestCSANoIndexerFusedVsUnfused | test_grad_accuracy_no_indexer[win_only_2k] | no_indexer_grad_key | 2048 |  | 32 |  |  | 0 | 128 |  | 0.986620 | - | - | PASS |
| TestCSANoIndexerFusedVsUnfused | test_grad_accuracy_no_indexer[win_only_4k] | no_indexer_grad_query | 4096 |  | 32 |  |  | 0 | 256 |  | 0.999999 | - | - | PASS |
| TestCSANoIndexerFusedVsUnfused | test_grad_accuracy_no_indexer[win_only_4k] | no_indexer_grad_key | 4096 |  | 32 |  |  | 0 | 256 |  | 0.940347 | - | - | PASS |
| TestCSANoIndexerFusedVsUnfused | test_grad_accuracy_no_indexer[ratio128_2k] | no_indexer_grad_query | 2048 |  | 32 |  |  | 128 | 128 |  | 0.999999 | - | - | PASS |
| TestCSANoIndexerFusedVsUnfused | test_grad_accuracy_no_indexer[ratio128_2k] | no_indexer_grad_key | 2048 |  | 32 |  |  | 128 | 128 |  | 0.986117 | - | - | PASS |
| TestCSANoIndexerFusedVsUnfused | test_grad_accuracy_no_indexer[ratio128_4k] | no_indexer_grad_query | 4096 |  | 32 |  |  | 128 | 256 |  | 0.999999 | - | - | PASS |
| TestCSANoIndexerFusedVsUnfused | test_grad_accuracy_no_indexer[ratio128_4k] | no_indexer_grad_key | 4096 |  | 32 |  |  | 128 | 256 |  | 0.937717 | - | - | PASS |
| TestDSASparseAttnBackward | test_grad_query_accuracy[bmm_bwd_topk128] | kernel_grad_query | 2048 |  | 32 | 128 |  |  |  | 2048 | 0.999999 | - | - | PASS |
| TestDSASparseAttnBackward | test_grad_query_accuracy[bmm_bwd_topk256] | kernel_grad_query | 2048 |  | 32 | 256 |  |  |  | 2048 | 0.999999 | - | - | PASS |
| TestDSASparseAttnBackward | test_grad_query_accuracy[bmm_bwd_topk256_sq4k] | kernel_grad_query | 4096 |  | 32 | 256 |  |  |  | 4096 | 0.999999 | - | - | PASS |
| TestDSASparseAttnBackward | test_grad_query_accuracy[bmm_bwd_topk128_np64] | kernel_grad_query | 2048 |  | 64 | 128 |  |  |  | 2048 | 0.999999 | - | - | PASS |
| TestDSASparseAttnBackward | test_grad_query_accuracy[triton_bwd_topk640] | kernel_grad_query | 2048 |  | 32 | 640 |  |  |  | 2048 | 0.999999 | - | - | PASS |
| TestDSASparseAttnBackward | test_grad_query_accuracy[triton_bwd_topk768] | kernel_grad_query | 2048 |  | 32 | 768 |  |  |  | 4096 | 0.999999 | - | - | PASS |
| TestDSASparseAttnBackward | test_grad_kv_accuracy[bmm_bwd_topk128] | kernel_grad_kv | 2048 |  | 32 | 128 |  |  |  | 2048 | 0.995320 | - | - | PASS |
| TestDSASparseAttnBackward | test_grad_kv_accuracy[bmm_bwd_topk256] | kernel_grad_kv | 2048 |  | 32 | 256 |  |  |  | 2048 | 0.996576 | - | - | PASS |
| TestDSASparseAttnBackward | test_grad_kv_accuracy[triton_bwd_topk640] | kernel_grad_kv | 2048 |  | 32 | 640 |  |  |  | 2048 | 0.993962 | - | - | PASS |
| TestIndexerGradAccuracy | test_grad_q_indexer_accuracy[sparse-7B_B1_sq2048_topk256] | grad_q_indexer | 2048 | 1 | 32 | 256 | True |  |  |  | 0.993276 | 3.4750e-05 | 2.7776e-08 | PASS |
| TestIndexerGradAccuracy | test_grad_q_indexer_accuracy[sparse-7B_B2_sq2048_topk256] | grad_q_indexer | 2048 | 2 | 32 | 256 | True |  |  |  | 0.995950 | 1.1325e-05 | 1.1621e-08 | PASS |
| TestIndexerGradAccuracy | test_grad_q_indexer_accuracy[sparse-13B_B1_sq4096_topk384] | grad_q_indexer | 4096 | 1 | 32 | 384 | True |  |  |  | 0.996359 | 2.1398e-05 | 7.6407e-09 | PASS |
| TestIndexerGradAccuracy | test_grad_q_indexer_accuracy[sparse-70B_B1_sq2048_topk512] | grad_q_indexer | 2048 | 1 | 64 | 512 | True |  |  |  | 0.993694 | 4.3154e-05 | 2.6222e-08 | PASS |
| TestIndexerGradAccuracy | test_grad_q_indexer_accuracy[dense-7B_B1_sq2048_topk256] | grad_q_indexer | 2048 | 1 | 32 | 256 | False |  |  |  | 0.993401 | 3.4750e-05 | 2.6959e-08 | PASS |
| TestIndexerGradAccuracy | test_grad_q_indexer_accuracy[dense-7B_B2_sq2048_topk256] | grad_q_indexer | 2048 | 2 | 32 | 256 | False |  |  |  | 0.996035 | 1.1325e-05 | 1.1183e-08 | PASS |
| TestIndexerGradAccuracy | test_grad_q_indexer_accuracy[dense-13B_B1_sq4096_topk384] | grad_q_indexer | 4096 | 1 | 32 | 384 | False |  |  |  | 0.996522 | 2.1398e-05 | 7.2709e-09 | PASS |
| TestIndexerGradAccuracy | test_grad_q_indexer_accuracy[dense-70B_B1_sq2048_topk512] | grad_q_indexer | 2048 | 1 | 64 | 512 | False |  |  |  | 0.993694 | 4.3154e-05 | 2.6222e-08 | PASS |
| TestIndexerGradAccuracy | test_grad_k_indexer_accuracy[sparse-7B_B1_sq2048_topk256] | grad_k_indexer | 2048 | 1 | 32 | 256 | True |  |  |  | 0.996526 | 2.3484e-05 | 2.6327e-07 | PASS |
| TestIndexerGradAccuracy | test_grad_k_indexer_accuracy[sparse-7B_B2_sq2048_topk256] | grad_k_indexer | 2048 | 2 | 32 | 256 | True |  |  |  | 0.997777 | 1.4424e-05 | 1.0151e-07 | PASS |
| TestIndexerGradAccuracy | test_grad_k_indexer_accuracy[sparse-13B_B1_sq4096_topk384] | grad_k_indexer | 4096 | 1 | 32 | 384 | True |  |  |  | 0.998360 | 1.1086e-05 | 7.1334e-08 | PASS |
| TestIndexerGradAccuracy | test_grad_k_indexer_accuracy[sparse-70B_B1_sq2048_topk512] | grad_k_indexer | 2048 | 1 | 64 | 512 | True |  |  |  | 0.996880 | 2.2247e-05 | 2.4753e-07 | PASS |
| TestIndexerGradAccuracy | test_grad_k_indexer_accuracy[dense-7B_B1_sq2048_topk256] | grad_k_indexer | 2048 | 1 | 32 | 256 | False |  |  |  | 0.996682 | 2.3365e-05 | 2.5772e-07 | PASS |
| TestIndexerGradAccuracy | test_grad_k_indexer_accuracy[dense-7B_B2_sq2048_topk256] | grad_k_indexer | 2048 | 2 | 32 | 256 | False |  |  |  | 0.997883 | 1.4544e-05 | 9.8895e-08 | PASS |
| TestIndexerGradAccuracy | test_grad_k_indexer_accuracy[dense-13B_B1_sq4096_topk384] | grad_k_indexer | 4096 | 1 | 32 | 384 | False |  |  |  | 0.998506 | 1.1027e-05 | 6.8712e-08 | PASS |
| TestIndexerGradAccuracy | test_grad_k_indexer_accuracy[dense-70B_B1_sq2048_topk512] | grad_k_indexer | 2048 | 1 | 64 | 512 | False |  |  |  | 0.996880 | 2.2247e-05 | 2.4753e-07 | PASS |
| TestIndexerGradAccuracy | test_grad_weights_accuracy[sparse-7B_B1_sq2048_topk256] | grad_weights | 2048 | 1 | 32 | 256 | True |  |  |  | 0.998697 | 4.4420e-04 | 1.9908e-06 | PASS |
| TestIndexerGradAccuracy | test_grad_weights_accuracy[sparse-7B_B2_sq2048_topk256] | grad_weights | 2048 | 2 | 32 | 256 | True |  |  |  | 0.999185 | 2.0191e-04 | 8.6791e-07 | PASS |
| TestIndexerGradAccuracy | test_grad_weights_accuracy[sparse-13B_B1_sq4096_topk384] | grad_weights | 4096 | 1 | 32 | 384 | True |  |  |  | 0.999503 | 1.6681e-04 | 5.7243e-07 | PASS |
| TestIndexerGradAccuracy | test_grad_weights_accuracy[sparse-70B_B1_sq2048_topk512] | grad_weights | 2048 | 1 | 64 | 512 | True |  |  |  | 0.999124 | 3.3225e-04 | 1.8590e-06 | PASS |
| TestIndexerGradAccuracy | test_grad_weights_accuracy[dense-7B_B1_sq2048_topk256] | grad_weights | 2048 | 1 | 32 | 256 | False |  |  |  | 0.998851 | 1.3004e-03 | 1.4960e-04 | PASS |
| TestIndexerGradAccuracy | test_grad_weights_accuracy[dense-7B_B2_sq2048_topk256] | grad_weights | 2048 | 2 | 32 | 256 | False |  |  |  | 0.999283 | 6.6285e-04 | 7.5078e-05 | PASS |
| TestIndexerGradAccuracy | test_grad_weights_accuracy[dense-13B_B1_sq4096_topk384] | grad_weights | 4096 | 1 | 32 | 384 | False |  |  |  | 0.999603 | 8.4341e-04 | 7.7698e-05 | PASS |
| TestIndexerGradAccuracy | test_grad_weights_accuracy[dense-70B_B1_sq2048_topk512] | grad_weights | 2048 | 1 | 64 | 512 | False |  |  |  | 0.999124 | 1.5159e-03 | 1.4972e-04 | PASS |
| TestIndexerLossConsistency | test_loss_value_consistency[sparse-7B_B1_sq2048_topk256] | indexer_loss | 2048 | 1 | 32 | 256 | True |  |  |  | 0.999031 | 9.2544e-05 | - | PASS |
| TestIndexerLossConsistency | test_loss_value_consistency[sparse-7B_B2_sq2048_topk256] | indexer_loss | 2048 | 2 | 32 | 256 | True |  |  |  | 0.999798 | 1.9602e-05 | - | PASS |
| TestIndexerLossConsistency | test_loss_value_consistency[sparse-13B_B1_sq4096_topk384] | indexer_loss | 4096 | 1 | 32 | 384 | True |  |  |  | 0.999917 | 7.8380e-06 | - | PASS |
| TestIndexerLossConsistency | test_loss_value_consistency[sparse-70B_B1_sq2048_topk512] | indexer_loss | 2048 | 1 | 64 | 512 | True |  |  |  | 0.998999 | 1.0376e-04 | - | PASS |
| TestIndexerLossConsistency | test_loss_value_consistency[dense-7B_B1_sq2048_topk256] | indexer_loss | 2048 | 1 | 32 | 256 | False |  |  |  | 0.998686 | 1.3697e-04 | - | PASS |
| TestIndexerLossConsistency | test_loss_value_consistency[dense-7B_B2_sq2048_topk256] | indexer_loss | 2048 | 2 | 32 | 256 | False |  |  |  | 0.999772 | 2.4140e-05 | - | PASS |
| TestIndexerLossConsistency | test_loss_value_consistency[dense-13B_B1_sq4096_topk384] | indexer_loss | 4096 | 1 | 32 | 384 | False |  |  |  | 0.999657 | 3.7484e-05 | - | PASS |
| TestIndexerLossConsistency | test_loss_value_consistency[dense-70B_B1_sq2048_topk512] | indexer_loss | 2048 | 1 | 64 | 512 | False |  |  |  | 0.998999 | 1.0376e-04 | - | PASS |
| TestIndexerLossConsistency | test_per_token_vs_mean_reduction[sparse-7B_B1_sq2048] | per_token_vs_mean | 2048 | 1 |  |  | True |  |  |  | 1.000000 | - | - | PASS |
| TestIndexerLossConsistency | test_per_token_vs_mean_reduction[sparse-7B_B2_sq2048] | per_token_vs_mean | 2048 | 2 |  |  | True |  |  |  | 1.000000 | - | - | PASS |
| TestIndexerLossConsistency | test_per_token_vs_mean_reduction[sparse-13B_B1_sq4096] | per_token_vs_mean | 4096 | 1 |  |  | True |  |  |  | 1.000000 | - | - | PASS |
| TestIndexerLossConsistency | test_per_token_vs_mean_reduction[dense-7B_B1_sq2048] | per_token_vs_mean | 2048 | 1 |  |  | False |  |  |  | 1.000000 | - | - | PASS |
| TestIndexerLossConsistency | test_per_token_vs_mean_reduction[dense-7B_B2_sq2048] | per_token_vs_mean | 2048 | 2 |  |  | False |  |  |  | 1.000000 | - | - | PASS |
| TestIndexerLossConsistency | test_per_token_vs_mean_reduction[dense-13B_B1_sq4096] | per_token_vs_mean | 4096 | 1 |  |  | False |  |  |  | 1.000000 | - | - | PASS |


### Performance

| test_class | test_name | label | sq | b | np | topk | sparse_loss | win | ratio | fused_ms | unfused_ms | speedup |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| TestFusedIndexerSparseAttnPerformance | test_performance_forward[sparse-7B_B1_sq2048_topk256] | fwd | 2048 | 1 | 32 | 256 | True |  |  | 2.582 | 6.038 | 2.34x |
| TestFusedIndexerSparseAttnPerformance | test_performance_forward[sparse-7B_B2_sq2048_topk256] | fwd | 2048 | 2 | 32 | 256 | True |  |  | 3.888 | 10.820 | 2.78x |
| TestFusedIndexerSparseAttnPerformance | test_performance_forward[sparse-13B_B1_sq4096_topk384] | fwd | 4096 | 1 | 32 | 384 | True |  |  | 5.347 | 17.483 | 3.27x |
| TestFusedIndexerSparseAttnPerformance | test_performance_forward[sparse-70B_B1_sq2048_topk512] | fwd | 2048 | 1 | 64 | 512 | True |  |  | 4.374 | 13.644 | 3.12x |
| TestFusedIndexerSparseAttnPerformance | test_performance_forward[sparse-13B_B1_sq4096_topk512] | fwd | 4096 | 1 | 32 | 512 | True |  |  | 6.338 | 19.434 | 3.07x |
| TestFusedIndexerSparseAttnPerformance | test_performance_forward[sparse-13B_B1_sq4096_topk1024] | fwd | 4096 | 1 | 32 | 1024 | True |  |  | 10.644 | 35.635 | 3.35x |
| TestFusedIndexerSparseAttnPerformance | test_performance_forward[sparse-longctx_B1_sq8192_topk512] | fwd | 8192 | 1 | 32 | 512 | True |  |  | 12.333 | 42.490 | 3.45x |
| TestFusedIndexerSparseAttnPerformance | test_performance_forward[dense-7B_B1_sq2048_topk256] | fwd | 2048 | 1 | 32 | 256 | False |  |  | 2.997 | 4.702 | 1.57x |
| TestFusedIndexerSparseAttnPerformance | test_performance_forward[dense-7B_B2_sq2048_topk256] | fwd | 2048 | 2 | 32 | 256 | False |  |  | 4.114 | 8.582 | 2.09x |
| TestFusedIndexerSparseAttnPerformance | test_performance_forward[dense-13B_B1_sq4096_topk384] | fwd | 4096 | 1 | 32 | 384 | False |  |  | 6.655 | 15.075 | 2.27x |
| TestFusedIndexerSparseAttnPerformance | test_performance_forward[dense-70B_B1_sq2048_topk512] | fwd | 2048 | 1 | 64 | 512 | False |  |  | 3.890 | 9.904 | 2.55x |
| TestFusedIndexerSparseAttnPerformance | test_performance_forward[dense-13B_B1_sq4096_topk512] | fwd | 4096 | 1 | 32 | 512 | False |  |  | 6.655 | 15.064 | 2.26x |
| TestFusedIndexerSparseAttnPerformance | test_performance_forward[dense-13B_B1_sq4096_topk1024] | fwd | 4096 | 1 | 32 | 1024 | False |  |  | 6.897 | 23.552 | 3.41x |
| TestFusedIndexerSparseAttnPerformance | test_performance_forward[dense-longctx_B1_sq8192_topk512] | fwd | 8192 | 1 | 32 | 512 | False |  |  | 20.055 | 40.519 | 2.02x |
| TestFusedIndexerSparseAttnPerformance | test_performance_backward[7B_sq2048_topk256] | bwd | 2048 | 1 | 32 | 256 |  |  |  | 6.365 | 6.365 | 1.00x |
| TestFusedIndexerSparseAttnPerformance | test_performance_backward[13B_sq4096_topk384] | bwd | 4096 | 1 | 32 | 384 |  |  |  | 16.626 | 16.626 | 1.00x |
| TestFusedIndexerSparseAttnPerformance | test_performance_backward[70B_sq2048_topk512] | bwd | 2048 | 1 | 64 | 512 |  |  |  | 13.526 | 13.526 | 1.00x |
| TestFusedIndexerSparseAttnPerformance | test_performance_end_to_end[sparse-7B_B1_sq2048_topk256] | e2e | 2048 | 1 | 32 | 256 | True |  |  | 6.371 | 201.623 | 31.65x |
| TestFusedIndexerSparseAttnPerformance | test_performance_end_to_end[sparse-7B_B2_sq2048_topk256] | e2e | 2048 | 2 | 32 | 256 | True |  |  | 11.331 | 216.201 | 19.08x |
| TestFusedIndexerSparseAttnPerformance | test_performance_end_to_end[sparse-13B_B1_sq4096_topk384] | e2e | 4096 | 1 | 32 | 384 | True |  |  | 16.631 | 464.293 | 27.92x |
| TestFusedIndexerSparseAttnPerformance | test_performance_end_to_end[sparse-70B_B1_sq2048_topk512] | e2e | 2048 | 1 | 64 | 512 | True |  |  | 13.507 | 771.662 | 57.13x |
| TestFusedIndexerSparseAttnPerformance | test_performance_end_to_end[dense-7B_B1_sq2048_topk256] | e2e | 2048 | 1 | 32 | 256 | False |  |  | 7.969 | 15.718 | 1.97x |
| TestFusedIndexerSparseAttnPerformance | test_performance_end_to_end[dense-7B_B2_sq2048_topk256] | e2e | 2048 | 2 | 32 | 256 | False |  |  | 11.148 | 32.614 | 2.93x |
| TestFusedIndexerSparseAttnPerformance | test_performance_end_to_end[dense-13B_B1_sq4096_topk384] | e2e | 4096 | 1 | 32 | 384 | False |  |  | 18.168 | 52.038 | 2.86x |
| TestFusedIndexerSparseAttnPerformance | test_performance_end_to_end[dense-70B_B1_sq2048_topk512] | e2e | 2048 | 1 | 64 | 512 | False |  |  | 11.255 | 32.685 | 2.90x |
| TestCSAFusedVsUnfusedPerformance | test_e2e_performance[sparse-7B_sq2048_topk256] | module_e2e | 2048 | 1 | 32 | 256 | True | 128 |  | 9.394 | 12.915 | 1.37x |
| TestCSAFusedVsUnfusedPerformance | test_e2e_performance[sparse-13B_sq4096_topk384] | module_e2e | 4096 | 1 | 32 | 384 | True | 256 |  | 19.695 | 35.662 | 1.81x |
| TestCSAFusedVsUnfusedPerformance | test_e2e_performance[sparse-70B_sq2048_topk512] | module_e2e | 2048 | 1 | 64 | 512 | True | 128 |  | 16.474 | 22.670 | 1.38x |
| TestCSAFusedVsUnfusedPerformance | test_e2e_performance[sparse-13B_sq4096_topk512] | module_e2e | 4096 | 1 | 32 | 512 | True | 128 |  | 21.854 | 35.755 | 1.64x |
| TestCSAFusedVsUnfusedPerformance | test_e2e_performance[sparse-13B_sq4096_topk1024] | module_e2e | 4096 | 1 | 32 | 1024 | True | 128 |  | 40.443 | 50.718 | 1.25x |
| TestCSAFusedVsUnfusedPerformance | test_e2e_performance[dense-7B_sq2048_topk256] | module_e2e | 2048 | 1 | 32 | 256 | False | 128 |  | 11.696 | 12.657 | 1.08x |
| TestCSAFusedVsUnfusedPerformance | test_e2e_performance[dense-13B_sq4096_topk384] | module_e2e | 4096 | 1 | 32 | 384 | False | 256 |  | 21.247 | 34.453 | 1.62x |
| TestCSAFusedVsUnfusedPerformance | test_e2e_performance[dense-70B_sq2048_topk512] | module_e2e | 2048 | 1 | 64 | 512 | False | 128 |  | 14.499 | 22.176 | 1.53x |
| TestCSAFusedVsUnfusedPerformance | test_e2e_performance[dense-13B_sq4096_topk512] | module_e2e | 4096 | 1 | 32 | 512 | False | 128 |  | 21.144 | 34.546 | 1.63x |
| TestCSAFusedVsUnfusedPerformance | test_e2e_performance[dense-13B_sq4096_topk1024] | module_e2e | 4096 | 1 | 32 | 1024 | False | 128 |  | 27.998 | 49.524 | 1.77x |
| TestCSANoIndexerPerformance | test_e2e_performance_no_indexer[win_only_2k] | no_indexer_e2e | 2048 | 1 | 32 |  |  | 128 | 0 | 1.848 | 2.973 | 1.61x |
| TestCSANoIndexerPerformance | test_e2e_performance_no_indexer[win_only_4k] | no_indexer_e2e | 4096 | 1 | 32 |  |  | 256 | 0 | 3.671 | 10.333 | 2.81x |
| TestCSANoIndexerPerformance | test_e2e_performance_no_indexer[ratio128_2k] | no_indexer_e2e | 2048 | 1 | 32 |  |  | 128 | 128 | 3.587 | 4.257 | 1.19x |
| TestCSANoIndexerPerformance | test_e2e_performance_no_indexer[ratio128_4k] | no_indexer_e2e | 4096 | 1 | 32 |  |  | 256 | 128 | 5.637 | 12.487 | 2.22x |


### Memory

| test_class | test_name | sq | b | np | topk | win | sparse_loss | ratio | fused_MB | unfused_MB | ratio |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| TestFusedIndexerSparseAttnPerformance | test_peak_memory[2048-1-32-128-512-128-4-64-256-4] | 2048 | 1 | 32 | 256 |  |  |  | 521.3 | 964.0 | 1.85x |
| TestCSAFusedVsUnfusedPerformance | test_e2e_memory[sparse-7B_sq2048_topk256] | 2048 | 1 | 32 | 256 | 128 | True |  | 884.0 | 1508.9 | 1.71x |
| TestCSAFusedVsUnfusedPerformance | test_e2e_memory[sparse-13B_sq4096_topk384] | 4096 | 1 | 32 | 384 | 256 | True |  | 2809.8 | 5854.6 | 2.08x |
| TestCSAFusedVsUnfusedPerformance | test_e2e_memory[sparse-70B_sq2048_topk512] | 2048 | 1 | 64 | 512 | 128 | True |  | 1821.8 | 3297.4 | 1.81x |
| TestCSAFusedVsUnfusedPerformance | test_e2e_memory[sparse-13B_sq4096_topk512] | 4096 | 1 | 32 | 512 | 128 | True |  | 2985.7 | 5858.6 | 1.96x |
| TestCSAFusedVsUnfusedPerformance | test_e2e_memory[sparse-13B_sq4096_topk1024] | 4096 | 1 | 32 | 1024 | 128 | True |  | 5823.7 | 8233.6 | 1.41x |
| TestCSAFusedVsUnfusedPerformance | test_e2e_memory[dense-7B_sq2048_topk256] | 2048 | 1 | 32 | 256 | 128 | False |  | 884.0 | 1508.9 | 1.71x |
| TestCSAFusedVsUnfusedPerformance | test_e2e_memory[dense-13B_sq4096_topk384] | 4096 | 1 | 32 | 384 | 256 | False |  | 2809.8 | 5854.6 | 2.08x |
| TestCSAFusedVsUnfusedPerformance | test_e2e_memory[dense-70B_sq2048_topk512] | 2048 | 1 | 64 | 512 | 128 | False |  | 1821.8 | 3297.4 | 1.81x |
| TestCSAFusedVsUnfusedPerformance | test_e2e_memory[dense-13B_sq4096_topk512] | 4096 | 1 | 32 | 512 | 128 | False |  | 2809.8 | 5858.6 | 2.09x |
| TestCSAFusedVsUnfusedPerformance | test_e2e_memory[dense-13B_sq4096_topk1024] | 4096 | 1 | 32 | 1024 | 128 | False |  | 4891.8 | 8233.6 | 1.68x |
| TestCSANoIndexerPerformance | test_e2e_memory_no_indexer[win_only_2k] | 2048 | 1 | 32 |  | 128 |  | 0 | 260.0 | 1296.5 | 4.99x |
| TestCSANoIndexerPerformance | test_e2e_memory_no_indexer[win_only_4k] | 4096 | 1 | 32 |  | 256 |  | 0 | 974.5 | 4392.0 | 4.51x |
| TestCSANoIndexerPerformance | test_e2e_memory_no_indexer[ratio128_2k] | 2048 | 1 | 32 |  | 128 |  | 128 | 291.0 | 1308.0 | 4.49x |
| TestCSANoIndexerPerformance | test_e2e_memory_no_indexer[ratio128_4k] | 4096 | 1 | 32 |  | 256 |  | 128 | 1094.0 | 4462.0 | 4.08x |
