### PR TITLE
perf(npu): optimize MoE chunk reorder with index_select

### DIFF
--- a/megatron/core/transformer/moe/moe_utils.py
+++ b/megatron/core/transformer/moe/moe_utils.py
@@ -23,6 +23,7 @@ from megatron.core.transformer.enums import CudaGraphScope
 from megatron.core.transformer.moe.router_replay import RouterReplay
 from megatron.core.transformer.transformer_config import TransformerConfig
 from megatron.core.utils import internal_api, is_te_min_version
+from megatron.plugin.decorators import overridable
 
 ########## FlagScale Begin ##########
 from megatron.plugin.platform import get_platform
@@ -536,6 +537,24 @@ def unpermute(
     return output_tokens.to(dtype=input_dtype)
 
 
+@overridable
+def _sort_chunks_by_idxs(
+    input: torch.Tensor,
+    split_sizes: torch.Tensor,
+    sorted_idxs: torch.Tensor,
+    probs: Optional[torch.Tensor] = None,
+) -> Tuple[torch.Tensor, Optional[torch.Tensor]]:
+    """Reference chunk reorder used when no platform plugin overrides it."""
+    input_chunks = torch.split(input, split_sizes.tolist(), dim=0)
+    output = torch.cat([input_chunks[i] for i in sorted_idxs.tolist()], dim=0)
+    if probs is not None:
+        prob_chunks = torch.split(probs, split_sizes.tolist(), dim=0)
+        permuted_probs = torch.cat([prob_chunks[i] for i in sorted_idxs.tolist()], dim=0)
+    else:
+        permuted_probs = None
+    return output, permuted_probs
+
+
 def sort_chunks_by_idxs(
     input: torch.Tensor,
     split_sizes: torch.Tensor,
@@ -571,14 +590,7 @@ def sort_chunks_by_idxs(
             )
         return fused_sort_chunks_by_index_with_probs(input, probs, split_sizes, sorted_idxs)
 
-    input = torch.split(input, split_sizes.tolist(), dim=0)
-    output = torch.cat([input[i] for i in sorted_idxs.tolist()], dim=0)
-    if probs is not None:
-        probs = torch.split(probs, split_sizes.tolist(), dim=0)
-        permuted_probs = torch.cat([probs[i] for i in sorted_idxs.tolist()], dim=0)
-    else:
-        permuted_probs = None
-    return output, permuted_probs
+    return _sort_chunks_by_idxs(input, split_sizes, sorted_idxs, probs)
 
 
 def group_limited_topk(

--- a/megatron/plugin/Ascend/transformer/moe/__init__.py
+++ b/megatron/plugin/Ascend/transformer/moe/__init__.py
@@ -1,0 +1,1 @@
+"""Ascend-specific Mixture-of-Experts overrides."""

--- a/megatron/plugin/Ascend/transformer/moe/moe_utils.py
+++ b/megatron/plugin/Ascend/transformer/moe/moe_utils.py
@@ -1,0 +1,128 @@
+"""Ascend implementations for narrow MoE utility override points."""
+
+from typing import Optional, Tuple
+
+import torch
+
+
+class _IndexedChunkReorder(torch.autograd.Function):
+    """Reorder rows with a bijection and apply its inverse in backward."""
+
+    @staticmethod
+    def forward(
+        ctx,
+        input: torch.Tensor,
+        probs: Optional[torch.Tensor],
+        row_permutation: torch.Tensor,
+        inverse_permutation: torch.Tensor,
+    ) -> Tuple[torch.Tensor, Optional[torch.Tensor]]:
+        ctx.save_for_backward(inverse_permutation)
+        output = input.index_select(0, row_permutation)
+        permuted_probs = (
+            probs.index_select(0, row_permutation) if probs is not None else None
+        )
+        return output, permuted_probs
+
+    @staticmethod
+    def backward(ctx, grad_output, grad_permuted_probs):
+        (inverse_permutation,) = ctx.saved_tensors
+        grad_input = (
+            grad_output.index_select(0, inverse_permutation)
+            if grad_output is not None
+            else None
+        )
+        grad_probs = (
+            grad_permuted_probs.index_select(0, inverse_permutation)
+            if grad_permuted_probs is not None
+            else None
+        )
+        return grad_input, grad_probs, None, None
+
+
+def _validate_chunk_metadata(
+    input: torch.Tensor,
+    split_sizes: torch.Tensor,
+    sorted_idxs: torch.Tensor,
+    probs: Optional[torch.Tensor],
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    """Validate the bijection required by the indexed NPU implementation."""
+    if split_sizes.ndim != 1 or sorted_idxs.ndim != 1:
+        raise ValueError("split_sizes and sorted_idxs must be one-dimensional")
+    if split_sizes.numel() != sorted_idxs.numel():
+        raise ValueError("sorted_idxs must contain exactly one entry for each chunk")
+    integer_dtypes = (torch.uint8, torch.int8, torch.int16, torch.int32, torch.int64)
+    if split_sizes.dtype not in integer_dtypes or sorted_idxs.dtype not in integer_dtypes:
+        raise TypeError("split_sizes and sorted_idxs must have integer dtype")
+
+    counts = split_sizes.detach().to(device="cpu", dtype=torch.long)
+    chunk_order = sorted_idxs.detach().to(device="cpu", dtype=torch.long)
+    if torch.any(counts < 0):
+        raise ValueError("split_sizes must be non-negative")
+    if int(counts.sum().item()) != input.shape[0]:
+        raise ValueError("sum(split_sizes) must equal input.shape[0]")
+    if probs is not None and probs.shape[0] != input.shape[0]:
+        raise ValueError("probs and input must have the same leading dimension")
+
+    num_chunks = counts.numel()
+    expected = torch.arange(num_chunks, dtype=torch.long)
+    if num_chunks and not torch.equal(torch.sort(chunk_order).values, expected):
+        raise ValueError("sorted_idxs must be a permutation of all chunk indices")
+    return counts, chunk_order
+
+
+def _build_row_permutations(
+    counts: torch.Tensor, chunk_order: torch.Tensor, device: torch.device
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    """Build row permutation and inverse from small CPU chunk metadata."""
+    num_rows = int(counts.sum().item())
+    if num_rows == 0:
+        empty = torch.empty(0, dtype=torch.long, device=device)
+        return empty, empty
+
+    sorted_counts = counts.index_select(0, chunk_order)
+    chunk_ids = torch.repeat_interleave(chunk_order, sorted_counts, output_size=num_rows)
+    sorted_offsets = sorted_counts.cumsum(0) - sorted_counts
+    offsets_within_chunks = torch.arange(num_rows) - torch.repeat_interleave(
+        sorted_offsets, sorted_counts, output_size=num_rows
+    )
+    source_offsets = counts.cumsum(0) - counts
+    row_permutation = source_offsets.index_select(0, chunk_ids) + offsets_within_chunks
+
+    inverse_permutation = torch.empty_like(row_permutation)
+    inverse_permutation[row_permutation] = torch.arange(num_rows)
+    permutation_pair = torch.stack((row_permutation, inverse_permutation)).to(
+        device=device, non_blocking=True
+    )
+    return permutation_pair.unbind(0)
+
+
+def _indexed_sort_chunks_by_idxs(
+    input: torch.Tensor,
+    split_sizes: torch.Tensor,
+    sorted_idxs: torch.Tensor,
+    probs: Optional[torch.Tensor] = None,
+) -> Tuple[torch.Tensor, Optional[torch.Tensor]]:
+    """Ascend indexed chunk reorder with an explicit bijection contract."""
+    counts, chunk_order = _validate_chunk_metadata(input, split_sizes, sorted_idxs, probs)
+    row_permutation, inverse_permutation = _build_row_permutations(
+        counts, chunk_order, input.device
+    )
+    return _IndexedChunkReorder.apply(input, probs, row_permutation, inverse_permutation)
+
+
+def _sort_chunks_by_idxs(
+    input: torch.Tensor,
+    split_sizes: torch.Tensor,
+    sorted_idxs: torch.Tensor,
+    probs: Optional[torch.Tensor] = None,
+) -> Tuple[torch.Tensor, Optional[torch.Tensor]]:
+    """Use indexed reorder for NPU tensors; preserve the original path elsewhere.
+
+    The public core function still owns the explicit TE fused branches. This
+    override only replaces its non-fused split/list/cat implementation.
+    """
+    if input.device.type != "npu":
+        from megatron.core.transformer.moe.moe_utils import _sort_chunks_by_idxs as reference
+
+        return reference.__wrapped__(input, split_sizes, sorted_idxs, probs)
+    return _indexed_sort_chunks_by_idxs(input, split_sizes, sorted_idxs, probs)

--- a/megatron/plugin/override_registry.py
+++ b/megatron/plugin/override_registry.py
@@ -178,3 +178,13 @@ register(
     impl="megatron.plugin.Ascend.transformer.transformer_config.NPUTransformerConfig",
     vendor="npu",
 )
+
+
+# =============================================================================
+# Transformer - MoE chunk reorder
+# =============================================================================
+register(
+    target="megatron.core.transformer.moe.moe_utils._sort_chunks_by_idxs",
+    impl="megatron.plugin.Ascend.transformer.moe.moe_utils._sort_chunks_by_idxs",
+    vendor="npu",
+)

--- a/megatron/plugin/tests/test_ascend_moe_utils.py
+++ b/megatron/plugin/tests/test_ascend_moe_utils.py
@@ -1,0 +1,105 @@
+import pytest
+import torch
+
+from megatron.plugin.Ascend.transformer.moe.moe_utils import (
+    _indexed_sort_chunks_by_idxs,
+    _sort_chunks_by_idxs,
+)
+
+
+def _reference(input, split_sizes, sorted_idxs):
+    chunks = torch.split(input, split_sizes.tolist(), dim=0)
+    return torch.cat([chunks[index] for index in sorted_idxs.tolist()], dim=0)
+
+
+@pytest.mark.parametrize("with_probs", [False, True])
+def test_indexed_chunk_reorder_matches_reference_forward_and_backward(with_probs):
+    split_sizes = torch.tensor([2, 0, 3, 1], dtype=torch.long)
+    sorted_idxs = torch.tensor([2, 0, 3, 1], dtype=torch.long)
+    input = torch.randn(6, 4, requires_grad=True)
+    probs = torch.randn(6, 2, requires_grad=True) if with_probs else None
+
+    output, permuted_probs = _indexed_sort_chunks_by_idxs(input, split_sizes, sorted_idxs, probs)
+    torch.testing.assert_close(output, _reference(input, split_sizes, sorted_idxs))
+    if probs is not None:
+        torch.testing.assert_close(
+            permuted_probs, _reference(probs, split_sizes, sorted_idxs)
+        )
+
+    loss = output.square().sum()
+    if permuted_probs is not None:
+        loss = loss + permuted_probs.square().sum()
+    loss.backward()
+
+    torch.testing.assert_close(input.grad, 2 * input.detach())
+    if probs is not None:
+        torch.testing.assert_close(probs.grad, 2 * probs.detach())
+
+
+@pytest.mark.parametrize(
+    "split_sizes,sorted_idxs,message",
+    [
+        ([2, 1], [0], "exactly one entry"),
+        ([2, -1], [0, 1], "non-negative"),
+        ([2, 1], [0, 0], "permutation"),
+        ([2, 2], [0, 1], "input.shape"),
+    ],
+)
+def test_indexed_chunk_reorder_rejects_invalid_metadata(split_sizes, sorted_idxs, message):
+    with pytest.raises(ValueError, match=message):
+        _indexed_sort_chunks_by_idxs(
+            torch.randn(3, 2),
+            torch.tensor(split_sizes),
+            torch.tensor(sorted_idxs),
+        )
+
+
+@pytest.mark.parametrize("dtype", [torch.float32, torch.bfloat16])
+@pytest.mark.parametrize("with_probs", [False, True])
+def test_512_chunks_bitwise_forward_and_backward(dtype, with_probs):
+    generator = torch.Generator().manual_seed(42)
+    sizes = torch.randint(0, 5, (512,), generator=generator)
+    order = torch.randperm(512, generator=generator)
+    rows = int(sizes.sum())
+    # Transpose to exercise non-contiguous inputs and upstream gradients.
+    values = torch.randn(8, rows, generator=generator, dtype=dtype).t()
+    input = values.detach().requires_grad_()
+    ref_input = values.clone().requires_grad_()
+    probs = torch.randn(rows, generator=generator, requires_grad=True) if with_probs else None
+    ref_probs = probs.detach().clone().requires_grad_() if with_probs else None
+    output, output_probs = _indexed_sort_chunks_by_idxs(input, sizes, order, probs)
+    reference = _reference(ref_input, sizes, order)
+    assert torch.equal(output, reference)
+    grad = torch.randn(8, rows, generator=generator, dtype=dtype).t()
+    output.backward(grad, retain_graph=with_probs)
+    reference.backward(grad)
+    assert torch.equal(input.grad, ref_input.grad)
+    if with_probs:
+        reference_probs = _reference(ref_probs, sizes, order)
+        assert torch.equal(output_probs, reference_probs)
+        grad_probs = torch.randn(rows, generator=generator)
+        output_probs.backward(grad_probs)
+        reference_probs.backward(grad_probs)
+        assert torch.equal(probs.grad, ref_probs.grad)
+
+
+def test_all_empty_chunks():
+    input = torch.empty(0, 8, requires_grad=True)
+    sizes = torch.zeros(512, dtype=torch.long)
+    order = torch.arange(511, -1, -1)
+    output, probs = _indexed_sort_chunks_by_idxs(input, sizes, order)
+    assert probs is None and torch.equal(output, _reference(input, sizes, order))
+    output.sum().backward()
+    assert input.grad.shape == input.shape
+
+
+def test_rejects_float_metadata():
+    with pytest.raises(TypeError, match="integer dtype"):
+        _indexed_sort_chunks_by_idxs(torch.randn(3, 2), torch.tensor([1.5, 1.5]), torch.tensor([1, 0]))
+
+
+def test_non_npu_keeps_core_reference():
+    input = torch.randn(3, 2, requires_grad=True)
+    sizes, order = torch.tensor([1, 2]), torch.tensor([1, 0])
+    actual, probs = _sort_chunks_by_idxs(input, sizes, order)
+    assert probs is None and torch.equal(actual, _reference(input, sizes, order))


### PR DESCRIPTION
# Description

本 PR 针对 Ascend NPU 上的非融合 MoE chunk reorder 路径进行优化，将原有的 `torch.split -> Python list indexing -> torch.cat` fallback 替换为基于 `index_select` 的行索引置换实现。

整体设计遵循 Megatron-LM-FL 现有的平台 Override 机制：

- 通用 Core 保留原有 reference 行为作为默认实现；
- 将 Core 中的非融合路径抽取为 `@overridable` 扩展点；
- Ascend Plugin 提供 NPU 专属 indexed reorder 实现；
- 现有 Transformer Engine fused 分支保持不变；
- 非 NPU tensor 显式回退到原始 Core reference 实现。

### Before / after

优化前，非融合路径会先生成大量 chunk view，再通过 Python 列表索引重排并重新执行 `cat`：

```python
input = torch.split(input, split_sizes.tolist(), dim=0)
output = torch.cat([input[i] for i in sorted_idxs.tolist()], dim=0)

if probs is not None:
    probs = torch.split(probs, split_sizes.tolist(), dim=0)
    permuted_probs = torch.cat([probs[i] for i in sorted_idxs.tolist()], dim=0)
```

Ascend Override 将 chunk 顺序转换为逐行 permutation，并直接通过 `index_select` 完成 NPU 前向重排：

```python
output = input.index_select(0, row_permutation)
permuted_probs = (
    probs.index_select(0, row_permutation) if probs is not None else None
)
```

反向传播使用 inverse permutation 恢复梯度顺序：

```python
grad_input = grad_output.index_select(0, inverse_permutation)
```

因此，在保持相同双射行重排语义的前提下，Ascend 路径不再执行大规模的 `split/list/cat` 模式。

### 实现细节

Core 中将原始非融合 fallback 抽取为：

```python
@overridable
def _sort_chunks_by_idxs(...):
    ...
```

公共 `sort_chunks_by_idxs` 仍然优先处理原有 TE fused 分支，仅将非融合 fallback 委托给该 helper。

Ascend 实现主要包括：

- 校验 `split_sizes`、`sorted_idxs`、输入行数、可选 routing probabilities 以及完整 permutation 条件；
- 根据 chunk metadata 构造 row permutation 和 inverse permutation；
- 前向通过 `index_select` 对 token 和可选 probabilities 进行重排；
- 反向通过 inverse permutation 恢复梯度顺序；
- 支持零长度 chunk 和 all-empty input；
- 非 NPU tensor 通过 `reference.__wrapped__` 保持原 Core fallback。

本 PR 同时在 `megatron/plugin/tests/test_ascend_moe_utils.py` 中新增 Plugin 单元测试，覆盖 forward/backward parity、FP32/BF16、带/不带 routing probabilities、512 chunks、零长度/all-empty chunk、非连续 tensor、非法 metadata 以及非 NPU fallback。

### PR 分支与验证版本

当前 PR 分支：

```text
HDU-Tiankuan/Megatron-LM-FL:zhanw-moe-reorder
```

当前分支 head：

```text
3e09d075137c75720fa00e9ed854196e4a60885c
```

该分支直接基于当前官方 `flagos-ai/Megatron-LM-FL:main`：

```text
942e8f56912de527fa4333425a0357784f6ca781
```

当前分支相对 upstream main 为 ahead 2 / behind 0，并已包含本优化计划中的 5 个文件，包括新增的 Plugin 单元测试文件。

性能验证基于 upstream snapshot：

```text
a922e77b9ba8ac5986049e69ad838be1cccc22cf
```

经核对，本优化涉及的生产代码文件在 `a922e77...` 到 `942e8f5...` 之间未发生变化，因此性能验证覆盖的 MoE reorder 生产代码路径与当前 PR 中对应的生产代码保持一致。

### Ascend 910C 验证

#### 环境

| 项目 | 配置 |
|---|---|
| Hardware | 8 × Ascend 910C NPU |
| PyTorch | `2.7.1+cpu` |
| torch_npu | `2.7.1.post6` |
| Model | Qwen3.5-MoE-35B-A3B reduced-depth L4/V1 performance configuration, MTP1 |
| Parallelism | TP2 / PP2 / EP2 / DP2 / CP1, sequence parallel |
| Batch | MBS1 / GBS4 |
| Sequence length | 2048 |
| Precision | BF16 |
| Seed | 42 |
| Data | Real packed LLaVA WebDataset |
| Packing | buffer 128 / target 2048 / max 32 source samples |
| Initialization | Random initialization; no checkpoint load/save |
| Performance window | Step 3-100，每个 run 统计 98 个 step |
| Profiling during performance runs | Disabled |

#### Plugin 单元测试

新增的 Plugin 单元测试在 CPU 执行下通过：

```text
13 passed
```

测试覆盖 reference 等价的 forward/backward 行为、512-chunk FP32/BF16、可选 routing probabilities、空 chunk、非法 metadata、非连续输入以及非 NPU fallback。

#### NPU 数值一致性

Indexed 实现与原始 `split/list/cat` reference 在 8 个 NPU parity case 下进行了对比，覆盖：

- dtype：FP32、BF16；
- routing probabilities：有、无；
- input：非空、all-empty；
- 对比项：forward output、input gradient；存在 probabilities 时同时比较 probability output 和 gradient。

结果：

| 检查项 | 结果 |
|---|---|
| Forward output | Bitwise equal |
| Input gradient | Bitwise equal |
| Probability output / gradient | 存在时 Bitwise equal |
| Maximum absolute error | `0.0` |
| CPU fallback | Passed |
| 实际选中的 NPU 实现 | `megatron.plugin.Ascend.transformer.moe.moe_utils._sort_chunks_by_idxs` |

#### 端到端性能

为降低运行顺序偏差，保留两组反向顺序 A/B：

```text
baseline_main -> indexed_main -> indexed_repeat -> baseline_repeat
```

4 个 run 均完成 100/100 steps，`REAL_TORCHRUN_EXIT=0`，loss 和 gradient norm 均为有限值，`skipped=0`、`nan=0`。

| Pair | Baseline mean | Indexed mean | Improvement | Speedup |
|---|---:|---:|---:|---:|
| Baseline -> Indexed | 2188.140 ms | 2149.838 ms | 1.7504% | 1.017816× |
| Indexed -> Baseline | 2197.037 ms | 2145.792 ms | 2.3325% | 1.023882× |

每种实现合并统计 196 个稳态 step：

| Metric | Baseline | Indexed | Change |
|---|---:|---:|---:|
| Mean iteration time | 2192.588 ms | 2147.815 ms | **-44.773 ms / 2.0420%** |
| Median iteration time | 2245.100 ms | 2222.650 ms | -22.450 ms |
| P90 | 2680.600 ms | 2581.500 ms | -99.100 ms |
| P95 | 3000.400 ms | 2890.200 ms | -110.200 ms |
| Samples/s | 1.824328 | 1.862358 | +2.0846% |
| Nominal tokens/s | 3736.224 | 3814.109 | +2.0846% |
| Actual non-padding tokens/s | 3471.407 | 3543.773 | +2.0846% |

Pooled mean 对应 `1.020846×` speedup。两个独立 A/B pair 均取得正向收益，并非从多次运行中只选择最快结果。

P99 和最大迭代时间没有改善，因此本 PR 不宣称所有尾部延迟统计指标均得到改善。

#### Profiler 证据

另外采集了独立的 MoE reorder forward/backward 单步 Profile，使用真实 rank0 训练 metadata：

```text
shape: [15922, 2048]
dtype: BF16
chunks: 512
with_probs: true
```

| Observed operation | Baseline | Indexed |
|---|---:|---:|
| `aten::split_with_sizes` | 2 | 0 |
| `aten::slice` | 1024 | 0 |
| `aten::narrow` | 1024 | 0 |
| `aclnnCat` | 4 | 0 |
| `aten::index_select` | 0 | 8 |
| `aclnnIndexSelect` | 0 | 4 |
| Host enqueue | 4 | 5 |

Profile 证明目标路径确实从 split/list/cat 实现切换到 Ascend `IndexSelect` 路径，并显著减少 view/slice/narrow 类操作。

Host enqueue 从 4 增加到 5，因此本 PR **不宣称 Host launch 数量下降**。性能结论来自端到端 no-profile A/B；该单步 Profile 只用于确认实际分派和性能归因。

### 兼容性与验证边界

- 现有 TE fused 分支在 Override 点之前执行，本 PR 不修改该路径。
- 未选择平台 Override 时，Core reference 仍为默认实现。
- 非 NPU tensor 显式保持原始 reference 行为。
- 本 PR 不修改 TE-FL 源码、optimizer、pipeline schedule、通信路径、backend-priority policy 或其他无关算子。

严格原生 current-main 训练在 Step 1 前被与本优化无关的 GDN/l2norm FLA Triton UB overflow 阻塞。为了保持 MoE reorder A/B 的单变量对照，baseline 与 indexed 两侧对该 GDN/l2norm 路径均使用完全相同的 upstream Torch reference symbols，且没有因此修改两份 Megatron 源码树。

因此，本次性能结论限定于双方使用相同 compatibility harness 的 reduced-depth L4/V1 packed 配置；不是完整 L40 权重训练或模型收敛结论。单步 Profiler 也不代表完整训练 step。

### Related

- [Megatron-LM-FL 当前 `sort_chunks_by_idxs` fallback](https://github.com/flagos-ai/Megatron-LM-FL/blob/main/megatron/core/transformer/moe/moe_utils.py#L490-L528)
- [NVIDIA Megatron-LM 对应 MoE 实现](https://github.com/NVIDIA/Megatron-LM/blob/main/megatron/core/transformer/moe/moe_utils.py)
- [MindSpeed `fused_moe_permute` wrapper](https://github.com/Ascend/MindSpeed/blob/master/mindspeed/core/fusions/fused_moe_permute.py)

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [ ] Infra/Build change (changes to CI/CD workflows or build scripts)
- [x] Code refactoring
- [ ] Documentation change
- [ ] Bug fix
- [ ] Breaking change

## Changes

- 将非融合 MoE `split/list/cat` fallback 抽取为 `@overridable` 的 `_sort_chunks_by_idxs` Core helper，同时保持公共 API 和 TE fused 分支不变。
- 新增 Ascend Plugin 实现，根据 chunk metadata 构造 row/inverse permutation，并在 forward/backward 中使用 `index_select`。
- 在 `megatron/plugin/override_registry.py` 中注册 Ascend `_sort_chunks_by_idxs` Override。
- 新增 Plugin 单元测试，覆盖 forward/backward parity、FP32/BF16、可选 routing probabilities、512 chunks、空/非法场景、非连续 tensor 和非 NPU fallback。
- Ascend NPU 路径之外继续保持原 Core reference 行为，不修改其他训练逻辑或 backend policy。

## Checklist

- [x] I have read and followed the contributing guidelines
- [x] The functionality is complete
- [x] I have commented my code, particularly in coverage report uploading steps
- [ ] I have made corresponding changes to the documentation — N/A：该内部性能优化不需要额外用户文档修改
- [ ] My changes generate no new warnings — targeted pytest 已通过，但未针对 upstream 单独建立 warning delta 基线
- [x] I have added/updated tests that prove my feature works
- [ ] New and existing unit tests pass locally — 新增 targeted Plugin 单测已通过（`13 passed`），未运行完整仓库 test suite

