### PR TITLE
fix(datasets): derive helpers_cpp extension suffix via sysconfig

### DIFF
--- a/megatron/core/datasets/utils.py
+++ b/megatron/core/datasets/utils.py
@@ -21,15 +21,14 @@ def compile_helpers():
     """Compile C++ helper functions at runtime. Make sure this is invoked on a single process."""
     import os
     import subprocess
+    import sysconfig
 
     src_dir = os.path.abspath(os.path.dirname(__file__))  # FlagScale Add
 
     # FlagScale Begin
     # Skip compilation if the shared library already exists (e.g. pip-installed package
     # where the .so is pre-built but the Makefile is not included in the wheel).
-    ext_suffix = subprocess.check_output(
-        ["python3-config", "--extension-suffix"], text=True
-    ).strip()
+    ext_suffix = sysconfig.get_config_var("EXT_SUFFIX")
     so_path = os.path.join(src_dir, f"helpers_cpp{ext_suffix}")
     if os.path.isfile(so_path):
         return


### PR DESCRIPTION
Fixes #160

## Problem

`compile_helpers()` in `megatron/core/datasets/utils.py` runs
`subprocess.check_output(["python3-config", "--extension-suffix"])` to
locate the pre-built `helpers_cpp{ext_suffix}.so` and skip `make`.

`python3-config` is a CPython **build artifact** (a shell script generated
from `python-config.in`), not a pip package — venvs created by uv
(and other modern toolchains) do not carry it in `bin/`. Any
pip-installed consumption path (`pip install megatron-core` in such a
venv, then `pretrain_gpt.py` / dataset import) therefore raises
`FileNotFoundError: 'python3-config'` before compilation can even be
skipped.

## Fix

Replace the `python3-config` subprocess with the standard-library
equivalent: `sysconfig.get_config_var("EXT_SUFFIX")`. It returns the same
value in any Python environment (venv or not) and removes the dependency
on an external binary that is not part of the wheel/dependency surface.

## Notes

This is the same class of fix as #106 (declare psutil) — an undeclared
runtime dependency that only surfaces on wheel-install paths.

This PR was written in part with the assistance of generative AI.
