### PR TITLE
feat(platform): add Cambricon MLU platform registration

### DIFF
--- a/megatron/plugin/platform/platform_manager.py
+++ b/megatron/plugin/platform/platform_manager.py
@@ -15,7 +15,12 @@ def get_platform():
     if cur_platform is not None:
         return cur_platform
 
-    if "cuda" in PLATFORMS.keys() and PLATFORMS["cuda"].is_available():
+    if "mlu" in PLATFORMS.keys() and PLATFORMS["mlu"].is_available():
+        # Checked before CUDA: the gpu_migration bridge makes the CUDA surface
+        # (and thus PLATFORMS["cuda"].is_available()) report True on MLU hosts.
+        cur_platform = PLATFORMS["mlu"]
+        print(f"Megatron-LM-FL Platform: mlu Selected")
+    elif "cuda" in PLATFORMS.keys() and PLATFORMS["cuda"].is_available():
         cur_platform = PLATFORMS["cuda"]
         print(f"Megatron-LM-FL Platform: cuda Selected")
     elif "musa" in PLATFORMS.keys() and PLATFORMS["musa"].is_available():

--- a/megatron/plugin/platform/platform_mlu.py
+++ b/megatron/plugin/platform/platform_mlu.py
@@ -1,0 +1,68 @@
+# Copyright (c) 2026, BAAI. All rights reserved.
+#
+# See LICENSE for license information.
+"""Cambricon MLU Platform for Megatron-LM-FL.
+
+Inherits from PlatformCUDA since torch_mlu's ``gpu_migration`` module aliases
+the ``torch.cuda.*`` surface (is_available, device_count, default_generators,
+Stream, Event, RNG, memory, ...) onto MLU devices — the same bridge a
+standalone cambricon shim used to provide. Importing the bridge at module load
+time makes every inherited PlatformCUDA method work unchanged on MLU, and keeps
+``megatron/training/initialize.py``'s ``assert torch.cuda.is_available()``
+satisfied.
+
+``is_available()`` also forces device initialization so that
+``torch.mlu.default_generators`` is non-empty before any tensor-parallel RNG
+path indexes into it (``megatron/core/tensor_parallel/random.py`` uses
+``cur_platform.default_generators[idx]``).
+
+Because the bridge makes ``torch.cuda.is_available()`` report True on MLU hosts,
+``platform_manager`` must prefer this platform over the generic CUDA one
+(which would otherwise be picked first).
+"""
+
+import torch
+
+try:
+    import torch_mlu.utils.gpu_migration  # noqa: F401  (aliases torch.cuda.* onto MLU)
+except ImportError:
+    pass
+
+from .platform_cuda import PlatformCUDA
+
+
+class PlatformMLU(PlatformCUDA):
+
+    def __init__(self):
+        super().__init__()
+        self._name = "mlu"
+
+    def is_available(self):
+        """Detect Cambricon MLU.
+
+        Forces device init (idempotent) so ``torch.mlu.default_generators`` is
+        populated before tensor-parallel RNG paths use it.
+        """
+        try:
+            if torch.mlu.device_count() > 0:
+                if not torch.mlu.is_initialized():
+                    _ = torch.ones(1, device="mlu:0")
+                    torch.mlu.synchronize()
+                return True
+            return False
+        except Exception:
+            return False
+
+    def device_name(self, device_index=None):
+        if device_index is None:
+            return "mlu"
+        return f"mlu:{device_index}"
+
+    def current_device_name(self):
+        return f"mlu:{torch.mlu.current_device()}"
+
+    def on_accelerator(self, tensor):
+        return str(tensor.device).startswith("mlu:")
+
+    def visible_devices_envs(self):
+        return ["MLU_VISIBLE_DEVICES"]

--- a/megatron/plugin/platform/platform_register.py
+++ b/megatron/plugin/platform/platform_register.py
@@ -17,13 +17,24 @@ def register_platforms() -> None:
         PLATFORMS["cpu"] = platform_cpu # use lower keys: cpu
         print(f"Megatron-LM-FL Platform: cpu Registered")
 
+    # Register MLU Platform
+    # NOTE: registered before CUDA. The gpu_migration bridge aliases
+    # torch.cuda.* onto MLU, so PlatformCUDA.is_available() also reports True
+    # on MLU hosts; registering first makes the manager's selection chain pick
+    # mlu over the generic cuda platform.
+    from .platform_mlu import PlatformMLU
+    platform_mlu = PlatformMLU()
+    if platform_mlu.is_available():
+        PLATFORMS["mlu"] = platform_mlu
+        print(f"Megatron-LM-FL Platform: mlu Registered")
+
     # Register CUDA Platform
     from .platform_cuda import PlatformCUDA
     platform_cuda = PlatformCUDA()
     if platform_cuda.is_available():
         PLATFORMS["cuda"] = platform_cuda # use lower keys: cuda
         print(f"Megatron-LM-FL Platform: cuda Registered")
-    
+
     # Register MUSA Platform
     from .platform_musa import PlatformMUSA
     platform_musa = PlatformMUSA()

--- a/megatron/plugin/tests/test_platform.py
+++ b/megatron/plugin/tests/test_platform.py
@@ -146,6 +146,24 @@ class TestPlatformManager(unittest.TestCase):
         platform = platform_manager.get_platform()
         self.assertEqual(platform._name, "cuda")
 
