### PR TITLE
[Model] Support DSA IndexShare with per-forward top-k carrier

### DIFF
--- a/megatron/core/transformer/experimental_attention_variant/dsa.py
+++ b/megatron/core/transformer/experimental_attention_variant/dsa.py
@@ -3,6 +3,7 @@
 import copy
 import math
 from dataclasses import dataclass
+from functools import lru_cache
 from typing import List, Optional, Tuple, Union
 
 import torch
@@ -194,6 +195,49 @@ class DSAIndexerLossLoggingHelper:
         DSAIndexerLossLoggingHelper.clean_loss_in_tracker()
 
 
+##### FlagScale Begin #####
+@lru_cache(maxsize=16)
+def _cached_causal_neg_inf_mask(sq: int, sk: int, device: torch.device) -> torch.Tensor:
+    """Return a cached upper-triangular additive causal mask.
+
+    Shape ``[sq, sk]``, fp32, ``-inf`` above the diagonal and ``0`` elsewhere.
+    The mask depends only on ``(sq, sk, device)``, so it is memoized to avoid
+    re-allocating and re-computing a potentially large ``[sq, sk]`` tensor on
+    every layer / micro-batch (e.g. ~256MB at seqlen=8192).
+
+    The returned tensor is shared across callers and MUST be treated as
+    read-only (only added to scores, never mutated in place).
+    """
+    return torch.triu(
+        torch.full((sq, sk), float("-inf"), dtype=torch.float32, device=device),
+        diagonal=1,
+    )
+
+
+_DSA_TOPK_HOLDER_ATTR = "_dsa_index_share_topk_holder"
+
+
+def _dsa_source_layer(indexer_types: List[str], layer_number: int) -> int:
+    """Resolve which 'full' layer a 'shared' DSA layer reuses top-k indices from.
+
+    ``indexer_types`` is 0-indexed; ``layer_number`` is 1-indexed. Returns the
+    1-indexed layer number of the nearest preceding 'full' layer. Raises if no
+    preceding 'full' layer exists (a 'shared' layer must be preceded by a 'full'
+    source within the same pipeline stage).
+    """
+    for prev in range(layer_number - 1, 0, -1):
+        if indexer_types[prev - 1] == "full":
+            return prev
+    raise ValueError(
+        f"DSA layer {layer_number} has indexer_type='shared' but no preceding 'full' "
+        f"layer to source top-k from. Ensure each 'shared' layer is preceded by a "
+        f"'full' layer (and that a pipeline stage never starts with 'shared')."
+    )
+
+
+##### FlagScale End #####
+
+
 def compute_dsa_indexer_loss(
     index_scores: torch.Tensor,
     topk_indices: torch.Tensor,
@@ -250,12 +294,7 @@ def compute_dsa_indexer_loss(
     if causal_mask_override is not None:
         causal_mask = causal_mask_override.to(dtype=torch.float32)  # [b, sq, sk]
     else:
-        causal_mask = torch.triu(
-            torch.full(
-                (sq, sk), float('-inf'), dtype=torch.float32, device=attention_scores.device
-            ),
-            diagonal=1,
-        )
+        causal_mask = _cached_causal_neg_inf_mask(sq, sk, attention_scores.device)
     # index_mask [b, sq, sk]
     index_mask = torch.full(
         (b, sq, sk), float("-inf"), dtype=torch.float32, device=causal_mask.device
@@ -475,12 +514,7 @@ def bwd_fused_indexer_loss_naive(
     if causal_mask_override is not None:
         causal_mask = causal_mask_override.to(dtype=torch.float32)  # [b, sq, sk]
     else:
-        causal_mask = torch.triu(
-            torch.full(
-                (sq, sk), float('-inf'), dtype=torch.float32, device=attention_scores.device
-            ),
-            diagonal=1,
-        )
+        causal_mask = _cached_causal_neg_inf_mask(sq, sk, attention_scores.device)
     # index_mask [b, sq, sk]
     index_mask = torch.full(
         (b, sq, sk), float("-inf"), dtype=torch.float32, device=causal_mask.device
@@ -1094,10 +1128,7 @@ def unfused_dsa_fn(query, key, value, topk_indices, softmax_scale):
     index_mask = torch.full((b, sq, skv), float("-inf"), device=attention_scores.device)
     index_mask.scatter_(-1, topk_indices, 0)
     # causal_mask [sq, skv]
-    causal_mask = torch.triu(
-        torch.full((sq, skv), float('-inf'), dtype=torch.float32, device=index_mask.device),
-        diagonal=1,
-    )
+    causal_mask = _cached_causal_neg_inf_mask(sq, skv, index_mask.device)
     # [b, sq, skv] + [1, sq, skv] -> [b, sq, skv]
     index_mask += causal_mask.view(1, sq, skv)
     # [b, np, sq, skv] + [b, 1, sq, skv] -> [b, np, sq, skv]
@@ -1149,15 +1180,18 @@ class DSAttention(MegatronModule):
         self.layer_number = layer_number
         if is_mtp_layer:
             self.layer_number = self.layer_number + self.config.num_layers
+        self.index_share = self.config.indexer_types is not None
 
-        # indexer_types is 0-indexed, layer_number is 1-indexed.
-        # "share" means this layer reuses the previous layer's topk indices (no indexer needed).
-        if (
-            self.config.indexer_types is not None
-            and self.config.indexer_types[layer_number - 1] == "share"
-        ):
+        # indexer_types is 0-indexed, layer_number is 1-indexed. A "shared" layer has no
+        # indexer and reuses a preceding 'full' layer's topk (resolved here as source_layer).
+        self.skip_topk = (
+            self.index_share and self.config.indexer_types[layer_number - 1] == "shared"
+        )
+        if self.skip_topk:
             self.indexer = None
+            self.source_layer = _dsa_source_layer(self.config.indexer_types, layer_number)
         else:
+            self.source_layer = None
             self.indexer = build_module(
                 submodules.indexer, config=self.config, pg_collection=pg_collection
             )
@@ -1167,6 +1201,40 @@ class DSAttention(MegatronModule):
                 k_channels if k_channels is not None else config.kv_channels
             )
         self.softmax_scale = softmax_scale
+
+    ##### FlagScale Begin #####
+    def _get_index_share_carrier(
+        self,
+        packed_seq_params: Optional[PackedSeqParams],
+        attention_mask: Optional[torch.Tensor],
+    ) -> object:
+        """Return the object that carries DSA top-k sharing state for this forward.
+
+        The carrier must flow through every DSA layer of a single forward pass. Because
+        it travels as a forward *argument*, the holder also survives activation
+        recompute: the checkpointed closure re-runs with the same carrier. Preferring
+        ``packed_seq_params`` keeps packed (THD) sequences isolated. ``self.config`` is a
+        fallback for the mask-free causal path; being module state, its holder lives
+        until the next forward overwrites it.
+        """
+        if packed_seq_params is not None:
+            return packed_seq_params
+        return attention_mask if attention_mask is not None else self.config
+
+    def _get_index_share_topk_holder(
+        self,
+        packed_seq_params: Optional[PackedSeqParams],
+        attention_mask: Optional[torch.Tensor],
+    ) -> dict:
+        """Return the ``{layer_number: topk_indices}`` holder for this forward."""
+        carrier = self._get_index_share_carrier(packed_seq_params, attention_mask)
+        holder = getattr(carrier, _DSA_TOPK_HOLDER_ATTR, None)
+        if holder is None:
+            holder = {}
+            setattr(carrier, _DSA_TOPK_HOLDER_ATTR, holder)
+        return holder
+
+    ##### FlagScale End #####
 
     def forward(
         self,
@@ -1179,7 +1247,6 @@ class DSAttention(MegatronModule):
         attn_mask_type: AttnMaskType = None,
         attention_bias: torch.Tensor = None,
         packed_seq_params: PackedSeqParams = None,
-        prev_topk_indices: Optional[torch.Tensor] = None,
     ):
         """
         Forward pass for Sparse Attention.
@@ -1194,7 +1261,6 @@ class DSAttention(MegatronModule):
             attn_mask_type: Type of attention mask.
             attention_bias: Optional attention bias.
             packed_seq_params: Packed sequence parameters.
-            prev_topk_indices: Top-k indices from previous layer for 'share' mode.
 
         Returns:
             output: Output tensor [sq, b, hidden_size]
@@ -1203,16 +1269,23 @@ class DSAttention(MegatronModule):
         skv = key.size(0)
         hnv = value.size(3)
 
-        # Share mode: reuse previous layer's topk indices, skip indexer computation
-        if self.indexer is None:
-            assert prev_topk_indices is not None, (
-                f"Layer {self.layer_number} has indexer_type='shared' but no prev_topk_indices "
-                f"available. Ensure the preceding layer has indexer_type='full'."
+        # 'full' layers publish holder[self.layer_number]; 'shared' layers read
+        # holder[self.source_layer].
+        topk_holder = (
+            self._get_index_share_topk_holder(packed_seq_params, attention_mask)
+            if self.index_share
+            else None
+        )
+
+        if self.skip_topk:
+            assert topk_holder is not None and self.source_layer in topk_holder, (
+                f"Layer {self.layer_number} (indexer_type='shared') needs top-k from source "
+                f"layer {self.source_layer}, not found in holder "
+                f"(available: {sorted(topk_holder) if topk_holder else '[]'}). "
+                f"Ensure its source layer runs earlier in the same pipeline stage."
             )
-            output = unfused_dsa_fn(query, key, value, prev_topk_indices, self.softmax_scale)
-            self.current_topk_indices = (
-                prev_topk_indices  # Store for potential use by next layer in share mode
-            )
+            topk_indices = topk_holder[self.source_layer]
+            output = unfused_dsa_fn(query, key, value, topk_indices, self.softmax_scale)
             return output
 
         # Detach x and qr to prevent gradients of indexer from flowing back to the main model.
@@ -1222,13 +1295,8 @@ class DSAttention(MegatronModule):
         # Get a FP32 mask with -inf for masked positions.
         if attn_mask_type is not None:
             assert attn_mask_type == AttnMaskType.causal, 'Only causal mask is supported for now'
-            # Generate upper triangular mask with -inf above diagonal, 0 elsewhere
-            # torch.triu with diagonal=1 creates upper triangular matrix (excluding main diagonal)
-            # float_mask [sq, skv]
-            float_mask = torch.triu(
-                torch.full((sq, skv), float('-inf'), dtype=torch.float32, device=x.device),
-                diagonal=1,
-            )
+            # float_mask [sq, skv] (cached, read-only)
+            float_mask = _cached_causal_neg_inf_mask(sq, skv, x.device)
         else:
             assert attention_mask.shape == (b, 1, sq, skv), 'attention_mask shape mismatch'
             # [b, 1, sq, skv] -> [b, sq, skv]
@@ -1292,8 +1360,9 @@ class DSAttention(MegatronModule):
             # ===================================
             output = unfused_dsa_fn(query, key, value, topk_indices, self.softmax_scale)
 
-        self.current_topk_indices = (
-            topk_indices  # Store for potential use by next layer in share mode
-        )
+        # Publish this 'full' layer's top-k so subsequent 'shared' layers can reuse it.
+        # detach() keeps the holder from pinning this layer's autograd graph alive.
+        if topk_holder is not None:
+            topk_holder[self.layer_number] = topk_indices.detach()
 
         return output

--- a/megatron/core/transformer/multi_latent_attention.py
+++ b/megatron/core/transformer/multi_latent_attention.py
@@ -309,13 +309,10 @@ class MultiLatentAttention(Attention):
             if inference_context is None or inference_context.is_static_batching():
                 extra_kwargs = {}
                 if self.config.experimental_attention_variant == "dsa":
-                    # For dsa we need to pass in the original hidden states and the compressed
-                    # query representation.
+                    # dsa needs the original hidden states and compressed query. Cross-layer
+                    # top-k sharing is handled inside DSAttention via a per-forward holder.
                     extra_kwargs["x"] = hidden_states
                     extra_kwargs["qr"] = q_compressed
-                    extra_kwargs["prev_topk_indices"] = getattr(
-                        self.core_attention, "current_topk_indices", None
-                    )  # FlagScale Add
                 with off_interface(
                     self.offload_core_attention and self.training, query, "core_attn"
                 ) as query:

--- a/megatron/core/transformer/transformer_block.py
+++ b/megatron/core/transformer/transformer_block.py
@@ -947,7 +947,6 @@ class TransformerBlock(GraphableMegatronModule, MegatronModule):
                     # No intermediate_hidden_states requested: just hidden_states
                     hidden_states = checkpointed_result
             else:
-                _dsa_prev_topk_indices = None  # FlagSale Add
                 for l_no, layer in enumerate(self.layers):
                     # Get appropriate inner quantization context
                     if use_inner_quantization_context:
@@ -982,20 +981,6 @@ class TransformerBlock(GraphableMegatronModule, MegatronModule):
                                 )
                         #### FlagScale End ####
 
-                        #### FlagScale Begin ####
-                        # Pass DSA prev_topk_indices via attribute
-                        # If the current layer is 'full',
-                        # the current_topk_indices will be updated in the layer.
-                        if hasattr(layer, 'self_attention') and hasattr(
-                            layer.self_attention, 'core_attention'
-                        ):
-                            setattr(
-                                layer.self_attention.core_attention,
-                                'current_topk_indices',
-                                _dsa_prev_topk_indices,
-                            )
-                        #### FlagScale End ####
-
                         hidden_states, context = layer(
                             hidden_states=hidden_states,
                             attention_mask=attention_mask,
@@ -1014,15 +999,6 @@ class TransformerBlock(GraphableMegatronModule, MegatronModule):
                             input_ids=input_ids,
                         )
 
-                        #### FlagScale Begin ####
-                        # Read DSA topk_indices for next layer
-                        if hasattr(layer, 'self_attention') and hasattr(
-                            layer.self_attention, 'core_attention'
-                        ):
-                            _dsa_prev_topk_indices = getattr(
-                                layer.self_attention.core_attention, 'current_topk_indices', None
-                            )
-                        #### FlagScale End ####
                     self._finalize_mhc_recompute_layer(
                         mhc_manager=mhc_manager,
                         hidden_states=hidden_states,

--- a/megatron/core/transformer/transformer_config.py
+++ b/megatron/core/transformer/transformer_config.py
@@ -1339,6 +1339,14 @@ class TransformerConfig(ModelParallelConfig):
                     f"indexer_types must only contain {valid_types}, "
                     f"got {set(self.indexer_types) - valid_types}"
                 )
+                # MTP layers don't thread the DSA top-k holder, so IndexShare + MTP is
+                # unsupported for now; fail loudly.
+                if any(t == "shared" for t in self.indexer_types) and (self.mtp_num_layers or 0) > 0:
+                    raise NotImplementedError(
+                        "DSA IndexShare (indexer_types with 'shared') is not yet supported "
+                        "with MTP (mtp_num_layers > 0). Set mtp_num_layers=0 or use all-'full' "
+                        "indexer_types (indexer_type_rule=None)."
+                    )
         ##### FlagScale End #####
         elif self.experimental_attention_variant == "dsv4_hybrid":
             assert self.multi_latent_attention, "DSv4 Hybrid requires multi_latent_attention."
@@ -2662,9 +2670,9 @@ class TransformerConfig(ModelParallelConfig):
           - Segments before repeat() are prefix, segments after are suffix.
 
         Examples:
-          "2*full + repeat(full, share, share, share)"
+          "2*full + repeat(full, shared, shared, shared)"
             → 2 full prefix, then cyclic pattern fills all remaining layers
-          "2*full + repeat(full, share, share, share) + 1*full"
+          "2*full + repeat(full, shared, shared, shared) + 1*full"
             → 2 full prefix, cyclic pattern in the middle, 1 full suffix
         """
         import re

--- a/megatron/training/arguments.py
+++ b/megatron/training/arguments.py
@@ -3276,6 +3276,28 @@ def _add_experimental_attention_variant_args(parser):
         'and fall back to unfused PyTorch implementations.',
         dest='apply_dsa_kernel_fusion',
     )
+    # DSA indexer sharing (GLM5/GLM5.1/GLM5.2 style DSA structure)
+    group.add_argument(
+        '--indexer-types',
+        type=str,
+        nargs='+',
+        default=None,
+        help="Per-layer DSA indexer type. Space-separated list of 'full'/'shared' with "
+        "length equal to --num-layers. 'full' means the layer computes its own top-k "
+        "indices; 'shared' means the layer reuses the previous layer's top-k indices "
+        "(no indexer). Mutually exclusive with --indexer-type-rule. "
+        "Example: --indexer-types full shared shared shared",
+    )
+    group.add_argument(
+        '--indexer-type-rule',
+        type=str,
+        default=None,
+        help="Compact rule string expanded into --indexer-types in TransformerConfig. "
+        "Supported syntax: 'N*type' (N consecutive layers), 'repeat(type, ...)' "
+        "(cyclic pattern filling remaining layers), segments joined with '+' where "
+        "segments before repeat() are prefix and segments after are suffix. "
+        "Example: '2*full + repeat(full, shared, shared, shared) + 1*full'.",
+    )
     return parser
 
 def _add_heterogeneous_args(parser):

--- a/tests/unit_tests/transformer/experimental_attention_variant/test_attention_variant_dsa.py
+++ b/tests/unit_tests/transformer/experimental_attention_variant/test_attention_variant_dsa.py
@@ -9,6 +9,7 @@ import megatron.core.parallel_state as parallel_state
 from megatron.core.models.gpt.experimental_attention_variant_module_specs import (
     get_dsa_module_spec_for_backend,
     get_experimental_attention_variant_module_spec,
+    get_transformer_block_with_experimental_attention_variant_spec,
 )
 from megatron.core.models.gpt.gpt_layer_specs import get_gpt_layer_with_transformer_engine_spec
 from megatron.core.process_groups_config import ProcessGroupCollection
@@ -16,6 +17,7 @@ from megatron.core.tensor_parallel.random import model_parallel_cuda_manual_seed
 from megatron.core.transformer import TransformerConfig
 from megatron.core.transformer.enums import AttnMaskType
 from megatron.core.transformer.experimental_attention_variant.dsa import (
+    _DSA_TOPK_HOLDER_ATTR,
     DSAIndexer,
     DSAIndexerLossAutoScaler,
     DSAIndexerSubmodules,
@@ -23,11 +25,13 @@ from megatron.core.transformer.experimental_attention_variant.dsa import (
     DSAttentionSubmodules,
     FusedDSAIndexerLoss,
     _compute_index_scores,
+    _dsa_source_layer,
     compute_dsa_indexer_loss,
     fused_qk_topk_naive,
     rotate_activation,
 )
 from megatron.core.transformer.multi_latent_attention import MLASelfAttention
+from megatron.core.transformer.transformer_block import TransformerBlock
 from megatron.core.transformer.transformer_config import MLATransformerConfig
 from tests.unit_tests.test_utilities import Utils
 
@@ -1731,3 +1735,246 @@ class TestDSAModuleSpecDispatch:
         config = self._make_dsa_config(qk_l2_norm=True)
         with pytest.raises(AssertionError, match="qk_l2_norm is not supported"):
             get_dsa_module_spec_for_backend(config, backend=None)
+
+
+# ======================================================================================
+# DSA IndexShare: cross-layer top-k sharing (GLM5/GLM5.1/GLM5.2 DSA structure)
+# ======================================================================================
+
+
+class TestDSAIndexerTypeRule:
+    """Fast, CPU-only coverage of the indexer_type_rule / indexer_types expansion.
+
+    Covers ``TransformerConfig._parse_indexer_type_rule`` (the compact rule parser),
+    ``__post_init__`` expansion into ``indexer_types``, the MTP-incompatibility guard,
+    and ``_dsa_source_layer`` resolution — none of which need a GPU.
+    """
+
+    @pytest.mark.parametrize(
+        "rule, num_layers, expected",
+        [
+            # prefix + cyclic pattern fills the rest
+            ("2*full + repeat(full, shared, shared, shared)", 6,
+             ["full", "full", "full", "shared", "shared", "shared"]),
+            # prefix + cyclic middle + suffix
+            ("2*full + repeat(full, shared) + 1*full", 6,
+             ["full", "full", "full", "shared", "full", "full"]),
+            # alternating pattern for all layers
+            ("repeat(full, shared)", 4, ["full", "shared", "full", "shared"]),
+            # single 'full' term inside a repeat prefix
+            ("full + repeat(full, shared, shared)", 5,
+             ["full", "full", "shared", "shared", "full"]),
+        ],
+    )
+    def test_parse_indexer_type_rule(self, rule, num_layers, expected):
+        assert TransformerConfig._parse_indexer_type_rule(rule, num_layers) == expected
+
+    def test_parse_indexer_type_rule_only_one_repeat(self):
+        with pytest.raises(ValueError, match="only one repeat"):
+            TransformerConfig._parse_indexer_type_rule(
+                "repeat(full, shared) + repeat(full)", 4
+            )
+
+    def test_parse_indexer_type_rule_prefix_exceeds_num_layers(self):
+        with pytest.raises(ValueError, match="exceeds num_layers"):
+            TransformerConfig._parse_indexer_type_rule("6*full + repeat(shared)", 4)
+
+    def test_parse_indexer_type_rule_no_repeat_length_mismatch(self):
+        # Without repeat() the explicit list must match num_layers exactly.
+        with pytest.raises(ValueError, match="!= "):
+            TransformerConfig._parse_indexer_type_rule("2*full", 6)
+
+    def test_dsa_source_layer_resolution(self):
+        # 1-indexed layer numbers; each 'shared' resolves to the nearest preceding 'full'.
+        indexer_types = ["full", "shared", "shared", "full", "shared"]
+        assert _dsa_source_layer(indexer_types, 2) == 1
+        assert _dsa_source_layer(indexer_types, 3) == 1
+        assert _dsa_source_layer(indexer_types, 5) == 4
+
+    def test_dsa_source_layer_no_preceding_full(self):
+        # A 'shared' layer with no preceding 'full' (e.g. layer 1) is a config error.
+        with pytest.raises(ValueError, match="no preceding 'full'"):
+            _dsa_source_layer(["shared", "full"], 1)
+
+
+class TestDSAIndexShareConfig:
+    """Config-construction coverage for IndexShare (rule expansion + guards)."""
+
+    @pytest.fixture(scope='class', autouse=True)
+    def setup_method(self):
+        Utils.initialize_model_parallel(
+            tensor_model_parallel_size=1, pipeline_model_parallel_size=1
+        )
+        yield
+        Utils.destroy_model_parallel()
+
+    def _make_config(self, **kwargs):
+        return MLATransformerConfig(
+            num_layers=6,
+            hidden_size=256,
+            num_attention_heads=16,
+            use_cpu_initialization=True,
+            bf16=True,
+            params_dtype=torch.bfloat16,
+            q_lora_rank=64,
+            kv_lora_rank=64,
+            qk_head_dim=64,
+            qk_pos_emb_head_dim=32,
+            v_head_dim=64,
+            rope_type='rope',
+            rotary_base=10000,
+            rotary_percent=1.0,
+            experimental_attention_variant="dsa",
+            dsa_indexer_n_heads=8,
+            dsa_indexer_head_dim=64,
+            dsa_indexer_topk=32,
+            **kwargs,
+        )
+
+    def test_rule_expanded_in_post_init(self):
+        """indexer_type_rule is expanded into indexer_types during __post_init__."""
+        config = self._make_config(
+            indexer_type_rule="2*full + repeat(full, shared, shared, shared)"
+        )
+        assert config.indexer_types == [
+            "full", "full", "full", "shared", "shared", "shared"
+        ]
+
+    def test_indexer_types_length_must_match_num_layers(self):
+        with pytest.raises(AssertionError, match="must equal"):
+            self._make_config(indexer_types=["full", "shared"])
+
+    def test_indexer_types_reject_unknown_type(self):
+        with pytest.raises(AssertionError, match="indexer_types must only contain"):
+            self._make_config(indexer_types=["full", "share", "full", "full", "full", "full"])
+
+    def test_index_share_with_mtp_is_rejected(self):
+        """IndexShare ('shared') is not yet supported together with MTP layers."""
+        with pytest.raises(NotImplementedError, match="not yet supported"):
+            self._make_config(
+                indexer_type_rule="repeat(full, shared)", mtp_num_layers=1
+            )
+
+
+class TestDSAIndexShareEndToEnd:
+    """End-to-end forward + backward over a TransformerBlock with shared indexers.
+
+    Ports the standalone smoke test (scripts/smoke_test_glm5_dsa.py) into the suite:
+    it exercises the whole IndexShare path — rule expansion, ``indexer=None`` on
+    'shared' layers with a resolved source layer, and the per-forward top-k holder
+    that flows top-k from 'full' layers to 'shared' layers within a single forward.
+    """
+
+    @pytest.fixture(scope='class', autouse=True)
+    def setup_method(self):
+        Utils.initialize_model_parallel(
+            tensor_model_parallel_size=1, pipeline_model_parallel_size=1
+        )
+        torch.manual_seed(123)
+        model_parallel_cuda_manual_seed(123)
+        yield
+        Utils.destroy_model_parallel()
+
+    def _build_config(self, num_layers, indexer_type_rule):
+        return MLATransformerConfig(
+            num_layers=num_layers,
+            hidden_size=256,
+            ffn_hidden_size=512,
+            num_attention_heads=16,
+            bf16=True,
+            params_dtype=torch.bfloat16,
+            tensor_model_parallel_size=1,
+            pipeline_model_parallel_size=1,
+            sequence_parallel=False,
+            add_bias_linear=False,
+            multi_latent_attention=True,
+            q_lora_rank=64,
+            kv_lora_rank=64,
+            qk_head_dim=64,
+            qk_pos_emb_head_dim=32,
+            v_head_dim=64,
+            rope_type="rope",
+            rotary_base=10000,
+            rotary_percent=1.0,
+            experimental_attention_variant="dsa",
+            dsa_indexer_n_heads=8,
+            dsa_indexer_head_dim=64,
+            dsa_indexer_topk=32,
+            dsa_indexer_loss_coeff=1.0,
+            dsa_indexer_use_sparse_loss=False,
+            indexer_type_rule=indexer_type_rule,
+        )
+
+    @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+    @pytest.mark.parametrize(
+        "num_layers, indexer_type_rule",
+        [
+            (6, "repeat(full, shared, shared)"),
+            (6, "2*full + repeat(full, shared)"),
+        ],
+    )
+    def test_index_share_forward_backward(self, num_layers, indexer_type_rule):
+        seq_len = 32
+        batch_size = 2
+
+        config = self._build_config(num_layers, indexer_type_rule)
+        # __post_init__ expands the rule; the block must start with a 'full' layer.
+        assert config.indexer_types is not None
+        assert len(config.indexer_types) == num_layers
+        assert config.indexer_types[0] == "full", "first layer must be 'full' to seed top-k"
+        n_shared = sum(t == "shared" for t in config.indexer_types)
+        assert n_shared > 0, "rule produced no 'shared' layers — nothing to exercise"
+
+        spec = get_transformer_block_with_experimental_attention_variant_spec(config)
+        block = TransformerBlock(config=config, spec=spec, post_layer_norm=True).cuda()
+        block.train()
+
+        # Structural invariant: 'shared' layers have no indexer and resolve a valid
+        # preceding 'full' source layer; 'full' layers own an indexer.
+        for i, layer in enumerate(block.layers):
+            core = layer.self_attention.core_attention
+            want_shared = config.indexer_types[i] == "shared"
+            has_indexer = getattr(core, "indexer", None) is not None
+            assert has_indexer != want_shared, (
+                f"layer {i} ({config.indexer_types[i]}): indexer presence contradicts type"
+            )
+            if want_shared:
+                assert core.skip_topk and core.source_layer is not None
+                assert config.indexer_types[core.source_layer - 1] == "full"
+
+        # ---- forward (attention_mask=None -> DSA builds a causal mask internally) ----
+        hidden_states = torch.randn(
+            seq_len, batch_size, config.hidden_size, dtype=torch.bfloat16, device="cuda"
+        ).requires_grad_(True)
+
+        output = block(
+            hidden_states=hidden_states,
+            attention_mask=None,
+            attn_mask_type=AttnMaskType.causal,
+        )
+        assert output.shape == (seq_len, batch_size, config.hidden_size)
+
+        # With attention_mask=None the top-k holder rides on config (the mask-free
+        # carrier). Every 'full' layer must have published its top-k; every 'shared'
+        # layer must be able to resolve its source in the holder.
+        holder = getattr(config, _DSA_TOPK_HOLDER_ATTR, None)
+        assert holder is not None, "DSA top-k holder was not created on the carrier"
+        for i, layer in enumerate(block.layers):
+            core = layer.self_attention.core_attention
+            if config.indexer_types[i] == "full":
+                assert core.layer_number in holder, (
+                    f"full layer {i} did not publish top-k to the holder"
+                )
+            else:
+                assert core.source_layer in holder, (
+                    f"shared layer {i} could not resolve source layer in the holder"
+                )
+
+        # ---- backward ----
+        loss = output.float().sum()
+        loss.backward()
+        assert hidden_states.grad is not None, "no gradient flowed to the input"
+        n_with_grad = sum(
+            1 for p in block.parameters() if p.requires_grad and p.grad is not None
+        )
+        assert n_with_grad > 0


### PR DESCRIPTION
# Description

Rework DSA IndexShare's cross-layer top-k passing from per-layer module attributes to a per-forward holder (full layers publish, shared layers read). Survives activation recompute, more memory-friendly, same behavior. Also adds --indexer-types / --indexer-type-rule and unit tests.

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [ ] Infra/Build change
- [x] Code refactoring
- [ ] Documentation change
- [ ] Bug fix
- [ ] Breaking change

## Changes

1. Replace per-layer attribute threading of DSA top-k with a per-forward holder (`full` layers publish, `shared` layers read); remove the manual setattr/getattr in `transformer_block`.
2. Rename indexer type `share` → `shared`; resolve each `shared` layer's preceding `full` source layer at init.
3. Cache the causal mask (`lru_cache`) to drop per-layer re-allocation.
4. Add `--indexer-types` / `--indexer-type-rule` CLI args, and guard IndexShare + MTP as unsupported.
5. Add unit tests (rule parsing, config guards, end-to-end forward/backward).

## Checklist

- [x] The functionality is complete
- [x] I have added tests that prove my feature works
- [x] New and existing unit tests pass locally
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

## Test Result

`15 passed, 0 failed`

| Test class | Result |
| --- | --- |
| `TestDSAIndexerTypeRule` | 9 passed |
| `TestDSAIndexShareConfig` | 4 passed |
| `TestDSAIndexShareEndToEnd` | 2 passed |
