### PR TITLE
[Core] Declare psutil as a runtime dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ dynamic = ["version", "readme"]
 description = "Megatron Core - a library for efficient and scalable training of transformer based models"
 requires-python = ">=3.12"
 license = { text = "Apache 2.0" }
-dependencies = ["torch>=2.6.0", "numpy", "packaging>=24.2"]
+dependencies = ["torch>=2.6.0", "numpy", "packaging>=24.2", "psutil"]
 authors = [{ name = "NVIDIA", email = "nemo-toolkit@nvidia.com" }]
 maintainers = [{ name = "NVIDIA", email = "nemo-toolkit@nvidia.com" }]
 keywords = [


### PR DESCRIPTION
Fixes #158

## Summary

`megatron/core/dist_checkpointing/strategies/filesystem_async.py` uses
psutil in the async checkpoint strategy: the worker thread calls
`_process_memory()` unconditionally, raising `RuntimeError` when psutil
is absent. psutil is not declared in `pyproject.toml` `dependencies`, so
a plain `pip install megatron-core` installs a package whose async
checkpoint path cannot run.

## Change

Add `psutil` to `[project].dependencies` in `pyproject.toml`.

This PR was written in part with the assistance of generative AI.
