### PR TITLE
feat(packaging): full-scope wheel — all four scenarios + top-level entry modules

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,9 +6,29 @@ build-backend = "setuptools.build_meta"
 
 [tool.setuptools]
 include-package-data = true
+# Top-level entry modules (repo-root files). Megatron-LM-FL keeps the
+# pretrain_* / train_rl entry scripts and their *_builders / model_provider
+# helpers at the repo root — outside the megatron/ package. Packaging them as
+# top-level py-modules makes the installed wheel self-contained: `python -m
+# pretrain_gpt` and bare `from gpt_builders import gpt_builder` resolve against
+# site-packages, so no repo checkout is needed at runtime.
+py-modules = [
+    "gpt_builders",
+    "mamba_builders",
+    "model_provider",
+    "pretrain_gpt",
+    "pretrain_bert",
+    "pretrain_mamba",
+    "pretrain_t5",
+    "pretrain_vlm",
+    "train_rl",
+]
 
 [tool.setuptools.packages.find]
-include = ["megatron.core", "megatron.core.*", "megatron.plugin", "megatron.plugin.*"]
+include = ["megatron.core", "megatron.core.*", "megatron.plugin", "megatron.plugin.*",
+           "megatron.training", "megatron.training.*", "megatron.legacy", "megatron.legacy.*",
+           "megatron.rl", "megatron.rl.*", "megatron.post_training", "megatron.post_training.*",
+           "megatron.inference", "megatron.inference.*"]
 
 [tool.setuptools.dynamic]
 version = { attr = "megatron.core.package_info.__version__" }


### PR DESCRIPTION
Fixes #159

## Type of change

- [x] Infra/Build change (changes to CI/CD workflows or build scripts)

## Changes

- **packages.find** 范围从 core+plugin 扩到 core / plugin / training / legacy / rl / post_training / inference —— 四个应用场景（training / rl / post_training / inference）归并进一个 wheel。
- **py-modules**：把 repo 根的 9 个入口文件（pretrain_gpt / pretrain_bert / pretrain_mamba / pretrain_t5 / pretrain_vlm / train_rl / gpt_builders / mamba_builders / model_provider）打包为顶层模块，使 `python -m pretrain_gpt` 与 `from gpt_builders import gpt_builder` 等裸导入在安装模式下直接解析，无需 repo checkout。

## Checklist

- [x] I have read and followed the contributing guidelines
- [x] The functionality is complete
- [x] I have commented my code, particularly in coverage report uploading steps
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added/updated tests that prove my feature works
- [x] New and existing unit tests pass locally

This PR was written in part with the assistance of generative AI.
