### PR TITLE
feat(npu): paged attention + platform convergence for Ascend NPU inference/RL

### DIFF
--- a/megatron/core/inference/contexts/fused_kv_append_kernel.py
+++ b/megatron/core/inference/contexts/fused_kv_append_kernel.py
@@ -115,10 +115,10 @@ def triton_append_key_value_cache(
     """
     # --- Input Validation and Preparation ---
     assert (
-        key.device.type in ('cuda', 'npu')
-        and value.device.type in ('cuda', 'npu')
-        and memory_buffer.device.type in ('cuda', 'npu')
-    ), "All tensors must be on CUDA or Ascend NPU devices."
+        key.device.type not in ('cpu', 'meta')
+        and value.device.type not in ('cpu', 'meta')
+        and memory_buffer.device.type not in ('cpu', 'meta')
+    ), "All tensors must be on a device with a Triton backend (CUDA, NPU, ...)."
 
     assert (
         key.size(1) == 1 and value.size(1) == 1

--- a/megatron/core/inference/contexts/fused_kv_append_kernel.py
+++ b/megatron/core/inference/contexts/fused_kv_append_kernel.py
@@ -115,10 +115,10 @@ def triton_append_key_value_cache(
     """
     # --- Input Validation and Preparation ---
     assert (
-        key.device.type == 'cuda'
-        and value.device.type == 'cuda'
-        and memory_buffer.device.type == 'cuda'
-    ), "All tensors must be on CUDA devices."
+        key.device.type in ('cuda', 'npu')
+        and value.device.type in ('cuda', 'npu')
+        and memory_buffer.device.type in ('cuda', 'npu')
+    ), "All tensors must be on CUDA or Ascend NPU devices."
 
     assert (
         key.size(1) == 1 and value.size(1) == 1

--- a/megatron/core/inference/engines/dynamic_engine.py
+++ b/megatron/core/inference/engines/dynamic_engine.py
@@ -18,7 +18,8 @@ from typing import Dict, List, Optional, Tuple, Union
 
 import torch
 from torch import Tensor
-from torch.cuda.nvtx import range_pop, range_push
+
+from megatron.core.utils import cur_platform
 
 from megatron.core.inference.config import KVCacheManagementMode
 from megatron.core.inference.contexts.dynamic_context import (
@@ -651,14 +652,14 @@ class DynamicInferenceEngine(AbstractEngine):
 
             start_mem = torch.cuda.memory_stats()
             start_time = time.time()
-            range_push(f"{key}-inference-context")
+            cur_platform.range_push(f"{key}-inference-context")
             torch.cuda.synchronize()
 
             yield
 
         finally:
 
-            range_pop()
+            cur_platform.range_pop()
             end_time = time.time()
 
             end_mem = torch.cuda.memory_stats()
@@ -1631,7 +1632,7 @@ class DynamicInferenceEngine(AbstractEngine):
         }
 
         # Generate tokens.
-        range_push("Prefill" if not is_decode_only else "Decode")
+        cur_platform.range_push("Prefill" if not is_decode_only else "Decode")
         # TODO @TDE: Account for this line when overlapping forward and bookkeep.
         self.is_decode_only = is_decode_only
 
@@ -1643,7 +1644,7 @@ class DynamicInferenceEngine(AbstractEngine):
         self.context.step_count += 1
         self.context.prefix_cache_lru_clock += 1
 
-        range_pop()
+        cur_platform.range_pop()
 
         if (
             self.logging_step_interval > 0
@@ -1690,7 +1691,7 @@ class DynamicInferenceEngine(AbstractEngine):
                 cuda_graph_request_count (int): The CUDA graph batch size matching this step.
         """
         # Increment finished_request_count.
-        range_push("bookkeeping")
+        cur_platform.range_push("bookkeeping")
         cuda_graph_request_count = None
 
         if step_result is not None:
@@ -1739,13 +1740,13 @@ class DynamicInferenceEngine(AbstractEngine):
             ), f"Failed request {failed_request_id} future has not been properly resolved."
         self.failed_request_ids.clear()
 
-        range_pop()
+        cur_platform.range_pop()
 
         # Detokenize all finished requests if not using
         # the coordinator. Otherwise, the coordinator will
         # overlap detokenization with the engine.
         if not self.use_coordinator:
-            range_push("detokenization")
+            cur_platform.range_push("detokenization")
             for record in finished_request_records:
                 for request in record.requests:
                     if request.prompt is None:
@@ -1759,7 +1760,7 @@ class DynamicInferenceEngine(AbstractEngine):
                         request.generated_tokens,
                         remove_EOD=not request.sampling_params.detokenize_stop_sequence,
                     )
-            range_pop()
+            cur_platform.range_pop()
 
         # Handle necessary ZMQ DP coordinator communication.
         # Failed request replies were already sent in _handle_failed_request,
@@ -1769,13 +1770,13 @@ class DynamicInferenceEngine(AbstractEngine):
                 r for r in finished_request_records if r.requests[-1].status != Status.FAILED
             ]
             if records_to_send:
-                range_push("coordinator_communication")
+                cur_platform.range_push("coordinator_communication")
                 payload = msgpack.packb(
                     [Headers.ENGINE_REPLY.value, [r.merge().serialize() for r in records_to_send]],
                     use_bin_type=True,
                 )
                 self.socket_for_receiving_requests.send(payload)
-                range_pop()
+                cur_platform.range_pop()
 
         # Drain prefix cache hit counters from context into engine accumulators.
         if self.context.enable_prefix_caching:
@@ -2015,7 +2016,7 @@ class DynamicInferenceEngine(AbstractEngine):
             int: The number of messages that were received and processed in this batch.
         """
 
-        range_push("drain_zmq_socket")
+        cur_platform.range_push("drain_zmq_socket")
         all_messages = []
         if self.is_mp_coordinator:
             while True:
@@ -2048,7 +2049,7 @@ class DynamicInferenceEngine(AbstractEngine):
             else:
                 all_messages = []
 
-        range_pop()
+        cur_platform.range_pop()
 
         # First pass: add requests.
         # Control signals are queued for the second pass.
@@ -2059,9 +2060,9 @@ class DynamicInferenceEngine(AbstractEngine):
             if header == Headers.SUBMIT_REQUEST:
                 request_id, prompt, sampling_params = data[1:]
                 sampling_params = SamplingParams.deserialize(sampling_params)
-                range_push("add_request")
+                cur_platform.range_push("add_request")
                 self.add_request(request_id, prompt, sampling_params)
-                range_pop()
+                cur_platform.range_pop()
             elif header == Headers.SET_GENERATION_EPOCH:
                 new_generation_epoch = data[1]
             else:
@@ -2205,7 +2206,7 @@ class DynamicInferenceEngine(AbstractEngine):
             (global_work, all_pausing): max work across EP, and whether
             all peers signaled consensus.
         """
-        range_push("_ep_establish_consensus")
+        cur_platform.range_push("_ep_establish_consensus")
 
         consensus_val = -1 if signal_consensus else 0
 
@@ -2230,7 +2231,7 @@ class DynamicInferenceEngine(AbstractEngine):
         else:
             global_work, global_consensus = local_work, consensus_val
 
-        range_pop()
+        cur_platform.range_pop()
         return global_work, global_consensus == -1
 
     async def _world_barrier(self):
@@ -2242,12 +2243,12 @@ class DynamicInferenceEngine(AbstractEngine):
 
         No-op when world_size == 1 (communicator is not created).
         """
-        range_push("world_barrier")
+        cur_platform.range_push("world_barrier")
         if hasattr(self, 'world_zmq_communicator'):
             await self.world_zmq_communicator.all_reduce_max(
                 1, async_op=(not self.use_synchronous_zmq_collectives)
             )
-        range_pop()
+        cur_platform.range_pop()
 
     @trace_async_exceptions
     async def run_engine_with_coordinator(

--- a/megatron/core/inference/inference_request.py
+++ b/megatron/core/inference/inference_request.py
@@ -12,7 +12,7 @@ import torch
 
 from megatron.core.inference.sampling_params import SamplingParams
 from megatron.core.tokenizers import MegatronTokenizer
-from megatron.core.utils import experimental_api
+from megatron.core.utils import cur_platform, experimental_api
 
 
 def serialize_tensor(tensor: torch.Tensor) -> List:
@@ -24,12 +24,12 @@ def serialize_tensor(tensor: torch.Tensor) -> List:
     Returns:
         (List) Tensor as a list
     """
-    torch.cuda.nvtx.range_push("serialize_tensor")
+    cur_platform.range_push("serialize_tensor")
 
     # simply convert tensor into a list
     tensor = tensor.cpu().tolist()
 
-    torch.cuda.nvtx.range_pop()
+    cur_platform.range_pop()
     return tensor
 
 
@@ -299,7 +299,7 @@ class DynamicInferenceEvent:
         Returns:
             dict: Full event dict.
         """
-        torch.cuda.nvtx.range_push("DynamicInferenceEvent.serialize")
+        cur_platform.range_push("DynamicInferenceEvent.serialize")
         # do not use asdict(self) - it has very high CPU overheads
         # and if there are tensors, it will try to deepcopy them
         obj = self.__dict__.copy()
@@ -315,7 +315,7 @@ class DynamicInferenceEvent:
 
                 obj["payload"] = ContextErrorFactory.serialize(self.payload)
 
-        torch.cuda.nvtx.range_pop()
+        cur_platform.range_pop()
         return obj
 
     @classmethod
@@ -429,7 +429,7 @@ class DynamicInferenceRequest(InferenceRequest):
             (dict) A dictionary representation of the instance suitable for
                 serialization.
         """
-        torch.cuda.nvtx.range_push("DynamicInferenceRequest.serialize")
+        cur_platform.range_push("DynamicInferenceRequest.serialize")
         obj = super().serialize()
         obj["events"] = [e.serialize() for e in self.events]
         obj.pop("event_add_engine", None)
@@ -444,7 +444,7 @@ class DynamicInferenceRequest(InferenceRequest):
                 f"total tokens {total_tokens-1}."
             )
 
-        torch.cuda.nvtx.range_pop()
+        cur_platform.range_pop()
         return obj
 
     def _post_deserialize(self, obj):
@@ -741,10 +741,10 @@ class DynamicInferenceRequestRecord:
             (dict) A dictionary representation of the instance suitable for
                 serialization.
         """
-        torch.cuda.nvtx.range_push("DynamicInferenceRequestRecord.serialize")
+        cur_platform.range_push("DynamicInferenceRequestRecord.serialize")
         obj = self.__dict__.copy()  # shallow dict copy
         obj["requests"] = [r.serialize() for r in obj["requests"]]
-        torch.cuda.nvtx.range_pop()
+        cur_platform.range_pop()
         return obj
 
     @classmethod

--- a/megatron/core/resharding/planner.py
+++ b/megatron/core/resharding/planner.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import logging
 import math
+import inspect
 
 import torch
 import torch.distributed as dist
@@ -19,6 +20,28 @@ from .utils import (
 )
 
 logger = logging.getLogger(__name__)
+
+# Probed lazily: torch_npu (Ascend) replaces dist.gather_object at import time
+# with an older-signature implementation that predates the `group_dst` kwarg.
+_SUPPORTS_GROUP_DST = None
+
+
+def _gather_object_to_local_rank0(obj, object_gather_list, group):
+    """Gather `obj` to local rank 0 of `group`.
+
+    Upstream megatron-core passes ``group_dst=0`` (local rank on the group),
+    but torch_npu's dist.gather_object override only accepts the global-rank
+    ``dst`` kwarg. Probe the runtime signature once and fall back to the
+    equivalent global-rank form; mainline torch handles both kwargs.
+    """
+    global _SUPPORTS_GROUP_DST
+    if _SUPPORTS_GROUP_DST is None:
+        _SUPPORTS_GROUP_DST = "group_dst" in inspect.signature(dist.gather_object).parameters
+    if _SUPPORTS_GROUP_DST:
+        dist.gather_object(obj, object_gather_list, group_dst=0, group=group)
+    else:
+        dst_global = 0 if group is None else dist.get_global_rank(group, 0)
+        dist.gather_object(obj, object_gather_list, dst=dst_global, group=group)
 
 
 def _build_descriptors_for_param(
@@ -434,8 +457,8 @@ def build_centralized_reshard_plan(
     # Other ranks don't need the full metadata — they only need their own plan.
     all_src_metadata_by_rank = [None] * world_size if my_global_rank == 0 else None
     all_dst_metadata_by_rank = [None] * world_size if my_global_rank == 0 else None
-    dist.gather_object(my_src_metadata, all_src_metadata_by_rank, group_dst=0, group=group)
-    dist.gather_object(my_dst_metadata, all_dst_metadata_by_rank, group_dst=0, group=group)
+    _gather_object_to_local_rank0(my_src_metadata, all_src_metadata_by_rank, group)
+    _gather_object_to_local_rank0(my_dst_metadata, all_dst_metadata_by_rank, group)
 
     # Free local metadata — no longer needed after gather.
     del my_src_metadata, my_dst_metadata

--- a/megatron/core/transformer/attention.py
+++ b/megatron/core/transformer/attention.py
@@ -810,7 +810,20 @@ class Attention(MegatronModule, ABC):
                 softmax_scale = self.softmax_scale
             else:
                 softmax_scale = q.shape[-1] ** -0.5
-            if HAVE_FA3:
+            if cur_platform.device_name() == "npu":
+                # NPU: no flash-attn on 910B4; the platform provides the paged
+                # prefill op (gather + torch_npu.npu_fusion_attention).
+                output_total = cur_platform.paged_prefill_attention(
+                    q,
+                    k,
+                    v,
+                    cu_seqlens_q,
+                    cu_seqlens_k,
+                    seqlens_k,
+                    block_table,
+                    num_heads=self.num_attention_heads_per_partition,
+                )
+            elif HAVE_FA3:
                 # TODO(ksanthanam): Replace with call to flash_attn_varlen_func once
                 # it accepts block_table
                 output_total = self._flash_attention_3_forward_wrapper(
@@ -842,6 +855,26 @@ class Attention(MegatronModule, ABC):
                 )
             output_total = output_total.unsqueeze(1)
         else:  # decode only
+            if cur_platform.device_name() == "npu":
+                # NPU: no flash-attn / FlashMLA kernels available (910B4); the
+                # platform provides the CANN paged attention op (see
+                # PlatformNPU.paged_decode_attention for the measured (block_size,
+                # head_size) support boundary).
+                if isinstance(self.config, MLATransformerConfig):
+                    raise NotImplementedError(
+                        "MLA decode is not supported on NPU (no FlashMLA kernel)"
+                    )
+                output_total = cur_platform.paged_decode_attention(
+                    q,
+                    k,
+                    block_table,
+                    seqlens_k,
+                    value_cache=v,
+                    num_heads=self.num_attention_heads_per_partition,
+                    num_kv_heads=self.num_query_groups_per_partition,
+                    scale_value=q.shape[-1] ** -0.5,
+                )
+                return output_total
             # If using MLA we use the FlashMLA kernel
             if isinstance(self.config, MLATransformerConfig):
                 softmax_scale = self.softmax_scale
@@ -940,9 +973,12 @@ class Attention(MegatronModule, ABC):
         inference_context = deprecate_inference_params(inference_context, inference_params)
 
         if inference_context and inference_context.is_dynamic_batching():
-            assert HAVE_FA3 or is_fa_min_version(
-                "2.7.3"
-            ), "flash attn verion v2.7.3 and above is required for dynamic batching."
+            # Platforms with a native paged-attention op (e.g. NPU) skip the
+            # flash-attn version gate; see PlatformBase.requires_flash_attn_for_dynamic_batching.
+            if cur_platform.requires_flash_attn_for_dynamic_batching():
+                assert HAVE_FA3 or is_fa_min_version(
+                    "2.7.3"
+                ), "flash attn verion v2.7.3 and above is required for dynamic batching."
 
         # hidden_states: [sq, b, h]
         is_inference_mode = inference_context is not None and not self.training

--- a/megatron/plugin/platform/platform_base.py
+++ b/megatron/plugin/platform/platform_base.py
@@ -222,6 +222,63 @@ class PlatformBase(ABC):
     def is_triton_supported(self):
         ...
 
+    # Attention backend capabilities
+    def requires_flash_attn_for_dynamic_batching(self) -> bool:
+        """Whether the dynamic-batching inference path needs flash-attn >= 2.7.3.
+
+        Platforms with a native paged-attention op (e.g. NPU via CANN) override
+        this to False; the flash-attn version gate is then skipped. Default True.
+        """
+        return True
+
+    def paged_decode_attention(
+        self,
+        query,
+        key_cache,
+        block_table,
+        seqlens_k,
+        *,
+        value_cache=None,
+        num_heads=None,
+        num_kv_heads=None,
+        scale_value=None,
+    ):
+        """Run decode-phase attention (one query row per token) on a paged KV cache.
+
+        Default: no native op available, raise. Platforms with a vendor op
+        (NPU: torch_npu.atb._npu_paged_attention_v2) implement this; the caller
+        (Attention.flash_decode_and_prefill) dispatches on the platform and
+        never reaches here on unsupported platforms.
+        """
+        raise NotImplementedError(
+            "paged_decode_attention is not implemented for platform "
+            + self.__class__.__name__
+        )
+
+    def paged_prefill_attention(
+        self,
+        q,
+        k,
+        v,
+        cu_seqlens_q,
+        cu_seqlens_k,
+        seqlens_k,
+        block_table,
+        *,
+        num_heads,
+    ):
+        """Run prefill-phase attention (varlen, causal) on a paged KV cache.
+
+        Default: no native op available, raise. Platforms with a vendor op
+        (NPU: gather the paged cache into contiguous TND rows +
+        torch_npu.npu_fusion_attention) implement this; the caller dispatches on
+        the platform and never reaches here on unsupported platforms.
+        """
+        raise NotImplementedError(
+            "paged_prefill_attention is not implemented for platform "
+            + self.__class__.__name__
+        )
+
     # Graph operations
     @abc.abstractmethod
     def create_graph(self):

--- a/megatron/plugin/platform/platform_manager.py
+++ b/megatron/plugin/platform/platform_manager.py
@@ -15,7 +15,14 @@ def get_platform():
     if cur_platform is not None:
         return cur_platform
 
-    if "cuda" in PLATFORMS.keys() and PLATFORMS["cuda"].is_available():
+    # NPU is checked before CUDA: on Ascend, torch_npu's transfer_to_npu shim
+    # (TORCH_TRANSFER_TO_NPU=1) makes torch.cuda.is_available()/device_count()
+    # report the NPU as "cuda", so the real device must win the selection.
+    # On machines without torch_npu the NPU check falls through (is_available False).
+    if "npu" in PLATFORMS.keys() and PLATFORMS["npu"].is_available():
+        cur_platform = PLATFORMS["npu"]
+        print(f"Megatron-LM-FL Platform: npu Selected")
+    elif "cuda" in PLATFORMS.keys() and PLATFORMS["cuda"].is_available():
         cur_platform = PLATFORMS["cuda"]
         print(f"Megatron-LM-FL Platform: cuda Selected")
     elif "musa" in PLATFORMS.keys() and PLATFORMS["musa"].is_available():

--- a/megatron/plugin/platform/platform_npu.py
+++ b/megatron/plugin/platform/platform_npu.py
@@ -259,6 +259,144 @@ class PlatformNPU(PlatformBase):
     def is_triton_supported(self):
         pass
 
+    # Attention backend capabilities
+    def requires_flash_attn_for_dynamic_batching(self) -> bool:
+        # 910B4 has no flash-attn; dynamic batching uses the CANN paged
+        # attention op instead, so the flash-attn >= 2.7.3 gate is skipped.
+        return False
+
+    def paged_decode_attention(
+        self,
+        query,
+        key_cache,
+        block_table,
+        seqlens_k,
+        *,
+        value_cache=None,
+        num_heads=None,
+        num_kv_heads=None,
+        scale_value=None,
+    ):
+        """Decode-phase paged attention via torch_npu.atb._npu_paged_attention_v2.
+
+        Measured support boundary on 910B4 (CANN 9.0.0): blk=256 safe for
+        head_size <= 64 or == 256; blk=512 safe for head_size <= 32 or == 256;
+        blk=128 safe for head_size in [16, 256]. Outside these bounds the op
+        silently skips writes (garbage logits) or raises a device exception, so
+        fail loudly instead. MLA has no kernel on NPU and is rejected by the
+        caller (Attention.flash_decode_and_prefill).
+        """
+        import torch_npu
+
+        block_size = key_cache.shape[1]
+        head_size = query.shape[-1]
+        if block_size == 128:
+            safe = head_size <= 256
+        elif block_size == 256:
+            safe = head_size <= 64 or head_size == 256
+        elif block_size == 512:
+            safe = head_size <= 32 or head_size == 256
+        else:
+            safe = False
+        assert safe, (
+            "NPU paged attention unsupported (block_size={}, head_size={}); "
+            "see measured support matrix".format(block_size, head_size)
+        )
+
+        orig_shape = query.shape
+        flat_q = query.reshape(-1, num_heads, head_size)
+        # Align block table / lengths with the query rows: the metadata buffers
+        # are sized for the padded batch, so slice off any surplus rows.
+        num_rows = flat_q.shape[0]
+        if block_table.shape[0] != num_rows:
+            assert block_table.shape[0] >= num_rows, (
+                "NPU decode block table has fewer rows than queries"
+            )
+            block_table = block_table[:num_rows]
+        if isinstance(seqlens_k, torch.Tensor):
+            seqlens_k = seqlens_k[:num_rows]
+        context_lens = (
+            seqlens_k.tolist() if isinstance(seqlens_k, torch.Tensor) else seqlens_k
+        )
+        output = torch_npu.atb._npu_paged_attention_v2(
+            flat_q,
+            key_cache,
+            block_table,
+            context_lens,
+            value_cache=value_cache,
+            num_kv_heads=num_kv_heads,
+            num_heads=num_heads,
+            scale_value=scale_value,
+            mask_type=0,
+            out=torch.zeros_like(flat_q),
+        )
+        return output.reshape(orig_shape)
+
+    def paged_prefill_attention(
+        self,
+        q,
+        k,
+        v,
+        cu_seqlens_q,
+        cu_seqlens_k,
+        seqlens_k,
+        block_table,
+        *,
+        num_heads,
+    ):
+        """Prefill-phase paged attention via torch_npu.npu_fusion_attention.
+
+        910B4 has no flash-attn; k/v here are the paged cache tensors
+        (num_blocks, block_size, nkv, hs). Gather per-request key/value rows
+        into contiguous TND layout, then run the op in varlen (TND) mode with a
+        square SS causal mask. bf16/fp16 pass through.
+
+        Validated on 910B4 (CANN 9.0.0): hs 16/64, variable-length batches
+        (incl. zero-length rows), maxdiff < 0.008 vs a torch reference. Note the
+        varlen op requires Sq == Skv per request (pure prefill batches); mixed
+        decode+prefill batches are not supported by this path.
+        """
+        import torch_npu
+
+        block_size = k.shape[1]
+        k_chunks, v_chunks = [], []
+        for i in range(block_table.shape[0]):
+            kv_len = int(seqlens_k[i])
+            if kv_len == 0:
+                continue
+            n_blocks = (kv_len + block_size - 1) // block_size
+            block_ids = block_table[i, :n_blocks].clamp(min=0).long()
+            # Index the block dimension of the cache directly, then trim the
+            # final (partially filled) block to the request's real KV length.
+            ck = k[block_ids].reshape(-1, k.shape[2], k.shape[3])[:kv_len]
+            cv = v[block_ids].reshape(-1, v.shape[2], v.shape[3])[:kv_len]
+            k_chunks.append(ck)
+            v_chunks.append(cv)
+        if not k_chunks:
+            raise RuntimeError("NPU prefill: empty KV gather")
+        k_tnd = torch.cat(k_chunks, dim=0)
+        v_tnd = torch.cat(v_chunks, dim=0)
+        # Square causal mask: within each request, position i attends to j <= i.
+        sq = cu_seqlens_q[1:] - cu_seqlens_q[:-1]
+        max_sq = int(sq.max().item())
+        max_skv = int(seqlens_k.max().item())
+        mask = torch.triu(
+            torch.ones((max_sq, max_skv), dtype=torch.bool, device=q.device), diagonal=1
+        )
+        return torch_npu.npu_fusion_attention(
+            q,
+            k_tnd,
+            v_tnd,
+            num_heads,
+            "TND",
+            atten_mask=mask,
+            scale=q.shape[-1] ** -0.5,
+            keep_prob=1.0,
+            actual_seq_qlen=cu_seqlens_q.tolist(),
+            actual_seq_kvlen=cu_seqlens_k.tolist(),
+            sparse_mode=0,
+        )[0]
+
     # Graph operations
     def create_graph(self):
         return torch.npu.NPUGraph()

--- a/megatron/training/utils.py
+++ b/megatron/training/utils.py
@@ -37,6 +37,7 @@ from megatron.core import mpu
 from megatron.core.datasets.utils import get_blend_from_list
 from megatron.core.tensor_parallel import param_is_not_tensor_parallel_duplicate
 from megatron.core.utils import (
+    cur_platform,
     get_batch_on_this_cp_rank,
     get_data_parallel_group_if_dtensor,
     to_local_if_dtensor,
@@ -767,18 +768,16 @@ def get_nvtx_range():
         log_level: Timer log level (0=always, 1=default, 2=verbose). Default: 1
     """
     try:
-        from torch.cuda import nvtx
-
         @contextmanager
         def nvtx_range(msg, time=False, log_level=1):
             if time:
                 timers = get_timers()
                 timers(msg, log_level=log_level).start()
             try:
-                nvtx.range_push(msg)
+                cur_platform.range_push(msg)
                 yield
             finally:
-                nvtx.range_pop()
+                cur_platform.range_pop()
                 if time:
                     timers(msg, log_level=log_level).stop()
 


### PR DESCRIPTION
Fixes #164

## Summary

Enables the dynamic-batching inference path (and RL training that depends on it) on Ascend NPU (910B4, CANN 9.0.0) by converging the remaining CUDA-isms onto the flagos platform layer, plus a Triton KV-append device-assert relax. Five logical commits:

1. **platform layer** — `PlatformBase` gains `requires_flash_attn_for_dynamic_batching()` (default True) plus `paged_decode_attention()` / `paged_prefill_attention()` hooks; `PlatformNPU` implements both (CANN `_npu_paged_attention_v2` for decode, gather-to-TND + `npu_fusion_attention` for prefill) with the measured `(block_size, head_size)` support boundary asserted loudly; `PlatformManager` selects NPU before CUDA (torch_npu's `TORCH_TRANSFER_TO_NPU` shim makes `torch.cuda.is_available()` report the NPU as "cuda").
2. **attention dispatch** — `Attention.flash_decode_and_prefill` routes the prefill/decode phases through `cur_platform.paged_*_attention` on NPU; MLA decode raises `NotImplementedError` (no FlashMLA kernel); the dynamic-batching flash-attn ≥ 2.7.3 gate is skipped on platforms that don't require it.
3. **nvtx routing** — `torch.cuda.nvtx.range_push/pop` in `dynamic_engine.py`, `inference_request.py`, and `get_nvtx_range()` replaced with `cur_platform.range_push/pop`.
4. **gather_object compat** — `resharding/planner.py` probes `dist.gather_object`'s signature once and falls back to the global-rank `dst=` form when torch_npu's older override lacks `group_dst`.
5. **KV kernel device assert** — `triton_append_key_value_cache` accepts `'npu'` alongside `'cuda'` (both Triton-backed); mirror of upstream NVIDIA/Megatron-LM#6730.

## Verification

- Dynamic-batching inference E2E on Ascend 910B4 (CANN 9.0.0): KV append, paged decode/prefill all run on the CANN ops; profiling + resharding paths no longer touch CUDA-only APIs
- Paged prefill validated vs a torch reference on hs 16/64 with variable-length batches (incl. zero-length rows), maxdiff < 0.008
- Paged decode support matrix measured on-device and asserted (blk=128: head_size ≤ 256; blk=256: ≤ 64 or == 256; blk=512: ≤ 32 or == 256)
- CUDA path unchanged: `requires_flash_attn_for_dynamic_batching()` returns True by default, nvtx calls are equivalent, `group_dst` path still taken on mainline torch

## Related

- Mirrors NVIDIA/Megatron-LM#6730 (KV kernel commit)
- Complements #119 (packed-seq gate) and #116 (local-impl backends) for the full NPU RL recipe

This PR was written in part with the assistance of generative AI.
