### PR TITLE
fix(training): platformize raw torch.cuda calls for non-CUDA backends

### DIFF
--- a/megatron/core/jit.py
+++ b/megatron/core/jit.py
@@ -3,6 +3,7 @@
 import torch
 
 from megatron.core.utils import is_torch_min_version
+from megatron.plugin.platform import get_platform
 
 jit_fuser = torch.jit.script
 # nvFuser is deprecated in PyTorch JIT starting from 2.2
@@ -30,4 +31,9 @@ def disable_jit_fuser():
     jit_fuser = noop_decorator
 
 
+# torch.compile jit fusion is only available on CUDA. On non-CUDA backends
+# (e.g. MUSA) inductor autotuning requires a Triton backend that is not
+# shipped, so fall back to the no-op decorator.
 enable_jit_fuser()
+if get_platform().device_name() != "cuda":
+    disable_jit_fuser()

--- a/megatron/core/optimizer/clip_grads.py
+++ b/megatron/core/optimizer/clip_grads.py
@@ -112,7 +112,7 @@ def get_grad_norm_fp32(
     # Calculate norm.
     if norm_type == inf:
         total_norm = max(grad.abs().max() for grad in grads_for_norm)
-        total_norm_cuda = torch.tensor([float(total_norm)], dtype=torch.float, device='cuda')
+        total_norm_cuda = torch.tensor([float(total_norm)], dtype=torch.float, device=cur_platform.device_name())
         # Take max across all data-parallel GPUs if using FSDP and then all model-parallel GPUs.
         if data_parallel_group:
             torch.distributed.all_reduce(
@@ -125,7 +125,7 @@ def get_grad_norm_fp32(
 
     else:
         if norm_type == 2.0:
-            dummy_overflow_buf = torch.zeros(1, dtype=torch.int, device='cuda')
+            dummy_overflow_buf = torch.zeros(1, dtype=torch.int, device=cur_platform.device_name())
             # Use apex's multi-tensor applier for efficiency reasons.
             # Multi-tensor applier takes a function and a list of list
             # and performs the operation on that list all in one kernel.
@@ -137,7 +137,7 @@ def get_grad_norm_fp32(
                     False,  # no per-parameter norm
                 )
             else:
-                grad_norm = torch.zeros(1, dtype=torch.float, device='cuda')
+                grad_norm = torch.zeros(1, dtype=torch.float, device=cur_platform.device_name())
             # Since we will be summing across data parallel groups,
             # we need the pow(norm-type).
             total_norm = grad_norm**norm_type
@@ -206,7 +206,7 @@ def clip_grad_by_total_norm_fp32(
 
     # Scale.
     clip_coeff = max_norm / (total_norm + 1.0e-6)
-    dummy_overflow_buf = torch.zeros(1, dtype=torch.int, device='cuda')
+    dummy_overflow_buf = torch.zeros(1, dtype=torch.int, device=cur_platform.device_name())
     if isinstance(clip_coeff, torch.Tensor):
         clip_coeff.clamp_max_(1.0)
         assert (

--- a/megatron/core/rerun_state_machine.py
+++ b/megatron/core/rerun_state_machine.py
@@ -267,11 +267,11 @@ class RerunStateMachine:
         For multiple inputs, returns a tuple.
         """
         if isinstance(value, list):
-            val_tensor: torch.Tensor = torch.tensor(value, dtype=torch.int32, device='cuda')
+            val_tensor: torch.Tensor = torch.tensor(value, dtype=torch.int32, device=cur_platform.device_name())
             torch.distributed.all_reduce(val_tensor)
             return tuple([x > 0 for x in val_tensor.tolist()])
         else:
-            val_tensor: torch.Tensor = torch.tensor([value], dtype=torch.int32, device='cuda')
+            val_tensor: torch.Tensor = torch.tensor([value], dtype=torch.int32, device=cur_platform.device_name())
             torch.distributed.all_reduce(val_tensor)
             return val_tensor.item() > 0
 

--- a/megatron/core/utils.py
+++ b/megatron/core/utils.py
@@ -1208,7 +1208,7 @@ def local_multi_tensor_l2_norm(chunk_size, noop_flag, tensor_lists, per_tensor, 
     """
     l2 = [[(torch.norm(tensor)) for tensor in tensor_list] for tensor_list in tensor_lists]
     l2_reduced = torch.norm(torch.tensor(l2))
-    l2_cuda = torch.tensor([float(l2_reduced)], dtype=torch.float, device="cuda")
+    l2_cuda = torch.tensor([float(l2_reduced)], dtype=torch.float, device=cur_platform.device_name())
     return l2_cuda, None
 
 

--- a/megatron/training/initialize.py
+++ b/megatron/training/initialize.py
@@ -24,6 +24,7 @@ from megatron.core.rerun_state_machine import (
 )
 from megatron.core.transformer.custom_layers.batch_invariant_kernels import enable_batch_invariant_mode
 from megatron.core.utils import get_te_version, is_te_min_version, is_torch_min_version
+from megatron.plugin.platform import get_platform
 from megatron.training import get_adlr_autoresume, get_args, get_tensorboard_writer
 from megatron.training.utils import print_rank_0, warn_rank_0
 from megatron.training import inprocess_restart
@@ -57,8 +58,8 @@ def initialize_megatron(
     (optionally, only when args.lazy_mpu_init == True)
     """
     if not allow_no_cuda:
-        # Make sure cuda is available.
-        assert torch.cuda.is_available(), "Megatron requires CUDA."
+        # Make sure an accelerator (CUDA, MUSA, NPU, etc.) is available.
+        assert get_platform().device_name() != 'cpu', "Megatron requires an accelerator."
 
     # Parse arguments
     if parsed_args is None:
@@ -141,7 +142,7 @@ def initialize_megatron(
         if args.num_experts is not None:
             from megatron.core.transformer.moe.router import MoEAuxLossAutoScaler
 
-            MoEAuxLossAutoScaler.set_loss_scale(torch.ones(1, device=torch.cuda.current_device()))
+            MoEAuxLossAutoScaler.set_loss_scale(torch.ones(1, device=get_platform().device_name()))
 
     if skip_mpu_initialization:
         return None
@@ -274,7 +275,7 @@ def _initialize_distributed(get_embedding_ranks, get_position_embedding_ranks, s
     """Initialize torch.distributed and core model parallel."""
     args = get_args()
 
-    device_count = torch.cuda.device_count()
+    device_count = get_platform().device_count()
     if torch.distributed.is_initialized():
 
         print_rank_0("torch distributed is already initialized, skipping initialization ...")
@@ -286,14 +287,14 @@ def _initialize_distributed(get_embedding_ranks, get_position_embedding_ranks, s
         print_rank_0("> initializing torch distributed ...")
         # Manually set the device ids.
         if device_count > 0:
-            torch.cuda.set_device(args.local_rank)
-            device_id = torch.device(f'cuda:{args.local_rank}')
+            get_platform().set_device(args.local_rank)
+            device_id = get_platform().device(args.local_rank)
         else:
             device_id = None
 
         # Set to non-default stream for cudagraph capturing.
         if args.cuda_graph_impl == "transformer_engine":
-            torch.cuda.set_stream(torch.cuda.Stream())
+            get_platform().set_stream(get_platform().Stream())
 
         # Set flight recorder env vars if specified.
         # Priority: pre-existing environment variable > MLM argument.
@@ -420,7 +421,7 @@ def _set_random_seed(
         random.seed(seed)
         np.random.seed(seed)
         torch.manual_seed(seed)
-        if torch.cuda.device_count() > 0:
+        if get_platform().device_count() > 0:
             tensor_parallel.model_parallel_cuda_manual_seed(
                 seed, te_rng_tracker, inference_rng_tracker, use_cudagraphable_rng
             )
@@ -470,10 +471,11 @@ def _warmup_jit_function():
         dtype = torch.float16
     else:
         dtype = torch.float32
+    device_name = get_platform().device_name()
 
     # Warmup fused bias+gelu
     bias = torch.rand(
-        args.ffn_hidden_size // args.tensor_model_parallel_size, dtype=dtype, device="cuda"
+        args.ffn_hidden_size // args.tensor_model_parallel_size, dtype=dtype, device=device_name
     )
     input = torch.rand(
         (
@@ -482,7 +484,7 @@ def _warmup_jit_function():
             args.ffn_hidden_size // args.tensor_model_parallel_size,
         ),
         dtype=dtype,
-        device="cuda",
+        device=device_name,
     )
     # Warmup JIT fusions with the input grad_enable state of both forward
     # prop and recomputation
@@ -503,14 +505,14 @@ def _warmup_jit_function():
     input = torch.rand(
         (seq_length // args.context_parallel_size, args.micro_batch_size, args.hidden_size),
         dtype=dtype,
-        device="cuda",
+        device=device_name,
     )
     residual = torch.rand(
         (seq_length // args.context_parallel_size, args.micro_batch_size, args.hidden_size),
         dtype=dtype,
-        device="cuda",
+        device=device_name,
     )
-    bias = torch.rand((args.hidden_size), dtype=dtype, device="cuda").expand_as(residual)
+    bias = torch.rand((args.hidden_size), dtype=dtype, device=device_name).expand_as(residual)
     dropout_rate = 0.1
     # Warmup JIT fusions with the input grad_enable state of both forward
     # prop and recomputation
@@ -521,7 +523,7 @@ def _warmup_jit_function():
         for _ in range(5):
             output = bias_dropout_add_fused_train([input, bias], residual, dropout_rate)
     del bias, input, residual, output
-    torch.cuda.empty_cache()
+    get_platform().empty_cache()
 
 
 def setup_logging() -> None:

--- a/megatron/training/training.py
+++ b/megatron/training/training.py
@@ -203,6 +203,7 @@ from megatron.core.parallel_state import (
 from megatron.core.inference.symmetric_memory import SymmetricMemoryManager
 from megatron.core.inference.unified_memory import create_unified_mempool
 from megatron.core.resharding.refit import swap_model_weights
+from megatron.plugin.platform import get_platform  # isort: skip
 
 try:
     from torch_memory_saver import torch_memory_saver
@@ -1039,13 +1040,13 @@ def pretrain(
     # Initialize program_start_global with a fallback value in case set_startup_timestamps() wasn't called
     program_start_global = _TRAIN_START_TIME
     if _STARTUP_TIMESTAMPS['program_start'] is not None:
-        program_start_global = torch.tensor([_STARTUP_TIMESTAMPS['program_start']], dtype=torch.double, device='cuda')
+        program_start_global = torch.tensor([_STARTUP_TIMESTAMPS['program_start']], dtype=torch.double, device=get_platform().device_name())
         torch.distributed.all_reduce(program_start_global, op=torch.distributed.ReduceOp.MIN)
         program_start_global = program_start_global.item()
     set_startup_timestamps(program_start=program_start_global)
 
     global _LEGACY_TRAIN_START_TIME
-    start_time_tensor = torch.tensor([_LEGACY_TRAIN_START_TIME], dtype=torch.double, device='cuda')
+    start_time_tensor = torch.tensor([_LEGACY_TRAIN_START_TIME], dtype=torch.double, device=get_platform().device_name())
     torch.distributed.all_reduce(start_time_tensor, op=torch.distributed.ReduceOp.MIN)
     _LEGACY_TRAIN_START_TIME = start_time_tensor.item()
 
@@ -1209,7 +1210,7 @@ def pretrain(
                     tag="rl_inference_model", enable_cpu_backup=True
                 )
             elif uvm_mempool is not None:
-                model_alloc_ctx = torch.cuda.use_mem_pool(uvm_mempool)
+                model_alloc_ctx = get_platform().use_mem_pool(uvm_mempool)
             else:
                 model_alloc_ctx = nullcontext()
 
@@ -1521,7 +1522,7 @@ def get_model(model_provider_func, model_type=ModelType.encoder_or_decoder, wrap
         and not args.init_model_with_meta_device
     ):
         for model_module in model:
-            model_module.cuda(torch.cuda.current_device())
+            model_module.to(get_platform().device(get_platform().current_device()))
 
     # Fp16 conversion.
     if args.fp16 or args.bf16:
@@ -1530,7 +1531,7 @@ def get_model(model_provider_func, model_type=ModelType.encoder_or_decoder, wrap
 
     # Materialize tensors on meta device (GPU allocation) if not using FSDP2 and not using Megatron FSDP.
     if args.init_model_with_meta_device and not args.use_torch_fsdp2 and not args.use_megatron_fsdp:
-        model = [to_empty_if_meta_device(model_module, device=torch.device("cuda")) for model_module in model]
+        model = [to_empty_if_meta_device(model_module, device=get_platform().device()) for model_module in model]
 
     # Before TE2.x: The model_module.bfloat16()/model_module.half() above will call the inplace
     #               copy of TE's Float8Tensor, which will write an unwanted value (amax calculated
@@ -1598,11 +1599,11 @@ def get_model(model_provider_func, model_type=ModelType.encoder_or_decoder, wrap
 
         # Setup stream for ddp initialization. The side-stream may be necessary for cuda graph
         #  capture support with DDP, but we sync it with the current stream to avoid races.
-        ddp_stream = torch.cuda.Stream()
+        ddp_stream = get_platform().Stream()
         # Wait for the default stream to complete before starting ddp_stream
-        ddp_stream.wait_stream(torch.cuda.current_stream())
+        ddp_stream.wait_stream(get_platform().current_stream())
         # Make ddp_stream start after whatever the default stream already queued
-        with torch.cuda.stream(ddp_stream):
+        with get_platform().stream(ddp_stream):
             model = [
                 DP(
                     config=config,
@@ -1616,7 +1617,7 @@ def get_model(model_provider_func, model_type=ModelType.encoder_or_decoder, wrap
             ]
         # End of setup_stream
         # Critical: ensure side-stream work completes before touching params on default stream
-        torch.cuda.current_stream().wait_stream(ddp_stream)
+        get_platform().current_stream().wait_stream(ddp_stream)
 
         # Broadcast params from data parallel src rank to other data parallel ranks.
         if args.data_parallel_random_init:
@@ -1984,7 +1985,7 @@ def train_step(forward_step_func, data_iterator, model, optimizer, opt_param_sch
 
     # Empty unused memory.
     if args.empty_unused_memory_level >= 1:
-        torch.cuda.empty_cache()
+        get_platform().empty_cache()
 
     # Vision gradients.
     if args.vision_pretraining and args.vision_pretraining_type == "dino":
@@ -2028,7 +2029,7 @@ def train_step(forward_step_func, data_iterator, model, optimizer, opt_param_sch
 
     # Empty unused memory.
     if args.empty_unused_memory_level >= 2:
-        torch.cuda.empty_cache()
+        get_platform().empty_cache()
 
     if mpu.is_pipeline_last_stage(ignore_virtual=True):
         # Average loss across microbatches.
@@ -2107,7 +2108,7 @@ def training_log(
     for key in loss_dict:
         if not skipped_iter:
             total_loss_dict[key] = (
-                total_loss_dict.get(key, torch.tensor([0.0], dtype=torch.float, device='cuda'))
+                total_loss_dict.get(key, torch.tensor([0.0], dtype=torch.float, device=get_platform().device_name()))
                 + loss_dict[key]
             )
         else:
@@ -2224,7 +2225,7 @@ def training_log(
             if wandb_writer:
                 wandb_writer.log({'grpo_collection_iteration': grpo_collection_iteration}, iteration)
         if args.log_memory_to_tensorboard:
-            mem_stats = torch.cuda.memory_stats()
+            mem_stats = get_platform().memory_stats()
             writer.add_scalar(
                 "mem-reserved-bytes", mem_stats["reserved_bytes.all.current"], iteration
             )
@@ -2300,7 +2301,11 @@ def training_log(
 
     # Dump memory snapshot and print metrics to stdout.
     if iteration % args.log_interval == 0 or is_first_iteration:
-        if args.record_memory_history and (is_last_rank() or torch.distributed.get_backend() == 'fake'):
+        if (
+            args.record_memory_history
+            and get_platform().device_name() == 'cuda'
+            and (is_last_rank() or torch.distributed.get_backend() == 'fake')
+        ):
             snapshot = torch.cuda.memory._snapshot()
             from pickle import dump
 
@@ -2364,7 +2369,7 @@ def training_log(
                 if avg >= 0.0:
                     log_string += ' {}: {:.6E} |'.format(key, avg)
                 if should_reset:
-                    total_loss_dict[key] = torch.tensor([0.0], dtype=torch.float, device='cuda')
+                    total_loss_dict[key] = torch.tensor([0.0], dtype=torch.float, device=get_platform().device_name())
         log_string += f' loss scale: {loss_scale:.1f} |'
         if grad_norm is not None:
             log_string += f' grad norm: {grad_norm:.3f} |'
@@ -2495,7 +2500,7 @@ def save_checkpoint_and_time(
     for model_chunk in model:
         if hasattr(model_chunk, 'free_overlap_buffers'):
             model_chunk.free_overlap_buffers()
-    torch.cuda.empty_cache()
+    get_platform().empty_cache()
 
     global num_checkpoints_memory_reported, MAX_NUM_CHECKPOINTS_MEMORY_REPORTED
     should_report_memory = num_checkpoints_memory_reported < MAX_NUM_CHECKPOINTS_MEMORY_REPORTED
@@ -2558,7 +2563,7 @@ def post_training_step_callbacks(
 
     # Bring CPU and GPU back in sync if on right iteration.
     if args.train_sync_interval and iteration % args.train_sync_interval == 0:
-        torch.cuda.synchronize()
+        get_platform().synchronize()
 
     # Straggler detector.
     if iteration % args.log_interval == 0 and args.log_straggler:
@@ -2598,7 +2603,8 @@ def post_training_step_callbacks(
             if prof.execution_trace_observer is not None:
                 prof.execution_trace_observer.unregister_callback()
         else:
-            torch.cuda.check_error(torch.cuda.cudart().cudaProfilerStop())
+            if get_platform().device_name() == 'cuda':
+                torch.cuda.check_error(torch.cuda.cudart().cudaProfilerStop())
             if nsys_nvtx_context is not None:
                 nsys_nvtx_context.__exit__(None, None, None)
 
@@ -2679,7 +2685,7 @@ def checkpoint_and_decide_exit(
     if args.exit_duration_in_mins:
         train_time = (time.time() - _TRAIN_START_TIME) / 60.0
         done_cuda = torch.tensor(
-            [train_time > args.exit_duration_in_mins], dtype=torch.int, device='cuda'
+            [train_time > args.exit_duration_in_mins], dtype=torch.int, device=get_platform().device_name()
         )
         torch.distributed.all_reduce(done_cuda, op=torch.distributed.ReduceOp.MAX)
         done = done_cuda.item()
@@ -3018,7 +3024,8 @@ def train(
             if args.use_pytorch_profiler:
                 prof.step()
             elif iteration == args.profile_step_start:
-                torch.cuda.check_error(torch.cuda.cudart().cudaProfilerStart())
+                if get_platform().device_name() == 'cuda':
+                    torch.cuda.check_error(torch.cuda.cudart().cudaProfilerStart())
                 nsys_nvtx_context = torch.autograd.profiler.emit_nvtx(record_shapes=True)
                 nsys_nvtx_context.__enter__()
 
@@ -3101,7 +3108,7 @@ def train(
         if args.perform_rl_step:
             if optimizer is None:
                 # Release stale CUDA cached memory before inference.
-                torch.cuda.empty_cache()
+                get_platform().empty_cache()
             with torch.no_grad():
                 train_data_iterator = rl_utils.get_grpo_data_iterator(
                     model, inference_model, optimizer, iteration, ref_state_dict,
@@ -3470,13 +3477,13 @@ def evaluate(
 
             # Empty unused memory
             if args.empty_unused_memory_level >= 1:
-                torch.cuda.empty_cache()
+                get_platform().empty_cache()
 
             if mpu.is_pipeline_last_stage(ignore_virtual=True):
                 # Reduce across processes.
                 for key in loss_dicts[0].keys():
                     if key not in total_loss_dict:
-                        total_loss_dict[key] = torch.tensor([0.0, 0.0], dtype=torch.float, device='cuda')
+                        total_loss_dict[key] = torch.tensor([0.0, 0.0], dtype=torch.float, device=get_platform().device_name())
                     val = [x[key].view(-1) for x in loss_dicts]
 
                     if val[0].numel() == 2:
@@ -3513,7 +3520,7 @@ def evaluate(
             if args.exit_duration_in_mins:
                 train_time = (time.time() - _TRAIN_START_TIME) / 60.0
                 done_cuda = torch.tensor(
-                    [train_time > args.exit_duration_in_mins], dtype=torch.int, device='cuda'
+                    [train_time > args.exit_duration_in_mins], dtype=torch.int, device=get_platform().device_name()
                 )
                 torch.distributed.all_reduce(done_cuda, op=torch.distributed.ReduceOp.MAX)
                 done = done_cuda.item()
@@ -3587,9 +3594,9 @@ def evaluate_and_print_results(
 
         # with full validation we need to distribute eval_iters to all ranks
         if mpu.get_tensor_model_parallel_rank() == 0:
-            eval_iters = torch.tensor(args.eval_iters, dtype=torch.long, device='cuda')
+            eval_iters = torch.tensor(args.eval_iters, dtype=torch.long, device=get_platform().device_name())
         else:
-            eval_iters = torch.tensor([0] * len(eval_iters), dtype=torch.long, device='cuda')
+            eval_iters = torch.tensor([0] * len(eval_iters), dtype=torch.long, device=get_platform().device_name())
         torch.distributed.broadcast(eval_iters, 0)
         eval_iters = eval_iters.tolist()
         args.eval_iters = eval_iters[0] if not args.multiple_validation_sets else eval_iters
@@ -3768,10 +3775,10 @@ def build_train_valid_test_data_loaders(build_train_valid_test_datasets_provider
             do_test = test_dataloader is not None and (args.full_validation or args.eval_iters > 0)
 
         flags = torch.tensor(
-            [int(do_train), int(do_valid), int(do_test)], dtype=torch.long, device='cuda'
+            [int(do_train), int(do_valid), int(do_test)], dtype=torch.long, device=get_platform().device_name()
         )
     else:
-        flags = torch.tensor([0, 0, 0], dtype=torch.long, device='cuda')
+        flags = torch.tensor([0, 0, 0], dtype=torch.long, device=get_platform().device_name())
 
     torch.distributed.broadcast(flags, 0)
 

--- a/megatron/training/utils.py
+++ b/megatron/training/utils.py
@@ -45,6 +45,10 @@ from megatron.core.utils import (
 
 from megatron.core.transformer.module import param_is_not_shared
 
+from megatron.plugin.platform import get_platform  # isort: skip
+
+cur_platform = get_platform()
+
 
 def calc_params_l2_norm(model, force_create_fp32_copy=False):
     """Calculate l2 norm of parameters"""
@@ -115,14 +119,14 @@ def calc_params_l2_norm(model, force_create_fp32_copy=False):
                         params_data.append(param.data)
 
     # Calculate norm.
-    dummy_overflow_buf = torch.tensor([0], dtype=torch.int, device='cuda')
+    dummy_overflow_buf = torch.tensor([0], dtype=torch.int, device=cur_platform.device_name())
     if len(params_data) > 0:
         norm, _ = multi_tensor_applier(
             multi_tensor_l2norm, dummy_overflow_buf, [params_data], False  # no per-parameter norm.
         )
         norm_2 = norm * norm
     else:
-        norm_2 = torch.zeros((1,), dtype=torch.float32, device='cuda')
+        norm_2 = torch.zeros((1,), dtype=torch.float32, device=cur_platform.device_name())
 
     if data_parallel_group is not None:
         torch.distributed.all_reduce(
@@ -133,7 +137,7 @@ def calc_params_l2_norm(model, force_create_fp32_copy=False):
     # accumulated across the DP group since the main parameters are sharded because
     # of distributed optimizer.
     if len(sharded_params_data) > 0:
-        dummy_overflow_buf = torch.tensor([0], dtype=torch.int, device='cuda')
+        dummy_overflow_buf = torch.tensor([0], dtype=torch.int, device=cur_platform.device_name())
         sharded_norm, _ = multi_tensor_applier(
             multi_tensor_l2norm,
             dummy_overflow_buf,
@@ -142,7 +146,7 @@ def calc_params_l2_norm(model, force_create_fp32_copy=False):
         )
         sharded_norm_2 = sharded_norm * sharded_norm
     else:
-        sharded_norm_2 = torch.zeros((1,), dtype=torch.float32, device='cuda')
+        sharded_norm_2 = torch.zeros((1,), dtype=torch.float32, device=cur_platform.device_name())
     # Sum over all DP groups, including CP since distributed optimizer state is
     # sharded jointly over DP+CP.
     torch.distributed.all_reduce(
@@ -201,12 +205,12 @@ def calc_dtensor_params_l2_norm(params):
     for param in params:
         params_data[param._spec].append(param._local_tensor)
 
-    total_norm_2 = torch.zeros((1,), dtype=torch.float32, device='cuda')
-    dummy_overflow_buf = torch.zeros((1,), dtype=torch.int, device='cuda')
+    total_norm_2 = torch.zeros((1,), dtype=torch.float32, device=cur_platform.device_name())
+    dummy_overflow_buf = torch.zeros((1,), dtype=torch.int, device=cur_platform.device_name())
     for dtensor_spec, local_tensors in params_data.items():
         local_tensors = [t for t in local_tensors if t.numel() > 0]
         if len(local_tensors) == 0:
-            norm = torch.zeros((1,), dtype=torch.float32, device='cuda')
+            norm = torch.zeros((1,), dtype=torch.float32, device=cur_platform.device_name())
         else:
             norm, _ = multi_tensor_applier(
                 multi_tensor_l2norm, dummy_overflow_buf, [local_tensors], False  # no per-parameter norm.
@@ -251,7 +255,7 @@ def reduce_max_stat_across_model_parallel_group(stat: float) -> float | None:
     """
     if stat is None:
         stat = -1.0
-    stat = torch.tensor([stat], dtype=torch.float32, device=torch.cuda.current_device())
+    stat = torch.tensor([stat], dtype=torch.float32, device=cur_platform.current_device())
     torch.distributed.all_reduce(
         stat, op=torch.distributed.ReduceOp.MAX, group=mpu.get_model_parallel_group()
     )
@@ -270,7 +274,7 @@ def logical_and_across_model_parallel_group(input: bool) -> bool:
         input = 1
     else:
         input = 0
-    input = torch.tensor([input], dtype=torch.int, device=torch.cuda.current_device())
+    input = torch.tensor([input], dtype=torch.int, device=cur_platform.current_device())
     torch.distributed.all_reduce(
         input, op=torch.distributed.ReduceOp.MIN, group=mpu.get_model_parallel_group()
     )
@@ -282,11 +286,11 @@ def report_memory(name):
     args = get_args()
     mega_bytes = 1024.0 * 1024.0
     string = name + ' memory (MB)'
-    string += f" | allocated: {torch.cuda.memory_allocated() / mega_bytes:.2f}"
-    string += f" | max allocated: {torch.cuda.max_memory_allocated() / mega_bytes:.2f}"
-    string += f" | reserved: {torch.cuda.memory_reserved() / mega_bytes:.2f}"
-    string += f" | max reserved: {torch.cuda.max_memory_reserved() / mega_bytes:.2f}"
-    if args.log_device_memory_used:
+    string += f" | allocated: {cur_platform.memory_allocated() / mega_bytes:.2f}"
+    string += f" | max allocated: {cur_platform.max_memory_allocated() / mega_bytes:.2f}"
+    string += f" | reserved: {cur_platform.memory_reserved() / mega_bytes:.2f}"
+    string += f" | max reserved: {cur_platform.max_memory_reserved() / mega_bytes:.2f}"
+    if args.log_device_memory_used and cur_platform.device_name() == 'cuda':
         string += f" | total device memory used: {torch.cuda.device_memory_used() / mega_bytes:.2f}"
     if mpu.get_data_parallel_rank() == 0:
         print("[Rank {}] {}".format(torch.distributed.get_rank(), string), flush=True)
@@ -451,7 +455,7 @@ def is_first_or_last_pipeline_stage(vp_stage):
 
 def get_device_arch_version():
     """Returns GPU arch version (8: Ampere, 9: Hopper, 10: Blackwell, ...)"""
-    return torch.cuda.get_device_properties(torch.device("cuda:0")).major
+    return cur_platform.get_device_properties(0).major
 
 
 def append_to_progress_log(string, barrier=True):
@@ -537,34 +541,34 @@ def get_batch_on_this_tp_rank(data_iterator, mtp_on_this_rank: bool = False):
         assert data_iterator is not None
         data = next(data_iterator)
         batch = {
-            'tokens': data["tokens"].cuda(non_blocking=True),
-            'labels': data["labels"].cuda(non_blocking=True),
-            'loss_mask': data["loss_mask"].cuda(non_blocking=True),
+            'tokens': data["tokens"].to(cur_platform.device(), non_blocking=True),
+            'labels': data["labels"].to(cur_platform.device(), non_blocking=True),
+            'loss_mask': data["loss_mask"].to(cur_platform.device(), non_blocking=True),
             'attention_mask': (
                 None
                 if "attention_mask" not in data
-                else data["attention_mask"].cuda(non_blocking=True)
+                else data["attention_mask"].to(cur_platform.device(), non_blocking=True)
             ),
-            'position_ids': data["position_ids"].cuda(non_blocking=True),
+            'position_ids': data["position_ids"].to(cur_platform.device(), non_blocking=True),
             'cu_seqlens': (
                 None
                 if "cu_seqlens" not in data
-                else data["cu_seqlens"].cuda(non_blocking=True)
+                else data["cu_seqlens"].to(cur_platform.device(), non_blocking=True)
             ),
             'max_seqlen': (
                 None
                 if "max_seqlen" not in data
-                else data["max_seqlen"].cuda(non_blocking=True)
+                else data["max_seqlen"].to(cur_platform.device(), non_blocking=True)
             ),
             'local_cp_size': (
                 None
                 if "local_cp_size" not in data
-                else data["local_cp_size"].cuda(non_blocking=True)
+                else data["local_cp_size"].to(cur_platform.device(), non_blocking=True)
             ),
         }
 
         def _broadcast_cu_seqlens(cu_seqlens):
-            dev = torch.cuda.current_device()
+            dev = cur_platform.current_device()
             n = 0 if cu_seqlens is None else int(cu_seqlens.numel())
             n_tensor = torch.tensor(n, dtype=torch.int64, device=dev)
             _broadcast(n_tensor)
@@ -579,7 +583,7 @@ def get_batch_on_this_tp_rank(data_iterator, mtp_on_this_rank: bool = False):
             _broadcast(buf)
 
         if args.hybrid_context_parallel:
-            seq_len = torch.tensor(batch['tokens'].shape[0], dtype=torch.int32, device=torch.cuda.current_device())
+            seq_len = torch.tensor(batch['tokens'].shape[0], dtype=torch.int32, device=cur_platform.current_device())
             _broadcast(seq_len)
             
         if args.pipeline_model_parallel_size == 1 or mtp_on_this_rank:
@@ -609,7 +613,7 @@ def get_batch_on_this_tp_rank(data_iterator, mtp_on_this_rank: bool = False):
 
     else:
         if args.hybrid_context_parallel:
-            seq_len = torch.tensor(0, dtype=torch.int32, device=torch.cuda.current_device())
+            seq_len = torch.tensor(0, dtype=torch.int32, device=cur_platform.current_device())
             _broadcast(seq_len)
             shape = (seq_len.item())
         else:
@@ -618,38 +622,38 @@ def get_batch_on_this_tp_rank(data_iterator, mtp_on_this_rank: bool = False):
         tokens = torch.empty(
             shape,
             dtype=torch.int64,
-            device=torch.cuda.current_device(),
+            device=cur_platform.current_device(),
         )
         labels = torch.empty(
             shape,
             dtype=torch.int64,
-            device=torch.cuda.current_device(),
+            device=cur_platform.current_device(),
         )
         loss_mask = torch.empty(
             shape,
             dtype=torch.float32,
-            device=torch.cuda.current_device(),
+            device=cur_platform.current_device(),
         )
         if args.create_attention_mask_in_dataloader:
             shape_attention_mask = (args.micro_batch_size, 1, args.seq_length, args.seq_length) if not args.hybrid_context_parallel else (1, 1, shape[0], shape[0])
             attention_mask = torch.empty(
                 shape_attention_mask,
                 dtype=torch.bool,
-                device=torch.cuda.current_device(),
+                device=cur_platform.current_device(),
             )
         else:
             attention_mask = None
         position_ids = torch.empty(
             shape,
             dtype=torch.int64,
-            device=torch.cuda.current_device(),
+            device=cur_platform.current_device(),
         )
         cu_seqlens = None
         if args.hybrid_context_parallel or args.sft:
             max_seqlen = torch.empty(
                 1,
                 dtype=torch.int32,
-                device=torch.cuda.current_device(),
+                device=cur_platform.current_device(),
             )
         else:
             max_seqlen = None
@@ -657,11 +661,11 @@ def get_batch_on_this_tp_rank(data_iterator, mtp_on_this_rank: bool = False):
         local_cp_size = torch.empty(
             1,
             dtype=torch.int32,
-            device=torch.cuda.current_device(),
+            device=cur_platform.current_device(),
         ) if args.hybrid_context_parallel else None
 
         def _broadcast_cu_seqlens():
-            dev = torch.cuda.current_device()
+            dev = cur_platform.current_device()
 
             n = torch.empty((), dtype=torch.int64, device=dev)
             _broadcast(n)


### PR DESCRIPTION
Fixes #168

## Summary

Platformize the hardcoded CUDA references in `megatron/training` and
`megatron/core` so non-CUDA backends (e.g. MUSA) pass the accelerator
checks and can run. Previously `megatron/training/initialize.py` asserted
`torch.cuda.is_available()` and many code paths constructed tensors on
`device='cuda'` or called `torch.cuda.*` directly, which broke on MUSA.

## Changes

- `initialize.py`: relax the `"Megatron requires CUDA."` assert to accept any
  accelerator, and platformize `device` / `set_device` / `Stream` /
  `set_stream` / `device_count` / `empty_cache`.
- `jit.py`: disable `torch.compile` jit fusion on non-CUDA backends, where
  inductor autotuning requires a Triton backend that MUSA does not ship.
- `training.py`, `utils.py`, `core/utils.py`, `core/optimizer/clip_grads.py`,
  `core/rerun_state_machine.py`: swap `device='cuda'` and `torch.cuda.*`
  calls for the platform API (`get_platform()` / `cur_platform`).

## Verification

Verified on MUSA 4.3.6 and 5.2.0, both flagtree and triton (vendor) dual
paths. Pretraining smoke run exits cleanly (`PRETRAIN_EXIT=0`) on both.
Distributed backend is `mccl` (`--distributed-backend mccl`).

This PR was written in part with the assistance of generative AI.
