### PR TITLE
fix(core): make jit_fuser decoration lazy so --disable-jit-fuser works

### DIFF
--- a/megatron/core/jit.py
+++ b/megatron/core/jit.py
@@ -1,33 +1,56 @@
 # Copyright (c) 2024, NVIDIA CORPORATION. All rights reserved.
 
+import functools
+
 import torch
 
 from megatron.core.utils import is_torch_min_version
 
-jit_fuser = torch.jit.script
-# nvFuser is deprecated in PyTorch JIT starting from 2.2
+# Whether functions decorated with @jit_fuser are compiled via torch.compile.
+# Enabled by default to match upstream behavior; `--disable-jit-fuser` flips
+# it off after CLI argument parsing. Decoration is deferred to first call so
+# that the flag is honored even though the decorated modules are imported
+# before the CLI args are parsed.
+jit_fuser_enabled = True
 
 
-def noop_decorator(func):
-    '''No-op decorator'''
-    return func
+def jit_fuser(func):
+    '''Lazily compile `func` with torch.compile (or torch.jit.script).
+
+    The decision is made at first call, not at decoration time. Decorated
+    modules are imported before the CLI args are parsed, so eagerly binding
+    torch.compile at import made `--disable-jit-fuser` ineffective: warmup
+    still triggered torch.compile -> inductor, crashing on backends whose
+    flagtree cannot compile those kernels (e.g. Hygon DTK).
+    '''
+    resolved = None
+
+    @functools.wraps(func)
+    def wrapper(*args, **kwargs):
+        nonlocal resolved
+        if resolved is None:
+            if jit_fuser_enabled:
+                try:
+                    if is_torch_min_version("2.2.0a0"):
+                        resolved = torch.compile(func)
+                    else:
+                        resolved = torch.jit.script(func)
+                except ImportError:
+                    resolved = func
+            else:
+                resolved = func
+        return resolved(*args, **kwargs)
+
+    return wrapper
 
 
 def enable_jit_fuser():
     '''Enable the JIT fuser'''
-    global jit_fuser
-    try:
-        if is_torch_min_version("2.2.0a0"):
-            jit_fuser = torch.compile
-    except ImportError:
-
-        jit_fuser = noop_decorator
+    global jit_fuser_enabled
+    jit_fuser_enabled = True
 
 
 def disable_jit_fuser():
     '''Disable the JIT fuser'''
-    global jit_fuser
-    jit_fuser = noop_decorator
-
-
-enable_jit_fuser()
+    global jit_fuser_enabled
+    jit_fuser_enabled = False


### PR DESCRIPTION
## Problem

`megatron/core/jit.py` calls `enable_jit_fuser()` at import time, globally
binding `jit_fuser = torch.compile` (torch >= 2.2). Every module using
`@jit_fuser` then binds `torch.compile` at its own import time.

`--disable-jit-fuser` is parsed in `megatron/training/global_vars.py`
(lines 151–152) — i.e. after all those modules are imported. So the flag
never takes effect on already-decorated functions: warmup still runs
`torch.compile` → inductor → flagtree, which crashes on backends whose
flagtree cannot compile those kernels (Hygon DTK flagtree 3.6.0
`KernelMetadata.cluster_dims` crash during warmup, even with
`--disable-jit-fuser`).

Note: identical code exists upstream in NVIDIA/Megatron-LM (jit.py synced
from core v0.17.0) — this is an upstream defect, not a fork deviation.

## Fix

Make `jit_fuser` a **lazy decorator**: it resolves to `torch.compile`
(default) or the plain function at *first call* rather than at decoration
time. `enable_jit_fuser()` / `disable_jit_fuser()` now flip a module-level
flag instead of rebinding a global.

- Default (no flag): `torch.compile` still applied — behavior unchanged,
  compilation still deferred to first call.
- `--disable-jit-fuser`: parsed after imports, flag flips before warmup,
  decorators resolve to plain functions — the flag now genuinely works.

This PR was written in part with the assistance of generative AI.
