### PR TITLE
[Fix] Fix HuggingFace tokenizer cache race in functional tests

### DIFF
--- a/tests/functional_tests/shell_test_utils/_run_training.sh
+++ b/tests/functional_tests/shell_test_utils/_run_training.sh
@@ -167,6 +167,55 @@ fi
 # Extract training params
 PARAMS=("${PARAMS[@]}" "${TRAINING_PARAMS_ARRAY[@]}")
 
+# Hugging Face copies custom tokenizer code into HF_MODULES_CACHE when
+# trust_remote_code is enabled. Preload it once before torchrun so that all
+# ranks read a fully populated dynamic-module cache instead of writing to it
+# concurrently.
+TOKENIZER_TYPE=""
+TOKENIZER_MODEL=""
+TOKENIZER_USE_FAST="true"
+TRUST_REMOTE_CODE="false"
+for ((i = 0; i < ${#TRAINING_PARAMS_ARRAY[@]}; i++)); do
+    case "${TRAINING_PARAMS_ARRAY[$i]}" in
+        --tokenizer-type)
+            TOKENIZER_TYPE="${TRAINING_PARAMS_ARRAY[$((i + 1))]:-}"
+            ;;
+        --tokenizer-model)
+            TOKENIZER_MODEL="${TRAINING_PARAMS_ARRAY[$((i + 1))]:-}"
+            ;;
+        --tokenizer-hf-no-use-fast)
+            TOKENIZER_USE_FAST="false"
+            ;;
+        --trust-remote-code)
+            TRUST_REMOTE_CODE="true"
+            ;;
+    esac
+done
+
+if [[ "$TOKENIZER_TYPE" == "HuggingFaceTokenizer" && "$TRUST_REMOTE_CODE" == "true" ]]; then
+    if [[ -z "$TOKENIZER_MODEL" ]]; then
+        echo "--tokenizer-model is required when preloading a Hugging Face tokenizer." >&2
+        exit 1
+    fi
+
+    echo "Preloading Hugging Face tokenizer before torchrun: $TOKENIZER_MODEL"
+    uv run --no-sync python - "$TOKENIZER_MODEL" "$TOKENIZER_USE_FAST" <<'PY'
+import sys
+
+from transformers import AutoTokenizer
+
+
+tokenizer_path = sys.argv[1]
+use_fast = sys.argv[2].lower() == "true"
+tokenizer = AutoTokenizer.from_pretrained(
+    tokenizer_path,
+    trust_remote_code=True,
+    use_fast=use_fast,
+)
+print(f"Preloaded tokenizer: {type(tokenizer).__name__} ({len(tokenizer)} tokens)")
+PY
+fi
+
 # Set PYTHONPATH
 export PYTHONPATH="$(pwd):${PYTHONPATH:-}"
 export WANDB_API_KEY="${WANDB_API_KEY:-}"

--- a/tests/functional_tests/test_cases/gpt/qwen3_0p6b_mcore_te_tp1_pp1_no_mmap_bin_files/model_config.yaml
+++ b/tests/functional_tests/test_cases/gpt/qwen3_0p6b_mcore_te_tp1_pp1_no_mmap_bin_files/model_config.yaml
@@ -4,6 +4,21 @@ ENV_VARS:
   NON_DETERMINSTIC_RESULTS: 1
   NCCL_ALGO: Ring
   CUBLAS_WORKSPACE_CONFIG: :4096:8
+BEFORE_SCRIPT: |
+  export HF_MODULES_CACHE="$(mktemp -d /tmp/hf-modules.XXXXXX)"
+  python3 - <<'PY'
+  from transformers import AutoTokenizer
+
+  tokenizer = AutoTokenizer.from_pretrained(
+      "/home/gitlab-runner/tokenizers/qwentokenizer",
+      trust_remote_code=True,
+      use_fast=True,
+      local_files_only=True,
+  )
+  assert type(tokenizer).__name__ == "QWenTokenizer"
+  assert len(tokenizer) == 151851
+  print("Preloaded tokenizer:", type(tokenizer).__name__, len(tokenizer))
+  PY
 MODEL_ARGS:
   --num-layers: 28
   --hidden-size: 1024

--- a/tests/functional_tests/test_cases/gpt/qwen3_0p6b_mcore_te_tp1_pp1_no_mmap_bin_files/model_config.yaml
+++ b/tests/functional_tests/test_cases/gpt/qwen3_0p6b_mcore_te_tp1_pp1_no_mmap_bin_files/model_config.yaml
@@ -4,21 +4,6 @@ ENV_VARS:
   NON_DETERMINSTIC_RESULTS: 1
   NCCL_ALGO: Ring
   CUBLAS_WORKSPACE_CONFIG: :4096:8
-BEFORE_SCRIPT: |
-  export HF_MODULES_CACHE="$(mktemp -d /tmp/hf-modules.XXXXXX)"
-  python3 - <<'PY'
-  from transformers import AutoTokenizer
-
-  tokenizer = AutoTokenizer.from_pretrained(
-      "/home/gitlab-runner/tokenizers/qwentokenizer",
-      trust_remote_code=True,
-      use_fast=True,
-      local_files_only=True,
-  )
-  assert type(tokenizer).__name__ == "QWenTokenizer"
-  assert len(tokenizer) == 151851
-  print("Preloaded tokenizer:", type(tokenizer).__name__, len(tokenizer))
-  PY
 MODEL_ARGS:
   --num-layers: 28
   --hidden-size: 1024


### PR DESCRIPTION

# Fix HuggingFace tokenizer cache race in functional tests

## Summary

This PR prevents intermittent HuggingFace tokenizer loading failures in distributed functional tests.

When multiple `torchrun` workers simultaneously load a local tokenizer with `trust_remote_code=True`, Transformers copies the tokenizer implementation into the shared dynamic-module cache. Concurrent writes can cause a worker to import an incomplete module and fail with errors such as:

```text
AttributeError: module 'transformers_modules.qwentokenizer.tokenization_qwen'
has no attribute 'QWenTokenizer'
```

## Changes

- Detect functional tests using both:
  - `--tokenizer-type HuggingFaceTokenizer`
  - `--trust-remote-code`
- Load the configured tokenizer once in `_run_training.sh` before starting `torchrun`.
- Respect `--tokenizer-hf-no-use-fast` during preloading.
- Reuse the existing HuggingFace module cache instead of creating a separate temporary cache.
- Remove the Qwen test-specific `BEFORE_SCRIPT`.

The parent process waits for tokenizer preloading to complete before launching distributed workers, ensuring every rank reads a fully populated dynamic-module cache.

This common handling also covers other functional tests with the same tokenizer configuration, including the Qwen TP2/PP2 benchmark.

## Root cause

Transformers protects dynamic-module imports with an in-process thread lock, but local custom module copies are not protected by a cross-process lock. Multiple distributed workers can therefore write and import the same cached Python file concurrently.

The issue is easier to reproduce when the tokenizer source resides on slower shared storage, although repeated source-file reads confirmed that the source files themselves remain consistent.

## Validation

- Verified shell syntax with `bash -n`.
- Verified the modified YAML can be parsed.
- Verified the tokenizer argument detection for:
  - HuggingFace tokenizer with remote code
  - non-HuggingFace tokenizer
  - `--tokenizer-hf-no-use-fast`
- Verified the patch with `git diff --check`.
- Previously reproduced the failure with eight processes sharing a cold dynamic-module cache and confirmed that single-process preloading prevents it.