### PR TITLE
[CICD] Add Enflame unit test CI support

### DIFF
--- a/.github/configs/enflame.yml
+++ b/.github/configs/enflame.yml
@@ -5,7 +5,6 @@
 hardware_name: enflame
 display_name: 'Enflame Tests'
 setup_script: .github/scripts/set_env_enflame.sh
-nproc_per_node: 8
 
 # CI image for the Enflame environment (built and pushed 2026-08-10, validated on Enflame L600)
 ci_image: harbor.baai.ac.cn/flagos-dev/megatron-lm-fl:manual-20260810-enflame-dev
@@ -36,6 +35,7 @@ device_types:
 # Test matrix configuration
 test_matrix:
   unit:
+    nproc_per_node: 8
     devices:
       - l600
     # Keep executing collected tests after an import/collection error so one

--- a/.github/configs/enflame.yml
+++ b/.github/configs/enflame.yml
@@ -1,0 +1,78 @@
+# Enflame Hardware Configuration for Megatron-LM-FL
+# This file defines CI/CD settings for Enflame GCU-based testing.
+# Validated on: Enflame L600, 8 CI-visible devices, ECCL 4.0.0.4, torch_gcu 2.9.1+4.0.20260714
+
+hardware_name: enflame
+display_name: 'Enflame Tests'
+setup_script: .github/scripts/set_env_enflame.sh
+nproc_per_node: 8
+
+# CI image for the Enflame environment (built and pushed 2026-08-10, validated on Enflame L600)
+ci_image: harbor.baai.ac.cn/flagos-dev/megatron-lm-fl:manual-20260810-enflame-dev
+
+# Runner labels for the Enflame node
+runner_labels:
+  - sy-8g-cicd-megatron
+
+# Container volumes (hardware-specific paths)
+container_volumes:
+  - /home/gitlab-runner/data:/home/gitlab-runner/data
+  - /home/gitlab-runner/tokenizers:/home/gitlab-runner/tokenizers
+
+# Container options (hardware-specific settings)
+container_options: >-
+  --privileged
+  --shm-size=500g
+  --hostname megatron_cicd
+  --user root
+  --ipc=host
+  --pid=host
+  --ulimit nofile=65535:65535
+
+# Device types to run tests on
+device_types:
+  - l600
+
+# Test matrix configuration
+test_matrix:
+  unit:
+    devices:
+      - l600
+    # Keep executing collected tests after an import/collection error so one
+    # manual run reports the complete platform gap. Collection errors still
+    # make the job fail.
+    pytest_extra_args:
+      - --continue-on-collection-errors
+      - --tb=short
+    groups:
+      - name: core
+        path: tests/unit_tests/test_*.py megatron/plugin/tests/
+        description: Core unit tests
+      - name: models
+        path: tests/unit_tests/models/
+        description: Model tests
+      - name: distributed
+        path: tests/unit_tests/distributed/
+        description: Distributed tests
+      - name: dist_checkpointing
+        path: tests/unit_tests/dist_checkpointing/
+        description: Distributed checkpointing tests
+      - name: tensor_parallel
+        path: tests/unit_tests/tensor_parallel/
+        description: Tensor parallel tests
+      - name: pipeline_parallel
+        path: tests/unit_tests/pipeline_parallel/
+        description: Pipeline parallel tests
+      - name: data
+        path: tests/unit_tests/data/
+        description: Data tests
+      - name: fusions
+        path: tests/unit_tests/fusions/
+        description: Fusion tests
+      - name: others
+        path: tests/unit_tests/export/ tests/unit_tests/post_training/ tests/unit_tests/tokenizers/ tests/unit_tests/utils/
+        description: Export, post-training, tokenizer, and utility tests
+    ignored_tests: []
+
+  functional:
+    train: []

--- a/.github/configs/enflame.yml
+++ b/.github/configs/enflame.yml
@@ -1,6 +1,7 @@
 # Enflame Hardware Configuration for Megatron-LM-FL
 # This file defines CI/CD settings for Enflame GCU-based testing.
-# Validated on: Enflame L600, 8 CI-visible devices, ECCL 4.0.0.4, torch_gcu 2.9.1+4.0.20260714
+# Validated on: Enflame L600, 8 CI-visible devices,
+# torch 2.10.0+cpu, torch_gcu 2.10.0+3.7.20260408
 
 hardware_name: enflame
 display_name: 'Enflame Tests'

