### PR TITLE
fix(core): make jit_fuser a lazy decorator so --disable-jit-fuser takes effect

### DIFF
--- a/megatron/core/jit.py
+++ b/megatron/core/jit.py
@@ -1,11 +1,20 @@
 # Copyright (c) 2024, NVIDIA CORPORATION. All rights reserved.
 
+import functools
+
 import torch
 
 from megatron.core.utils import is_torch_min_version
 
-jit_fuser = torch.jit.script
-# nvFuser is deprecated in PyTorch JIT starting from 2.2
+# ``jit_fuser`` is a lazy decorator: it wraps the decorated function and
+# resolves the active fuser (torch.compile / torch.jit.script / no-op) at the
+# first call, not at module import time. The indirection is required because
+# ``--disable-jit-fuser`` is parsed at runtime, after the many ``@jit_fuser``
+# consumers have already been imported -- binding ``torch.compile`` eagerly at
+# import time would make that flag a no-op for the already-decorated functions.
+_fuser = torch.jit.script
+# nvFuser is deprecated in PyTorch JIT starting from 2.2, hence the upgrade to
+# torch.compile below.
 
 
 def noop_decorator(func):
@@ -13,21 +22,41 @@ def noop_decorator(func):
     return func
 
 
+def jit_fuser(func):
+    '''Decorate a function to be JIT-fused.
+
+    The active fuser is resolved at the first call and cached, so a function
+    decorated here still respects a later ``disable_jit_fuser()`` call even
+    though it was imported before training arguments were parsed.
+    '''
+    fused = None
+
+    @functools.wraps(func)
+    def inner(*args, **kwargs):
+        nonlocal fused
+        if fused is None:
+            target = _fuser
+            fused = target(func) if target is not noop_decorator else func
+        return fused(*args, **kwargs)
+
+    return inner
+
+
 def enable_jit_fuser():
     '''Enable the JIT fuser'''
-    global jit_fuser
+    global _fuser
     try:
         if is_torch_min_version("2.2.0a0"):
-            jit_fuser = torch.compile
+            _fuser = torch.compile
     except ImportError:
 
-        jit_fuser = noop_decorator
+        _fuser = noop_decorator
 
 
 def disable_jit_fuser():
     '''Disable the JIT fuser'''
-    global jit_fuser
-    jit_fuser = noop_decorator
+    global _fuser
+    _fuser = noop_decorator
 
 
 enable_jit_fuser()


### PR DESCRIPTION
Fixes #165

## What does this PR do?

Makes `jit_fuser` (`megatron/core/jit.py`) a lazy decorator so that `--disable-jit-fuser` actually takes effect on the functions decorated with `@jit_fuser`.

`enable_jit_fuser()` runs at module import time and binds the module-global `jit_fuser` to `torch.compile` (torch >= 2.2). The ~18 consumer modules apply `@jit_fuser` at their own import time, before `--disable-jit-fuser` is parsed in `set_global_variables()`. As a result the flag had no effect on the already-decorated functions, and on backends where `torch.compile` warmup fails there was no way to opt out (observed with FlagTree 3.6.0 on Hygon DCU, where the first call of a bound function crashes during warmup).

The decorator now wraps the function and resolves the active fuser (torch.compile / torch.jit.script / no-op) at the first call, then caches it. Default behavior is unchanged: torch.compile on torch >= 2.2, torch.jit.script below. On torch < 2.2 the `torch.jit.script` application moves from import time to first call, matching the already-lazy torch.compile semantics. Both `@jit_fuser` decorator usage and direct `jit_fuser(func)` calls keep working.

## Issue tracking

Fixes #121

## Checks / tests

- The lazy decorator semantics are covered by a standalone unit test (fuser resolved at first call; `disable_jit_fuser()` before the first call yields the plain function; method decoration and `functools.wraps` preserved). Verified locally.
- No behavior change for the default CUDA path: torch.compile is still applied, just resolved at first call.

This PR was written in part with the assistance of generative AI.
