### PR TITLE
Fix: short-circuit single-rank param-group alignment to avoid all_gather_object garbage sizes

### DIFF
--- a/megatron/core/optimizer/__init__.py
+++ b/megatron/core/optimizer/__init__.py
@@ -366,7 +366,13 @@ def _get_param_groups(
     # runtime error when loading the checkpoint or numerical error when resuming training.
     params_key = list(params_map.keys())
     gathered_params_key = [None for _ in range(torch.distributed.get_world_size())]
-    torch.distributed.all_gather_object(gathered_params_key, params_key)
+    # Single-rank short-circuit: the gather is a no-op with one rank, and
+    # skipping it avoids all_gather_object's internal sizes exchange, which
+    # returns garbage on some vendor collectives (e.g. torch-gcu/ECCL).
+    if torch.distributed.get_world_size() == 1:
+        gathered_params_key = [params_key]
+    else:
+        torch.distributed.all_gather_object(gathered_params_key, params_key)
     for keys in gathered_params_key:
         for key in keys:
             if key not in params_key:


### PR DESCRIPTION
Fixes #169

## Problem

`_param_group_alignment` aligns param groups across ranks with `torch.distributed.all_gather_object`. When `world_size == 1` this gather is a semantic no-op (each rank gathers from itself), yet the collective still runs its full internal machinery — including the object sizes exchange — adding an unnecessary collective + implicit sync to every single-rank / single-node run.

The issue is not merely wasteful: on Enflame GCU (torch-gcu 2.10.0+3.7.20260408) the sizes exchange returns garbage even for a single-rank process (repro: local rank 0 gathers `-4888733163028742123` as the max object size, driving `input_tensor.resize_(max_object_size)` to a ~1 EB allocation → OOM).

## Fix

Short-circuit `all_gather_object` when `world_size == 1` (fill `gathered_params_key` locally). Single-rank semantics are unchanged; multi-rank runs are unaffected and still rely on the backend's object-gather support.

This matches the existing upstream pattern of guarding collectives with `world_size > 1` checks in the training startup path.

## Verification

- Enflame GCU 1.9.10 runtime (torch-gcu 2.10.0+3.7.20260408, ECCL 3.6.3.11): single-GPU `pretrain_gpt.py` (mock-data, 5 iters) previously OOM'd; with this short-circuit both FlagTree and Triton compiler paths exit 0 and test-set validation loss is identical across paths.
- `torch.gcu.synchronize()` does not fix the garbage sizes; only skipping the collective does.

This PR was written in part with the assistance of generative AI.
