### PR TITLE
Fix: use float32 for startup timestamp sync (ECCL rejects fp64/int64 all_reduce)

### DIFF
--- a/megatron/training/training.py
+++ b/megatron/training/training.py
@@ -1039,13 +1039,13 @@ def pretrain(
     # Initialize program_start_global with a fallback value in case set_startup_timestamps() wasn't called
     program_start_global = _TRAIN_START_TIME
     if _STARTUP_TIMESTAMPS['program_start'] is not None:
-        program_start_global = torch.tensor([_STARTUP_TIMESTAMPS['program_start']], dtype=torch.double, device='cuda')
+        program_start_global = torch.tensor([_STARTUP_TIMESTAMPS['program_start']], dtype=torch.float32, device='cuda')
         torch.distributed.all_reduce(program_start_global, op=torch.distributed.ReduceOp.MIN)
         program_start_global = program_start_global.item()
     set_startup_timestamps(program_start=program_start_global)
 
     global _LEGACY_TRAIN_START_TIME
-    start_time_tensor = torch.tensor([_LEGACY_TRAIN_START_TIME], dtype=torch.double, device='cuda')
+    start_time_tensor = torch.tensor([_LEGACY_TRAIN_START_TIME], dtype=torch.float32, device='cuda')
     torch.distributed.all_reduce(start_time_tensor, op=torch.distributed.ReduceOp.MIN)
     _LEGACY_TRAIN_START_TIME = start_time_tensor.item()
 


### PR DESCRIPTION
Fixes #170

## Problem

The startup-time MIN sync in `train()` builds `torch.double` tensors and reduces them with `torch.distributed.all_reduce`. ECCL (Enflame GCU's NCCL substitute, v3.6.3.11) rejects fp64 — and int64 — all_reduce with `ecclInvalidArgument` (`DistBackendError`), aborting training before the first step on Enflame GCU 1.10.6.

## Fix

Use `torch.float32` for the two timestamp tensors. fp32 all_reduce is accepted by ECCL and is sufficient here: the values are only compared with `ReduceOp.MIN` and consumed as coarse startup bookkeeping (`app_start_time` ms, legacy start time), so fp32's reduced precision at epoch-scale timestamps is an acceptable tradeoff for portability across non-CUDA collectives.

## Verification

- Reproduced on Enflame GCU 1.10.6 runtime (ECCL 3.6.3.11, torch-gcu 2.11.0+3.8.20260713): without the change `train()` dies in the timestamp sync; with it, single-GPU `pretrain_gpt.py` (mock-data, 5 iters) exits 0 on both FlagTree and Triton compiler paths with identical test-set validation loss.
- The same two sites are the only `torch.double` collectives in `megatron/training/training.py`.

This PR was written in part with the assistance of generative AI.
