### PR TITLE
fix(core): degrade gracefully when persist_layer_norm is unsupported

### DIFF
--- a/megatron/core/transformer/torch_norm.py
+++ b/megatron/core/transformer/torch_norm.py
@@ -1,4 +1,5 @@
 # Copyright (c) 2024, NVIDIA CORPORATION. All rights reserved.
+import warnings
 from typing import Protocol
 
 import torch
@@ -45,7 +46,19 @@ class WrappedTorchNorm:
             not config.layernorm_zero_centered_gamma
         ), f"zero_centered_gamma not supported by torch LayerNorm"
 
-        assert not config.persist_layer_norm, f"persist_layer_norm not supported by torch LayerNorm"
+        if config.persist_layer_norm:
+            # ``persist_layer_norm`` selects the persistent fused kernel in
+            # FusedLayerNorm; the torch-native path cannot provide it. Degrade
+            # with a warning instead of failing so that backends without
+            # Transformer Engine / apex can run with the default arguments
+            # (``persist_layer_norm`` defaults to True when
+            # ``--no-persist-layer-norm`` is not passed) -- the math is
+            # identical, only the kernel differs.
+            warnings.warn(
+                "persist_layer_norm=True is not supported by the torch-native "
+                "LayerNorm path; using the non-persistent torch implementation.",
+                UserWarning,
+            )
 
         assert not config.sequence_parallel, f"sequence parallel not supported by torch LayerNorm"
 


### PR DESCRIPTION
Fixes #166

## What does this PR do?

`config.persist_layer_norm` defaults to True (derived from `not args.no_persist_layer_norm` in `megatron/training/arguments.py`), but the torch-native norm path (`WrappedTorchNorm`) cannot provide the persistent fused kernel and previously asserted. On backends without Transformer Engine or apex the default arguments crashed at model construction (observed on Ascend 910B4 with `--transformer-impl local`):

```
AssertionError: persist_layer_norm not supported by torch LayerNorm
```

This PR replaces the assert with a warning and falls back to the non-persistent torch implementation. The persistent fused kernel is a performance optimization with identical math, so the fallback is numerically safe. The other guards in `WrappedTorchNorm.__new__` (`zero_centered_gamma`, `sequence_parallel`, `memory_efficient_layer_norm`) are unchanged — those change numerics and must keep asserting.

On backends where Transformer Engine or apex is available the `WrappedTorchNorm` path is not selected, so there is no behavior change for the CUDA path.

## Issue tracking

Fixes #123

## Checks / tests

Covered by a standalone unit test: persist_layer_norm=True warns and returns the torch implementation, persist_layer_norm=False produces no warning, RMSNorm dispatch is unaffected, and the other asserts still fire. Verified locally.

This PR was written in part with the assistance of generative AI.
