### PR TITLE
fix(rl): enable RL on local-attention (non-TE) backends

### DIFF
--- a/megatron/core/tokenizers/text/libraries/null_tokenizer.py
+++ b/megatron/core/tokenizers/text/libraries/null_tokenizer.py
@@ -82,6 +82,36 @@ class NullTokenizer:
         return self._eod_id
 
     @property
+    def pad_id(self):
+        """Returns id of padding token. NullTokenizer has none -> eod."""
+        return self._eod_id
+
+    @property
+    def pad(self):
+        """Returns padding token id (needed by RL trajectory padding)."""
+        return self._eod_id
+
+    @property
+    def bos_id(self):
+        """Returns id of beginning of sentence token. NullTokenizer has none."""
+        return None
+
+    @property
+    def bos(self):
+        """Returns beginning of sentence token id."""
+        return None
+
+    @property
+    def eos_id(self):
+        """Returns id of end of sentence token."""
+        return self._eod_id
+
+    @property
+    def eos(self):
+        """Returns end of sentence token id."""
+        return self._eod_id
+
+    @property
     def additional_special_tokens_ids(self):
         """ """
         return None

--- a/megatron/core/transformer/attention.py
+++ b/megatron/core/transformer/attention.py
@@ -940,8 +940,13 @@ class Attention(MegatronModule, ABC):
         inference_context = deprecate_inference_params(inference_context, inference_params)
 
         if inference_context and inference_context.is_dynamic_batching():
-            assert HAVE_FA3 or is_fa_min_version(
-                "2.7.3"
+            # DotProductAttention (--attention-backend unfused) never calls
+            # flash_attn (pure baddbmm/bmm, no block_table), so the flash_attn
+            # version gate only applies to flash/TE attention implementations.
+            assert (
+                HAVE_FA3
+                or is_fa_min_version("2.7.3")
+                or self.core_attention.__class__.__name__ == "DotProductAttention"
             ), "flash attn verion v2.7.3 and above is required for dynamic batching."
 
         # hidden_states: [sq, b, h]

--- a/megatron/inference/utils.py
+++ b/megatron/inference/utils.py
@@ -347,7 +347,7 @@ def get_inference_config_from_model_and_args(model: MegatronModule, args):
         max_sequence_length=max_sequence_length,
         mamba_inference_state_config=mamba_inference_state_config,
         pg_collection=pg_collection,
-        use_flashinfer_fused_rope=args.use_flashinfer_fused_rope,
+        use_flashinfer_fused_rope=getattr(args, 'use_flashinfer_fused_rope', False),
         materialize_only_last_token_logits=(not args.return_log_probs and args.num_speculative_tokens == 0),
         track_generated_token_events=args.inference_dynamic_batching_track_generated_token_events,
         track_paused_request_events=args.inference_dynamic_batching_track_paused_request_events,

--- a/megatron/rl/rl_utils.py
+++ b/megatron/rl/rl_utils.py
@@ -670,6 +670,10 @@ def get_logprobs(model, tokens, position_ids, no_grad=False, sequence_packing=Fa
                 max_sequences_per_bin=args.rl_sequence_packing_max_sequences_per_bin,
                 device=tokens.device,
             )
+        elif args.transformer_impl == "local":
+            # local impl (DotProductAttention) rejects THD packed sequences —
+            # thd is only consumed by TE fused attention. Pass None through.
+            pass
         else:
             cu_seqlens = torch.tensor([0, tokens.shape[1]], dtype=torch.int32, device=tokens.device)
             packed_seq_params = PackedSeqParams(
@@ -1840,7 +1844,7 @@ def megatron_rl_inference_mode(
     model[0].config.cuda_graph_impl = "local"
 
     # If we get a lower precision wrapper, we go one object deeper.
-    lang_module = model[0].module.module if hasattr(model[0].module, "module") else model[0].module
+    lang_module = unwrap_model(model[0])
 
     # Switch MoE layers to full CUDA graph capture for inference
     if args.rl_training_cuda_graphs and args.num_experts is not None:

--- a/megatron/training/arguments.py
+++ b/megatron/training/arguments.py
@@ -1837,6 +1837,9 @@ def _add_inference_args(parser):
     group.add_argument('--inference-max-seq-length', type=int, default=2560,
                        help='Maximum sequence length expected for inference (prefill + decode).',
                        dest='inference_max_seq_length')
+    group.add_argument('--return-log-probs', action='store_true', default=False,
+                       help='Whether to return logprobs for each generated token.',
+                       dest='return_log_probs')
     group.add_argument('--inference-dynamic-batching',
                        action='store_true', default=False,
                        help='Enable dynamic batching mode.')


### PR DESCRIPTION
Fixes #162

## Summary

The RL dynamic-engine path must run without a vendor TransformerEngine
(`--transformer-impl local`). This consolidates the 5 patches that path
needs into upstream.

- `rl_utils`: skip THD `packed_seq_params` construction for local impl
  (thd is only consumed by TE fused attention; DotProductAttention
  rejects it); `unwrap_model(model[0])` instead of the `.module.module`
  chain for the lang module in inference mode
- `arguments`: register `--return-log-probs` (consumed by
  `inference/utils.py materialize_only_last_token_logits`)
- `inference/utils`: `getattr` fallback for `use_flashinfer_fused_rope`
- `null_tokenizer`: add pad/bos/eos property group (RL trajectory
  padding touches these)
- `attention`: gate the dynamic-batching flash_attn version assert on
  `DotProductAttention` (version-number check, not functional; vendor
  flash_attn variants below 2.7.3 support block_table paths)

This PR was written in part with the assistance of generative AI.
