### PR TITLE
[Core] Fix is_built_on_zero_rank import when megatron.training is absent

### DIFF
--- a/megatron/plugin/utils.py
+++ b/megatron/plugin/utils.py
@@ -27,9 +27,9 @@ def is_built_on_zero_rank():
         bool: True if the current rank is responsible for building resources, False otherwise.
     """
     
-    from megatron.training import get_args
     #TODO: We should not depend on get_args in megatron core, the args belong to training.
     try: ### for unit tests
+        from megatron.training import get_args
         args = get_args()
     except Exception:
         if torch.distributed.get_rank() == 0 or int(os.environ["LOCAL_RANK"]) == 0:


### PR DESCRIPTION
## Summary

Fixes #157

`is_built_on_zero_rank()` in `megatron/plugin/utils.py` imports `get_args`
from `megatron.training` outside the `try/except`. The `megatron-core`
wheel ships only `megatron.core` (+ `megatron.plugin`) — `megatron.training`
is not packaged — so any wheel-only consumer that triggers this path dies
with `ModuleNotFoundError: No module named 'megatron.training'` before the
except clause can run.

## Change

Move the import inside the `try` block so the fallback branch works when
`megatron.training` is not installed.

This PR was written in part with the assistance of generative AI.