+    def test_get_platform_prefers_mlu_over_cuda(self):
+        """When both mlu and cuda are available, get_platform should prefer mlu.
+
+        The gpu_migration bridge aliases the cuda surface onto MLU, so
+        PlatformCUDA.is_available() also reports True on MLU hosts; mlu must be
+        selected first or the generic cuda platform would win.
+        """
+        mock_mlu = _create_mock_platform("mlu")
+        mock_mlu.is_available = lambda: True
+        mock_cuda = _create_mock_platform("cuda")
+        mock_cuda.is_available = lambda: True
+        platform_register.PLATFORMS["mlu"] = mock_mlu
+        platform_register.PLATFORMS["cuda"] = mock_cuda
+
+        _reset_platform_manager()
+        platform = platform_manager.get_platform()
+        self.assertEqual(platform._name, "mlu")
+
     def test_get_platform_falls_back_to_cpu(self):
         """When only cpu is available, get_platform should return cpu."""
         # Remove all non-cpu platforms
@@ -165,7 +183,7 @@ class TestPlatformManager(unittest.TestCase):
             platform_manager.get_platform()
 
     def test_platform_selection_priority(self):
-        """Platforms are selected in priority order: cuda > musa > txda > npu > enflame > cpu."""
+        """Platforms are selected in priority order: mlu > cuda > musa > txda > npu > enflame > cpu."""
         # Register mock platforms for musa and cpu only
         platform_register.PLATFORMS.clear()
         mock_musa = _create_mock_platform("musa")
@@ -702,6 +720,53 @@ class TestMockedVendorPlatforms(unittest.TestCase):
             platform.replay_graph(graph)
             self.assertTrue(graph.replayed)
             self.assertEqual(platform.visible_devices_envs(), ["ASCEND_RT_VISIBLE_DEVICES"])
+
+    def test_mlu_platform_contract_with_mock_backend(self):
+        """MLU wraps the cuda surface (via torch_mlu's gpu_migration bridge)."""
+        module = __import__("megatron.plugin.platform.platform_mlu", fromlist=["PlatformMLU"])
+        cuda_module = __import__("megatron.plugin.platform.platform_cuda", fromlist=["PlatformCUDA"])
+        accelerator = _FakeAccelerator()
+        accelerator.is_initialized = lambda: False  # force the init branch in is_available
+        fake_torch = _fake_torch_for_platform("mlu", accelerator)
+        fake_torch.ones = lambda *args, **kwargs: _FakeTensor("mlu:0")
+        fake_torch.cuda = accelerator  # bridge: the cuda surface aliases mlu
+        with patch.dict(sys.modules, {"torch": fake_torch}), patch.object(
+            module, "torch", fake_torch
+        ), patch.object(cuda_module, "torch", fake_torch):
+            platform = module.PlatformMLU()
+            self.assertTrue(platform.is_available())
+            self.assertEqual(platform._name, "mlu")
+            self.assertEqual(platform.device_name(), "mlu")
+            self.assertEqual(platform.device_name(2), "mlu:2")
+            self.assertEqual(platform.current_device_name(), "mlu:1")
+            self.assertEqual(platform.device_count(), 2)
+            self.assertEqual(platform.default_generators, ("gen0",))
+            self.assertTrue(platform.on_accelerator(_FakeTensor("mlu:0")))
+            self.assertFalse(platform.on_accelerator(_FakeTensor("cpu")))
+            self.assertEqual(platform.visible_devices_envs(), ["MLU_VISIBLE_DEVICES"])
+
+    def test_mlu_is_available_false_without_devices(self):
+        """is_available() returns False when no MLU device is visible."""
+        module = __import__("megatron.plugin.platform.platform_mlu", fromlist=["PlatformMLU"])
+        accelerator = _FakeAccelerator()
+        accelerator.is_initialized = lambda: False
+        accelerator.device_count = lambda: 0
+        fake_torch = _fake_torch_for_platform("mlu", accelerator)
+        with patch.dict(sys.modules, {"torch": fake_torch}), patch.object(
+            module, "torch", fake_torch
+        ):
+            platform = module.PlatformMLU()
+            self.assertFalse(platform.is_available())
+
+    def test_mlu_is_available_false_without_torch_mlu(self):
+        """Without the torch_mlu surface, is_available() returns False, not raises."""
+        module = __import__("megatron.plugin.platform.platform_mlu", fromlist=["PlatformMLU"])
+        fake_torch = types.SimpleNamespace()  # no .mlu attribute
+        with patch.dict(sys.modules, {"torch": fake_torch}), patch.object(
+            module, "torch", fake_torch
+        ):
+            platform = module.PlatformMLU()
+            self.assertFalse(platform.is_available())
 
 
 # ---------- Auto-discovery: Interface Contract Tests for ALL Registered Platforms ----------


### PR DESCRIPTION
Fixes #167

## What

Add Cambricon MLU platform registration so MLU hosts are selected explicitly instead of falling through to the CPU platform, which broke the tensor-parallel RNG path (`cur_platform.default_generators[idx]` — the CPU platform exposes a single generator).

## Why

`PlatformMLU` inherits `PlatformCUDA` because `torch_mlu.utils.gpu_migration` aliases the `torch.cuda.*` surface onto MLU, which also keeps the `assert torch.cuda.is_available()` in `initialize.py` satisfied. `is_available()` forces device init so `torch.mlu.default_generators` is populated before RNG paths index into it.

MLU is registered/selected **before** CUDA: the bridge makes `PlatformCUDA.is_available()` report True on MLU hosts, so the generic CUDA platform must not win.

Verified end-to-end on MLU590 (neuware 4.4.3 / 4.7.2): `mlu Selected`, post_training smoke exits 0 with no shim. 4 new tests cover selection precedence, the platform contract, and `is_available` False paths.

---

This PR was written in part with the assistance of generative AI.
