### PR TITLE
Enable fused AdamW for Ascend NPU

### DIFF
--- a/megatron/core/optimizer/__init__.py
+++ b/megatron/core/optimizer/__init__.py
@@ -56,6 +56,7 @@ from megatron.core.optimizer_param_scheduler import (
 )
 from megatron.core.process_groups_config import ProcessGroupCollection
 from megatron.core.transformer.fsdp_dtensor_checkpoint import get_global_unique_param_name
+from megatron.plugin.decorators import overridable
 
 from ..distributed.param_and_grad_buffer import _ParamAndGradBuffer
 from ..transformer.module import MegatronModule
@@ -456,6 +457,15 @@ def _get_param_groups_and_buffers(
     return param_groups, buffers
 
 
+@overridable
+def _get_adam_class(config: OptimizerConfig, kwargs: Dict[str, Any]):
+    """Select the Adam implementation and its backend-specific arguments."""
+    if USING_PYTORCH_OPTIMIZER:
+        return torch.optim.AdamW if config.decoupled_weight_decay else torch.optim.Adam
+    kwargs["adam_w_mode"] = config.decoupled_weight_decay
+    return Adam
+
+
 def _get_megatron_optimizer_based_on_param_groups(
     config: OptimizerConfig,
     model_chunks: List[MegatronModule],
@@ -547,13 +557,7 @@ def _get_megatron_optimizer_based_on_param_groups(
                 "capturable": config.optimizer_cuda_graph,
             }
 
-            # set Adam class and weight decay mode depending
-            # on source of optimizer (Torch or TE/Apex)
-            if USING_PYTORCH_OPTIMIZER:
-                adam_cls = torch.optim.AdamW if config.decoupled_weight_decay else torch.optim.Adam
-            else:
-                kwargs["adam_w_mode"] = config.decoupled_weight_decay
-                adam_cls = Adam
+            adam_cls = _get_adam_class(config, kwargs)
 
             if config.use_precision_aware_optimizer:
                 kwargs.update(
@@ -586,6 +590,17 @@ def _get_megatron_optimizer_based_on_param_groups(
                     for p in group['params']:
                         if len(opt.state[p]) == 0:
                             if config is None or not config.use_precision_aware_optimizer:
+                                if isinstance(opt, (torch.optim.Adam, torch.optim.AdamW)):
+                                    # Native Adam keeps a scalar step per parameter, including
+                                    # when moments are initialized before checkpoint loading.
+                                    step_device = (
+                                        p.device
+                                        if group.get('fused', False) or group.get('capturable', False)
+                                        else 'cpu'
+                                    )
+                                    opt.state[p]['step'] = torch.zeros(
+                                        (), dtype=torch.float32, device=step_device
+                                    )
                                 opt.state[p]['exp_avg'] = torch.zeros_like(p.data)
                                 opt.state[p]['exp_avg_sq'] = torch.zeros_like(p.data)
                             else:

--- a/megatron/core/optimizer/distrib_optimizer.py
+++ b/megatron/core/optimizer/distrib_optimizer.py
@@ -672,11 +672,14 @@ class DistributedOptimizer(MixedPrecisionOptimizer):
         inner_state_dict = self.optimizer.state_dict()
         state_dict = {}
 
-        # Extract 'step', for non-Apex/TE support.
-        if not HAVE_APEX_OR_TE:
+        # State layout follows the optimizer instance, not installed optional packages.
+        native_torch_optimizer = isinstance(
+            self.optimizer, (torch.optim.Adam, torch.optim.AdamW)
+        )
+        if native_torch_optimizer or not HAVE_APEX_OR_TE:
             steps = list(set([s["step"].item() for s in inner_state_dict["state"].values()]))
-            assert len(steps) == 1
-            step = steps[0]
+            assert len(steps) <= 1, f"Inconsistent per-parameter steps: {steps}"
+            step = steps[0] if steps else 0
         elif isinstance(self.optimizer, HybridDeviceOptimizer):
             step = None
             for optimizer in self.optimizer.sub_optimizers:
@@ -705,7 +708,7 @@ class DistributedOptimizer(MixedPrecisionOptimizer):
         state_dict['optimizer'] = {k: v for k, v in inner_state_dict.items() if k != "state"}
         for param_group in state_dict["optimizer"]["param_groups"]:
             del param_group["params"]
-            if not HAVE_APEX_OR_TE:
+            if native_torch_optimizer or not HAVE_APEX_OR_TE:
                 # Native PyTorch param group requires step (i.e., iteration).
                 param_group["step"] = step
             elif (
@@ -852,15 +855,18 @@ class DistributedOptimizer(MixedPrecisionOptimizer):
             # Retrieve existing optimizer state.
             state_dict_state = inner_state_dict["state"]
 
-        # Extract 'step', for non-Apex/TE support.
-        if not HAVE_APEX_OR_TE:
+        # Restore native Adam state even when TE or Apex is available.
+        native_torch_optimizer = isinstance(
+            self.optimizer, (torch.optim.Adam, torch.optim.AdamW)
+        )
+        if native_torch_optimizer or not HAVE_APEX_OR_TE:
             steps = list(set([g["step"] for g in state_dict["optimizer"]["param_groups"]]))
             assert len(steps) == 1
             step = torch.tensor(steps[0], dtype=torch.float)
 
             for s in state_dict_state.values():
                 # Native PyTorch state dict requires step (i.e., iteration).
-                s["step"] = step
+                s["step"] = step.detach().clone()
         elif isinstance(self.optimizer, HybridDeviceOptimizer):
             # Handle Torch AdamW special case, which, unlike FusedAdam, Torch AdamW
             # has an extra optimizer state "step".

--- a/megatron/plugin/Ascend/optimizer/__init__.py
+++ b/megatron/plugin/Ascend/optimizer/__init__.py
@@ -1,0 +1,1 @@
+"""Ascend optimizer implementations."""

--- a/megatron/plugin/Ascend/optimizer/adamw.py
+++ b/megatron/plugin/Ascend/optimizer/adamw.py
@@ -1,0 +1,30 @@
+"""Select TorchNPU fused AdamW through the Megatron override interface."""
+
+import torch
+
+from megatron.core.optimizer import _get_adam_class
+
+
+def get_adam_class(config, kwargs):
+    """Use native fused AdamW only for supported, device-resident NPU parameters.
+
+    Parameter groups, distributed optimizer wrapping, and checkpoint handling
+    remain owned by core. Unsupported configurations retain the original path.
+    """
+    npu = getattr(torch, "npu", None)
+    supported = (
+        npu is not None
+        and npu.is_available()
+        and config.decoupled_weight_decay
+        and not config.optimizer_cuda_graph
+        and not config.use_precision_aware_optimizer
+        and not config.optimizer_cpu_offload
+    )
+    if supported:
+        params = [param for group in kwargs["params"] for param in group["params"]]
+        supported = bool(params) and all(param.device.type == "npu" for param in params)
+    if not supported:
+        return _get_adam_class.__wrapped__(config, kwargs)
+
+    kwargs.update(fused=True, foreach=False, capturable=False)
+    return torch.optim.AdamW

--- a/megatron/plugin/override_registry.py
+++ b/megatron/plugin/override_registry.py
@@ -11,6 +11,16 @@ The ``@override`` decorator on the implementation function is no longer needed.
 
 from megatron.plugin.decorators import register
 
+# =============================================================================
+# Optimizer - NPU fused AdamW
+# =============================================================================
+register(
+    target="megatron.core.optimizer._get_adam_class",
+    impl="megatron.plugin.Ascend.optimizer.adamw.get_adam_class",
+    vendor="npu",
+)
+
+
 
 # =============================================================================
 # Optimizer - clip_grads

--- a/tests/unit_tests/optimizer/test_npu_adamw.py
+++ b/tests/unit_tests/optimizer/test_npu_adamw.py
@@ -1,0 +1,241 @@
+"""Dependency-free contract tests; these do not claim NPU numerical validation.
+
+Run directly with Python. The real override dispatcher and source functions are
+loaded in isolation, with hardware and tensor operations replaced by test doubles.
+"""
+
+import ast
+import copy
+import importlib.util
+import os
+from pathlib import Path
+import sys
+from types import ModuleType, SimpleNamespace
+import unittest
+from unittest.mock import patch
+
+
+ROOT = Path(__file__).resolve().parents[3]
+CORE = ROOT / "megatron/core/optimizer/__init__.py"
+DISTRIBUTED = ROOT / "megatron/core/optimizer/distrib_optimizer.py"
+PLUGIN = ROOT / "megatron/plugin/Ascend/optimizer/adamw.py"
+
+
+class Scalar:
+    def __init__(self, value, dtype="float32", device="cpu"):
+        self.value, self.dtype, self.device = value, dtype, device
+
+    def item(self):
+        return self.value
+
+    def detach(self):
+        return self
+
+    def clone(self):
+        return copy.copy(self)
+
+
+class Parameter:
+    def __init__(self, device="npu"):
+        self.device = SimpleNamespace(type=device)
+        self.data = self
+
+
+class Adam:
+    def __init__(self, values=(3, 3)):
+        self.state = {index: {"step": Scalar(value)} for index, value in enumerate(values)}
+        self.param_groups = [{"params": list(self.state)}]
+
+    def state_dict(self):
+        return copy.deepcopy({"state": self.state, "param_groups": self.param_groups})
+
+    def load_state_dict(self, state):
+        self.state = state["state"]
+        self.param_groups = state["param_groups"]
+
+
+class AdamW(Adam):
+    pass
+
+
+class FusedAdam:
+    def state_dict(self):
+        return {"state": {}, "param_groups": [{"params": [0], "step": 3}]}
+
+
+def source_function(path, name):
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    return next(node for node in ast.walk(tree) if isinstance(node, ast.FunctionDef) and node.name == name)
+
+
+def execute_function(node, namespace):
+    exec(compile(ast.Module(body=[copy.deepcopy(node)], type_ignores=[]), "<source>", "exec"), namespace)
+    return namespace[node.name]
+
+
+def load_module(name, path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+class NpuAdamWContractTest(unittest.TestCase):
+    def setUp(self):
+        self.env = patch.dict(os.environ, {"MG_FL_PREFER": "npu"})
+        self.env.start()
+        self.addCleanup(self.env.stop)
+        fake_torch = ModuleType("torch")
+        fake_torch.optim = SimpleNamespace(Adam=Adam, AdamW=AdamW)
+        fake_torch.npu = SimpleNamespace(is_available=lambda: True)
+        fake_torch.float32 = fake_torch.float = "float32"
+        fake_torch.tensor = lambda value, dtype: Scalar(value, dtype)
+        fake_torch.zeros = lambda shape, dtype, device: Scalar(0, dtype, device)
+        fake_torch.zeros_like = lambda value: Scalar(0)
+        self.torch = fake_torch
+        packages = {"torch": fake_torch}
+        for name in ("megatron", "megatron.plugin", "megatron.core", "megatron.plugin.Ascend",
+                     "megatron.plugin.Ascend.optimizer", "megatron.plugin.override_registry"):
+            packages[name] = ModuleType(name)
+            packages[name].__path__ = []
+        self.modules = patch.dict(sys.modules, packages)
+        self.modules.start()
+        self.addCleanup(self.modules.stop)
+        self.dispatcher = load_module("megatron.plugin.decorators", ROOT / "megatron/plugin/decorators.py")
+        self.core = ModuleType("megatron.core.optimizer")
+        self.core.__dict__.update(torch=fake_torch, overridable=self.dispatcher.overridable,
+                                  OptimizerConfig=object, Dict=dict, Any=object,
+                                  USING_PYTORCH_OPTIMIZER=False, Adam=FusedAdam)
+        sys.modules[self.core.__name__] = self.core
+        execute_function(source_function(CORE, "_get_adam_class"), self.core.__dict__)
+        self.plugin = load_module("megatron.plugin.Ascend.optimizer.adamw", PLUGIN)
+        registry = ast.parse((ROOT / "megatron/plugin/override_registry.py").read_text(encoding="utf-8"))
+        registration = next(
+            node for node in registry.body
+            if isinstance(node, ast.Expr) and isinstance(node.value, ast.Call)
+            and any(k.arg == "target" and isinstance(k.value, ast.Constant)
+                    and k.value.value == "megatron.core.optimizer._get_adam_class"
+                    for k in node.value.keywords)
+        )
+        exec(compile(ast.Module(body=[registration], type_ignores=[]), "<registry>", "exec"),
+             {"register": self.dispatcher.register})
+        self.config = SimpleNamespace(decoupled_weight_decay=True, optimizer_cuda_graph=False,
+                                      use_precision_aware_optimizer=False, optimizer_cpu_offload=False)
+        self.kwargs = {"params": [{"params": [Parameter()]}], "capturable": False}
+
+    def test_npu_dispatch_preserves_native_class_and_exact_options(self):
+        self.assertIs(self.core._get_adam_class(self.config, self.kwargs), AdamW)
+        self.assertEqual({k: self.kwargs[k] for k in ("fused", "foreach", "capturable")},
+                         {"fused": True, "foreach": False, "capturable": False})
+        self.assertNotIn("adam_w_mode", self.kwargs)
+
+    def test_explicit_default_uses_original_te_selection(self):
+        os.environ["MG_FL_PREFER"] = "default"
+        self.assertIs(self.core._get_adam_class(self.config, self.kwargs), FusedAdam)
+        self.assertTrue(self.kwargs["adam_w_mode"])
+        self.assertNotIn("fused", self.kwargs)
+
+    def test_native_default_selects_adam_or_adamw(self):
+        self.core.USING_PYTORCH_OPTIMIZER = True
+        original = self.core._get_adam_class.__wrapped__
+        self.assertIs(original(self.config, self.kwargs), AdamW)
+        self.config.decoupled_weight_decay = False
+        self.assertIs(original(self.config, self.kwargs), Adam)
+
+    def test_no_npu_falls_back_without_vendor_options(self):
+        del self.torch.npu
+        self.assertIs(self.plugin.get_adam_class(self.config, self.kwargs), FusedAdam)
+        self.assertNotIn("fused", self.kwargs)
+
+    def test_unavailable_npu_falls_back(self):
+        self.torch.npu.is_available = lambda: False
+        self.assertIs(self.plugin.get_adam_class(self.config, self.kwargs), FusedAdam)
+
+    def test_unsupported_modes_preserve_original_path(self):
+        for key, value in (("decoupled_weight_decay", False), ("optimizer_cuda_graph", True),
+                           ("use_precision_aware_optimizer", True), ("optimizer_cpu_offload", True)):
+            with self.subTest(key=key):
+                config = copy.copy(self.config)
+                setattr(config, key, value)
+                kwargs = copy.deepcopy(self.kwargs)
+                self.assertIs(self.plugin.get_adam_class(config, kwargs), FusedAdam)
+                self.assertNotIn("fused", kwargs)
+
+    def test_cpu_mixed_and_empty_params_do_not_select_npu(self):
+        for params in ([Parameter("cpu")], [Parameter(), Parameter("cpu")], []):
+            with self.subTest(params=params):
+                kwargs = {"params": [{"params": params}]}
+                self.assertIs(self.plugin.get_adam_class(self.config, kwargs), FusedAdam)
+
+    def distributed_function(self, name, have_te=True):
+        namespace = {"torch": self.torch, "HAVE_APEX_OR_TE": have_te,
+                     "HybridDeviceOptimizer": type("HybridDeviceOptimizer", (), {}),
+                     "USING_TE_OPTIMIZER": have_te, "USING_APEX_OPTIMIZER": False,
+                     "param_group_identifier_keys": []}
+        return execute_function(source_function(DISTRIBUTED, name), namespace)
+
+    def test_native_save_uses_instance_with_and_without_te(self):
+        for have_te in (True, False):
+            for cls in (Adam, AdamW):
+                with self.subTest(have_te=have_te, optimizer=cls):
+                    state = self.distributed_function("state_dict", have_te)(
+                        SimpleNamespace(optimizer=cls(), grad_scaler=None))
+                    self.assertEqual(state["optimizer"]["param_groups"][0]["step"], 3)
+
+    def test_empty_native_state_can_be_saved_at_step_zero(self):
+        state = self.distributed_function("state_dict")(
+            SimpleNamespace(optimizer=AdamW(values=()), grad_scaler=None))
+        self.assertEqual(state["optimizer"]["param_groups"][0]["step"], 0)
+
+    def test_inconsistent_parameter_steps_are_rejected(self):
+        with self.assertRaises(AssertionError):
+            self.distributed_function("state_dict")(
+                SimpleNamespace(optimizer=AdamW(values=(2, 3)), grad_scaler=None))
+
+    def test_te_save_still_reads_group_step(self):
+        state = self.distributed_function("state_dict")(
+            SimpleNamespace(optimizer=FusedAdam(), grad_scaler=None))
+        self.assertEqual(state["optimizer"]["param_groups"][0]["step"], 3)
+
+    def test_native_load_restores_distinct_step_scalars(self):
+        optimizer = AdamW(values=(0, 0))
+        receiver = SimpleNamespace(optimizer=optimizer, grad_scaler=None,
+                                   ddp_config=SimpleNamespace(use_megatron_fsdp=False),
+                                   config=SimpleNamespace(fp16=False))
+        self.distributed_function("load_state_dict")(
+            receiver, {"optimizer": {"param_groups": [{"step": 3}]}})
+        steps = [state["step"] for state in optimizer.state.values()]
+        self.assertEqual([step.item() for step in steps], [3, 3])
+        self.assertIsNot(steps[0], steps[1])
+        self.assertEqual(steps[0].dtype, "float32")
+
+    def test_native_init_creates_step_before_moments(self):
+        init = execute_function(source_function(CORE, "init_state_fn"), {"torch": self.torch})
+        for fused in (True, False):
+            optimizer, param = AdamW(values=()), Parameter()
+            optimizer.param_groups = [{"params": [param], "fused": fused}]
+            optimizer.state = {param: {}}
+            init(optimizer)
+            state = optimizer.state[param]
+            self.assertEqual(set(state), {"step", "exp_avg", "exp_avg_sq"})
+            self.assertEqual(state["step"].item(), 0)
+            self.assertEqual(state["step"].device, param.device if fused else "cpu")
+
+    def test_sharded_formats_already_handle_step_separately(self):
+        for name in ("sharded_param_state_fs_model_space",
+                     "load_parameter_state_from_fs_model_space",
+                     "load_parameter_state_from_fully_reshardable"):
+            with self.subTest(name=name):
+                node = source_function(DISTRIBUTED, name)
+                self.assertTrue(any(
+                    isinstance(branch, ast.If)
+                    and any(isinstance(value, ast.Constant) and value.value == "step"
+                            for value in ast.walk(branch.test))
+                    and any(isinstance(child, ast.Continue) for child in branch.body)
+                    for branch in ast.walk(node)
+                ))
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
Select TorchNPU fused AdamW through the Megatron optimizer override while preserving the original path for unsupported configurations. Handle native Adam step state and add contract tests for dispatch, fallback, initialization, and checkpoint metadata.

# Description

PR Description

## Type of change

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Infra/Build change (changes to CI/CD workflows or build scripts)
- [ ] Code refactoring
- [ ] Documentation change
- [ ] Bug fix
- [ ] Breaking change

## Changes

- Content 1
- Content 2
- Content 3
- Content 4

## Checklist

- [ ] I have read and followed the contributing guidelines
- [ ] The functionality is complete
- [ ] I have commented my code, particularly in coverage report uploading steps
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added/updated tests that prove my feature works
- [ ] New and existing unit tests pass locally