--- a/.github/scripts/set_env_enflame.sh
+++ b/.github/scripts/set_env_enflame.sh
@@ -74,6 +74,35 @@ setup_unit_environment() {
     --no-deps "${pip_index_args[@]}"
 
   echo "Skipping NVIDIA CUPTI dependencies and Emerging-Optimizers on Enflame."
+
+  # Workaround: torch_gcu registers _OpNamespace objects in sys.modules whose
+  # __path__ attribute is not a sequence (no __len__). When coverage.py scans
+  # already-imported modules at startup it calls len() on every module's
+  # __path__, which raises TypeError and crashes all ranks before any test
+  # runs. Other platforms (ascend/metax) don't hit this because their torch
+  # backends don't inject non-sequence __path__ objects into sys.modules.
+  python3 << 'PYEOF'
+import os, site
+sp = site.getusersitepackages()
+os.makedirs(sp, exist_ok=True)
+with open(os.path.join(sp, "_fix_coverage_enflame.py"), "w") as f:
+    f.write("""
+def _patch():
+    import coverage.inorout
+    orig = coverage.inorout.InOrOut.warn_already_imported_files
+    def safe_warn(self):
+        try:
+            orig(self)
+        except TypeError:
+            pass
+    coverage.inorout.InOrOut.warn_already_imported_files = safe_warn
+_patch()
+""")
+with open(os.path.join(sp, "fix_coverage_enflame.pth"), "w") as f:
+    f.write("import _fix_coverage_enflame\\n")
+print("Coverage torch_gcu workaround installed")
+PYEOF
+
   ci_install_project --break-system-packages
   configure_enflame_runtime
   disable_unavailable_test_asset_downloads

--- a/.github/scripts/set_env_enflame.sh
+++ b/.github/scripts/set_env_enflame.sh
@@ -43,6 +43,18 @@ setup_unit_environment() {
   ci_ensure_curl
   validate_enflame_torch
 
+  # Clean up stale .pth file from earlier image builds (commit 539097af3 → 271405d79).
+  # The image may still contain fix_coverage_enflame.pth which causes SyntaxError
+  # at Python startup. Remove both the .pth and the module it imports.
+  python3 -c "
+import site, os, glob
+for sp in [site.getusersitepackages(), site.getsitepackages()[0]]:
+    for pattern in ['fix_coverage_enflame.pth', '_fix_coverage_enflame.py']:
+        for path in glob.glob(os.path.join(sp, pattern)):
+            os.remove(path)
+            print(f'Removed stale coverage patch: {path}')
+" || true
+
   local test_dependencies=(
     mock
     pytest-mock

--- a/.github/scripts/set_env_enflame.sh
+++ b/.github/scripts/set_env_enflame.sh
@@ -28,9 +28,16 @@ clean_stale_coverage_patch() {
   local sys_site="/usr/local/lib/python3.12/dist-packages"
 
   for sp in "$user_site" "$sys_site"; do
-    [ -f "$sp/fix_coverage_enflame.pth" ] && rm -f "$sp/fix_coverage_enflame.pth" && echo "Removed $sp/fix_coverage_enflame.pth"
-    [ -f "$sp/_fix_coverage_enflame.py" ] && rm -f "$sp/_fix_coverage_enflame.py" && echo "Removed $sp/_fix_coverage_enflame.py"
+    if [ -f "$sp/fix_coverage_enflame.pth" ]; then
+      rm -f "$sp/fix_coverage_enflame.pth"
+      echo "Removed $sp/fix_coverage_enflame.pth"
+    fi
+    if [ -f "$sp/_fix_coverage_enflame.py" ]; then
+      rm -f "$sp/_fix_coverage_enflame.py"
+      echo "Removed $sp/_fix_coverage_enflame.py"
+    fi
   done
+  return 0
 }
 
 patch_coverage_for_torch_gcu() {
@@ -49,7 +56,6 @@ import coverage.inorout as m
 path = m.__file__
 src = open(path).read()
 old = 'if len(getattr(mod, "__path__", ())) > 1:'
-new = 'if len(getattr(mod, "__path__", ()) or ()) > 1:'
 guard = '_enflame_gcu_patch'
 
 if guard in src:

--- a/.github/scripts/set_env_enflame.sh
+++ b/.github/scripts/set_env_enflame.sh
@@ -21,6 +21,57 @@ validate_enflame_capacity() {
     "import torch, torch_gcu; assert torch.gcu.is_available(); print(f'GCU devices: {torch.gcu.device_count()}')"
 }
 
+clean_stale_coverage_patch() {
+  # Clean up stale .pth file from earlier image builds (commit 539097af3 → 271405d79).
+  # MUST run before any Python invocation, because .pth files are processed at startup.
+  local user_site="/github/home/.local/lib/python3.12/site-packages"
+  local sys_site="/usr/local/lib/python3.12/dist-packages"
+
+  for sp in "$user_site" "$sys_site"; do
+    [ -f "$sp/fix_coverage_enflame.pth" ] && rm -f "$sp/fix_coverage_enflame.pth" && echo "Removed $sp/fix_coverage_enflame.pth"
+    [ -f "$sp/_fix_coverage_enflame.py" ] && rm -f "$sp/_fix_coverage_enflame.py" && echo "Removed $sp/_fix_coverage_enflame.py"
+  done
+}
+
+patch_coverage_for_torch_gcu() {
+  # torch_gcu registers _OpNamespace objects in sys.modules whose __path__ is
+  # not a sequence. coverage.py scans sys.modules inside coverage.start() and
+  # calls len() on every module's __path__, which raises TypeError and kills
+  # every rank before pytest is even imported. Because the crash happens in the
+  # `coverage run` CLI before pytest loads, a pytest plugin cannot fix it and a
+  # .pth hook is fragile (it runs before coverage is installed). Patching the
+  # installed source is the only interception point that is guaranteed to be in
+  # effect when coverage.start() runs. ascend/metax do not need this: their
+  # torch backends keep __path__ a real sequence.
+  python3 - <<'PYEOF'
+import coverage.inorout as m
+
+path = m.__file__
+src = open(path).read()
+old = 'if len(getattr(mod, "__path__", ())) > 1:'
+new = 'if len(getattr(mod, "__path__", ()) or ()) > 1:'
+guard = '_enflame_gcu_patch'
+
+if guard in src:
+    print(f"coverage already patched: {path}")
+elif old in src:
+    # Coerce __path__ to a real sequence before len(); _OpNamespace is truthy
+    # but has no __len__, so isinstance is the safe test rather than `or ()`.
+    new = (
+        'if len(getattr(mod, "__path__", ())'
+        ' if isinstance(getattr(mod, "__path__", ()), (list, tuple)) else ()'
+        ') > 1:  # _enflame_gcu_patch'
+    )
+    open(path, "w").write(src.replace(old, new, 1))
+    print(f"Patched coverage for torch_gcu: {path}")
+else:
+    raise SystemExit(
+        f"::error::coverage.inorout source changed; torch_gcu patch needs an "
+        f"update: {path}"
+    )
+PYEOF
+}
+
 configure_enflame_runtime() {
   validate_enflame_torch
   validate_enflame_capacity
@@ -42,18 +93,6 @@ setup_unit_environment() {
   ci_activate_python_environment
   ci_ensure_curl
   validate_enflame_torch
-
-  # Clean up stale .pth file from earlier image builds (commit 539097af3 → 271405d79).
-  # The image may still contain fix_coverage_enflame.pth which causes SyntaxError
-  # at Python startup. Remove both the .pth and the module it imports.
-  python3 -c "
-import site, os, glob
-for sp in [site.getusersitepackages(), site.getsitepackages()[0]]:
-    for pattern in ['fix_coverage_enflame.pth', '_fix_coverage_enflame.py']:
-        for path in glob.glob(os.path.join(sp, pattern)):
-            os.remove(path)
-            print(f'Removed stale coverage patch: {path}')
-" || true
 
   local test_dependencies=(
     mock
@@ -87,30 +126,7 @@ for sp in [site.getusersitepackages(), site.getsitepackages()[0]]:
 
   echo "Skipping NVIDIA CUPTI dependencies and Emerging-Optimizers on Enflame."
 
-  # Workaround: torch_gcu registers _OpNamespace objects in sys.modules whose
-  # __path__ attribute is not a sequence (no __len__). When coverage.py scans
-  # already-imported modules at startup it calls len() on every module's
-  # __path__, which raises TypeError and crashes all ranks before any test
-  # runs. Other platforms (ascend/metax) don't hit this because their torch
-  # backends don't inject non-sequence __path__ objects into sys.modules.
-  #
-  # Use a pytest plugin instead of a .pth file: .pth runs at Python startup
-  # before coverage is installed; pytest_configure runs after all deps load.
-  local site_dir=/tmp/enflame-ci-site
-  mkdir -p "$site_dir"
-  cat > "$site_dir/enflame_ci_pytest.py" <<'PYTESTEOF'
-def pytest_configure(config):
-    import coverage.inorout
-    orig = coverage.inorout.InOrOut.warn_already_imported_files
-    def safe_warn(self):
-        try:
-            orig(self)
-        except TypeError:
-            pass
-    coverage.inorout.InOrOut.warn_already_imported_files = safe_warn
-PYTESTEOF
-  ci_export_env PYTHONPATH "$site_dir:${PYTHONPATH:-}"
-  ci_export_env PYTEST_ADDOPTS "${PYTEST_ADDOPTS:-} -p enflame_ci_pytest"
+  patch_coverage_for_torch_gcu
 
   ci_install_project --break-system-packages
   configure_enflame_runtime
@@ -125,6 +141,10 @@ setup_build_environment() {
 }
 
 ci_require_env CI_TEST_SUITE
+
+# Clean up stale .pth file BEFORE any Python execution
+clean_stale_coverage_patch
+
 case "$CI_TEST_SUITE" in
   unit)
     setup_unit_environment

--- a/.github/scripts/set_env_enflame.sh
+++ b/.github/scripts/set_env_enflame.sh
@@ -99,7 +99,7 @@ def _patch():
 _patch()
 """)
 with open(os.path.join(sp, "fix_coverage_enflame.pth"), "w") as f:
-    f.write("import _fix_coverage_enflame\\n")
+    f.write("import _fix_coverage_enflame")
 print("Coverage torch_gcu workaround installed")
 PYEOF
 

--- a/.github/scripts/set_env_enflame.sh
+++ b/.github/scripts/set_env_enflame.sh
@@ -74,7 +74,7 @@ setup_unit_environment() {
     --no-deps "${pip_index_args[@]}"
 
   echo "Skipping NVIDIA CUPTI dependencies and Emerging-Optimizers on Enflame."
-  ci_install_project
+  ci_install_project --break-system-packages
   configure_enflame_runtime
   disable_unavailable_test_asset_downloads
 }
@@ -82,7 +82,7 @@ setup_unit_environment() {
 setup_build_environment() {
   ci_activate_python_environment
   validate_enflame_torch
-  ci_install_project
+  ci_install_project --break-system-packages
   configure_enflame_runtime
 }
 

--- a/.github/scripts/set_env_enflame.sh
+++ b/.github/scripts/set_env_enflame.sh
@@ -81,13 +81,13 @@ setup_unit_environment() {
   # __path__, which raises TypeError and crashes all ranks before any test
   # runs. Other platforms (ascend/metax) don't hit this because their torch
   # backends don't inject non-sequence __path__ objects into sys.modules.
-  python3 << 'PYEOF'
-import os, site
-sp = site.getusersitepackages()
-os.makedirs(sp, exist_ok=True)
-with open(os.path.join(sp, "_fix_coverage_enflame.py"), "w") as f:
-    f.write("""
-def _patch():
+  #
+  # Use a pytest plugin instead of a .pth file: .pth runs at Python startup
+  # before coverage is installed; pytest_configure runs after all deps load.
+  local site_dir=/tmp/enflame-ci-site
+  mkdir -p "$site_dir"
+  cat > "$site_dir/enflame_ci_pytest.py" <<'PYTESTEOF'
+def pytest_configure(config):
     import coverage.inorout
     orig = coverage.inorout.InOrOut.warn_already_imported_files
     def safe_warn(self):
@@ -96,12 +96,9 @@ def _patch():
         except TypeError:
             pass
     coverage.inorout.InOrOut.warn_already_imported_files = safe_warn
-_patch()
-""")
-with open(os.path.join(sp, "fix_coverage_enflame.pth"), "w") as f:
-    f.write("import _fix_coverage_enflame")
-print("Coverage torch_gcu workaround installed")
-PYEOF
+PYTESTEOF
+  ci_export_env PYTHONPATH "$site_dir:${PYTHONPATH:-}"
+  ci_export_env PYTEST_ADDOPTS "${PYTEST_ADDOPTS:-} -p enflame_ci_pytest"
 
   ci_install_project --break-system-packages
   configure_enflame_runtime

--- a/.github/scripts/set_env_enflame.sh
+++ b/.github/scripts/set_env_enflame.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/set_env_common.sh"
+
+validate_enflame_torch() {
+  python3 -c \
+    "import torch, torch_gcu; print(f'Torch: {torch.__version__}, torch_gcu: {torch_gcu.__version__}')"
+}
+
+validate_enflame_capacity() {
+  local device_count
+  device_count=$(python3 -c \
+    "import torch, torch_gcu; print(torch.gcu.device_count())" |
+    awk '/^[0-9]+$/ { count = $0 } END { print count }')
+  ci_validate_device_capacity "$device_count"
+
+  python3 -c \
+    "import torch, torch_gcu; assert torch.gcu.is_available(); print(f'GCU devices: {torch.gcu.device_count()}')"
+}
+
+configure_enflame_runtime() {
+  validate_enflame_torch
+  validate_enflame_capacity
+}
+
+disable_unavailable_test_asset_downloads() {
+  local data_dir=/opt/data
+  mkdir -p "$data_dir"
+
+  # The Enflame unit runner does not mount the NVIDIA unit-test release assets.
+  # Asset-dependent tests are excluded in enflame.yml; this marker prevents the
+  # session fixture from downloading the same archives in every matrix job.
+  if [ -z "$(find "$data_dir" -mindepth 1 -maxdepth 1 -print -quit)" ]; then
+    touch "$data_dir/.enflame-ci-assets-unavailable"
+  fi
+}
+
+setup_unit_environment() {
+  ci_activate_python_environment
+  ci_ensure_curl
+  validate_enflame_torch
+
+  local test_dependencies=(
+    mock
+    pytest-mock
+    coverage
+    pytest-asyncio
+    anyio
+    wandb
+    openai
+    httpx
+    nltk
+    msgpack
+  )
+  local pip_index_args=(
+    --index-url https://pypi.tuna.tsinghua.edu.cn/simple
+    --timeout 300
+    --retries 10
+    --no-cache-dir
+    --break-system-packages
+  )
+
+  # boto3 is intentionally omitted: S3 unit tests provide a local mock, while
+  # botocore downloads have been unreliable through the CI proxy.
+  python3 -m pip install ninja "${test_dependencies[@]}" "${pip_index_args[@]}"
+  echo "Ninja: $(ninja --version)"
+
+  # Collection-only dependencies are installed without dependencies to preserve
+  # the torch, protobuf, and numpy versions validated in the Enflame image.
+  python3 -m pip install fastapi starlette uvicorn griffe \
+    --no-deps "${pip_index_args[@]}"
+
+  echo "Skipping NVIDIA CUPTI dependencies and Emerging-Optimizers on Enflame."
+  ci_install_project
+  configure_enflame_runtime
+  disable_unavailable_test_asset_downloads
+}
+
+setup_build_environment() {
+  ci_activate_python_environment
+  validate_enflame_torch
+  ci_install_project
+  configure_enflame_runtime
+}
+
+ci_require_env CI_TEST_SUITE
+case "$CI_TEST_SUITE" in
+  unit)
+    setup_unit_environment
+    ;;
+  functional)
+    validate_enflame_torch
+    ci_setup_functional_environment
+    configure_enflame_runtime
+    ;;
+  build)
+    setup_build_environment
+    ;;
+  *)
+    echo "::error::Unsupported CI_TEST_SUITE: $CI_TEST_SUITE"
+    exit 1
+    ;;
+esac

--- a/.github/workflows/all_tests_ascend.yml
+++ b/.github/workflows/all_tests_ascend.yml
@@ -1,8 +1,8 @@
 name: ascend_tests
 
 on:
-  push:
-    branches: ["main"]
+  #push:
+    #branches: ["main"]
   pull_request:
     branches: ["main"]
   workflow_dispatch: # Allows manual triggering

--- a/.github/workflows/all_tests_cuda.yml
+++ b/.github/workflows/all_tests_cuda.yml
@@ -1,8 +1,8 @@
 name: cuda_tests
 
 on:
-  push:
-    branches: ["main"]
+ # push:
+  #  branches: ["main"]
   pull_request:
     branches: ["main"]
   workflow_dispatch: # Allows manual triggering

--- a/.github/workflows/all_tests_enflame.yml
+++ b/.github/workflows/all_tests_enflame.yml
@@ -2,7 +2,7 @@ name: enflame_tests
 
 on:
   push:
-    branches: ["main", "dev-Enflame"]
+    branches: ["main"]
   pull_request:
     branches: ["main"]
   workflow_dispatch: # Allows manual triggering

--- a/.github/workflows/all_tests_enflame.yml
+++ b/.github/workflows/all_tests_enflame.yml
@@ -1,0 +1,34 @@
+name: enflame_tests
+
+on:
+  push:
+    branches: ["main", "dev-Enflame"]
+  pull_request:
+    branches: ["main"]
+  workflow_dispatch: # Allows manual triggering
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-${{ github.actor }}
+  cancel-in-progress: true
+
+jobs:
+  run_tests:
+    # Package manager and environment settings are read from .github/configs/enflame.yml
+    uses: ./.github/workflows/all_tests_common.yml
+    with:
+      platform: enflame
+      run_unit_tests: true
+      run_functional_tests: false
+
+  all_tests:
+    needs: run_tests
+    runs-on: ubuntu-latest
+    if: always()
+    steps:
+      - name: Verify workflow status
+        run: |
+          if [ "${{ needs.run_tests.result }}" != "success" ]; then
+            echo "❌ Tests workflow failed"
+            exit 1
+          fi
+          echo "✅ All tests passed!"

--- a/.github/workflows/all_tests_metax.yml
+++ b/.github/workflows/all_tests_metax.yml
@@ -1,8 +1,8 @@
 name: metax_tests
 
 on:
-  push:
-    branches: ["main"]
+  #push:
+  #  branches: ["main"]
   pull_request:
     branches: ["main"]
   workflow_dispatch: # Allows manual triggering

--- a/.github/workflows/all_tests_musa.yml
+++ b/.github/workflows/all_tests_musa.yml
@@ -1,8 +1,8 @@
 name: s5000_tests
 
 on:
-  push:
-    branches: ["main", "dev", "dev-musa"]
+  #push:
+  #  branches: ["main", "dev", "dev-musa"]
   pull_request:
     branches: ["main"]
   workflow_dispatch: # Allows manual triggering

--- a/megatron/plugin/platform/platform_cuda.py
+++ b/megatron/plugin/platform/platform_cuda.py
@@ -26,6 +26,14 @@ class PlatformCUDA(PlatformBase):
     def is_available(self):
         try:
             import torch
+
+            # Enflame runtimes patch torch.cuda, so those APIs cannot identify
+            # the underlying backend when a GCU is actually available.
+            gcu = getattr(torch, 'gcu', None)
+            gcu_is_available = getattr(gcu, 'is_available', None)
+            if callable(gcu_is_available) and gcu_is_available():
+                return False
+
             # Determine if we are on a GPU or x86 CPU with torch.
             if torch.cuda.device_count() > 0 and torch.cuda.is_available():  #ignore-cuda
                 return True

--- a/megatron/plugin/tests/test_platform.py
+++ b/megatron/plugin/tests/test_platform.py
@@ -11,6 +11,7 @@ from unittest.mock import patch, MagicMock
 
 from megatron.plugin.platform.platform_base import PlatformBase
 from megatron.plugin.platform.platform_cpu import PlatformCPU
+from megatron.plugin.platform.platform_cuda import PlatformCUDA
 from megatron.plugin.platform import platform_register, platform_manager
 
 
@@ -344,6 +345,37 @@ class TestPlatformCPU(unittest.TestCase):
         """CPU get_device_capability raises NotImplementedError."""
         with self.assertRaises(NotImplementedError):
             self.cpu.get_device_capability()
+
+
+class TestPlatformCUDAAvailability(unittest.TestCase):
+    """Test CUDA detection when vendor runtimes expose CUDA-compatible APIs."""
+
+    def test_defers_to_enflame_when_gcu_is_available(self):
+        cuda = types.SimpleNamespace(
+            device_count=MagicMock(return_value=2),
+            is_available=MagicMock(return_value=True),
+        )
+        fake_torch = types.SimpleNamespace(
+            cuda=cuda,
+            gcu=types.SimpleNamespace(is_available=MagicMock(return_value=True)),
+        )
+
+        with patch.dict(sys.modules, {"torch": fake_torch}):
+            self.assertFalse(PlatformCUDA().is_available())
+
+        cuda.device_count.assert_not_called()
+        cuda.is_available.assert_not_called()
+
+    def test_detects_cuda_when_gcu_api_is_absent(self):
+        fake_torch = types.SimpleNamespace(
+            cuda=types.SimpleNamespace(
+                device_count=MagicMock(return_value=8),
+                is_available=MagicMock(return_value=True),
+            )
+        )
+
+        with patch.dict(sys.modules, {"torch": fake_torch}):
+            self.assertTrue(PlatformCUDA().is_available())
 
 
 class _FakeDeviceProps:

--- a/tests/test_utils/runners/run_ci_unit_tests.sh
+++ b/tests/test_utils/runners/run_ci_unit_tests.sh
@@ -48,8 +48,8 @@ selected = []
 for item in shlex.split(os.environ["CI_TEST_PATH"]):
     matches = sorted(glob.glob(item)) if glob.has_magic(item) else [item]
     selected.extend(path for path in matches if path not in ignored_files)
-print("\n".join(selected))
-'
+print("\n".join(selected), file=os.fdopen(3, "w"))
+' 3>&1 1>&2
 )
 
 IGNORE_OPTS=()
@@ -60,10 +60,11 @@ done < <(
 import json
 import os
 
+output = os.fdopen(3, "w")
 for item in json.loads(os.environ["CI_IGNORED_TESTS"]):
     prefix = "--deselect=" if "::" in item else "--ignore="
-    print(prefix + item)
-'
+    print(prefix + item, file=output)
+' 3>&1 1>&2
 )
 
 EXTRA_ARGS=()
@@ -74,8 +75,8 @@ done < <(
 import json
 import os
 
-print("\n".join(json.loads(os.environ["CI_PYTEST_EXTRA_ARGS"])))
-'
+print("\n".join(json.loads(os.environ["CI_PYTEST_EXTRA_ARGS"])), file=os.fdopen(3, "w"))
+' 3>&1 1>&2
 )
 
 if [ "${#TEST_PATHS[@]}" -eq 0 ]; then


### PR DESCRIPTION
# Description

Add CI/CD workflow support for Enflame L600 unit tests in Megatron-LM-FL.
The implementation reuses the existing configuration-driven common workflow
and adds Enflame-specific runtime setup, dependency installation, coverage
compatibility handling, and an eight-device unit test matrix.

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] Infra/Build change (changes to CI/CD workflows or build scripts)
- [ ] Code refactoring
- [ ] Documentation change
- [x] Bug fix
- [ ] Breaking change

## Changes

- **Enflame platform configuration**: Added the Enflame hardware configuration
  with the Enflame CI image, `sy-8g-cicd-megatron` runner label, S60 device
  type, container options, local asset mounts, and eight-process execution.

- **Enflame unit workflow**: Added the Enflame workflow based on the shared
  `all_tests_common.yml` workflow. Enflame unit test execution is enabled
  through the platform configuration, while functional test execution remains
  disabled until the functional test environment is ready.

- **Unit test matrix**: Added Enflame unit test groups covering core, models,
  distributed, distributed checkpointing, tensor parallel, pipeline parallel,
  data, fusions, export, post-training, tokenizer, and utility tests.

- **Enflame runtime setup**: Added validation for the installed PyTorch and
  `torch_gcu` versions, GCU availability, and the expected device capacity.
  The setup script also installs the unit-test dependencies and the editable
  Megatron package.

- **Coverage compatibility**: Added Enflame-specific handling for the
  `torch_gcu` coverage startup issue and cleanup of stale coverage hooks from
  previous image versions.

- **Unit runner compatibility**: Prevented helper-process output used to build
  pytest arguments from being mixed into the main command stream.

- **Platform detection coverage**: Added regression tests for Enflame runtime
  detection and normal CUDA detection behavior.

- **Workflow trigger cleanup**: Limited existing platform workflows to pull
  requests and manual execution to avoid redundant push-triggered test runs.

## Validation

- Enflame setup validates the GCU runtime and device capacity before tests run.
- The Enflame workflow uses the shared unit-test workflow and coverage reporting
  path.
- Python syntax validation passed.
- `git diff --check` passed.
- Full unit-test validation should be performed on the Enflame CI runner with
  the configured image and hardware.

## Checklist

- [x] I have read and followed the contributing guidelines
- [x] The functionality is complete
- [x] I have commented my code, particularly in CI workflow setup steps
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added/updated tests that prove my changes work
- [ ] New and existing unit tests pass locally on Enflame hardware