### PR TITLE
feat(npu): enable fused AdamW through the Megatron optimizer override

### DIFF
--- a/megatron/core/optimizer/__init__.py
+++ b/megatron/core/optimizer/__init__.py
@@ -56,6 +56,7 @@ from megatron.core.optimizer_param_scheduler import (
 )
 from megatron.core.process_groups_config import ProcessGroupCollection
 from megatron.core.transformer.fsdp_dtensor_checkpoint import get_global_unique_param_name
+from megatron.plugin.decorators import overridable
 
 from ..distributed.param_and_grad_buffer import _ParamAndGradBuffer
 from ..transformer.module import MegatronModule
@@ -456,6 +457,15 @@ def _get_param_groups_and_buffers(
     return param_groups, buffers
 
 
+@overridable
+def _get_adam_class(config: OptimizerConfig, kwargs: Dict[str, Any]):
+    """Select the Adam implementation and its backend-specific arguments."""
+    if USING_PYTORCH_OPTIMIZER:
+        return torch.optim.AdamW if config.decoupled_weight_decay else torch.optim.Adam
+    kwargs["adam_w_mode"] = config.decoupled_weight_decay
+    return Adam
+
+
 def _get_megatron_optimizer_based_on_param_groups(
     config: OptimizerConfig,
     model_chunks: List[MegatronModule],
@@ -547,13 +557,7 @@ def _get_megatron_optimizer_based_on_param_groups(
                 "capturable": config.optimizer_cuda_graph,
             }
 
-            # set Adam class and weight decay mode depending
-            # on source of optimizer (Torch or TE/Apex)
-            if USING_PYTORCH_OPTIMIZER:
-                adam_cls = torch.optim.AdamW if config.decoupled_weight_decay else torch.optim.Adam
-            else:
-                kwargs["adam_w_mode"] = config.decoupled_weight_decay
-                adam_cls = Adam
+            adam_cls = _get_adam_class(config, kwargs)
 
             if config.use_precision_aware_optimizer:
                 kwargs.update(
@@ -586,6 +590,17 @@ def _get_megatron_optimizer_based_on_param_groups(
                     for p in group['params']:
                         if len(opt.state[p]) == 0:
                             if config is None or not config.use_precision_aware_optimizer:
+                                if isinstance(opt, (torch.optim.Adam, torch.optim.AdamW)):
+                                    # Native Adam keeps a scalar step per parameter, including
+                                    # when moments are initialized before checkpoint loading.
+                                    step_device = (
+                                        p.device
+                                        if group.get('fused', False) or group.get('capturable', False)
+                                        else 'cpu'
+                                    )
+                                    opt.state[p]['step'] = torch.zeros(
+                                        (), dtype=torch.float32, device=step_device
+                                    )
                                 opt.state[p]['exp_avg'] = torch.zeros_like(p.data)
                                 opt.state[p]['exp_avg_sq'] = torch.zeros_like(p.data)
                             else:

--- a/megatron/core/optimizer/distrib_optimizer.py
+++ b/megatron/core/optimizer/distrib_optimizer.py
@@ -672,11 +672,14 @@ class DistributedOptimizer(MixedPrecisionOptimizer):
         inner_state_dict = self.optimizer.state_dict()
         state_dict = {}
 
-        # Extract 'step', for non-Apex/TE support.
-        if not HAVE_APEX_OR_TE:
+        # State layout follows the optimizer instance, not installed optional packages.
+        native_torch_optimizer = isinstance(
+            self.optimizer, (torch.optim.Adam, torch.optim.AdamW)
+        )
+        if native_torch_optimizer or not HAVE_APEX_OR_TE:
             steps = list(set([s["step"].item() for s in inner_state_dict["state"].values()]))
-            assert len(steps) == 1
-            step = steps[0]
+            assert len(steps) <= 1, f"Inconsistent per-parameter steps: {steps}"
+            step = steps[0] if steps else 0
         elif isinstance(self.optimizer, HybridDeviceOptimizer):
             step = None
             for optimizer in self.optimizer.sub_optimizers:
@@ -705,7 +708,7 @@ class DistributedOptimizer(MixedPrecisionOptimizer):
         state_dict['optimizer'] = {k: v for k, v in inner_state_dict.items() if k != "state"}
         for param_group in state_dict["optimizer"]["param_groups"]:
             del param_group["params"]
-            if not HAVE_APEX_OR_TE:
+            if native_torch_optimizer or not HAVE_APEX_OR_TE:
                 # Native PyTorch param group requires step (i.e., iteration).
                 param_group["step"] = step
             elif (
@@ -852,15 +855,18 @@ class DistributedOptimizer(MixedPrecisionOptimizer):
             # Retrieve existing optimizer state.
             state_dict_state = inner_state_dict["state"]
 
-        # Extract 'step', for non-Apex/TE support.
-        if not HAVE_APEX_OR_TE:
+        # Restore native Adam state even when TE or Apex is available.
+        native_torch_optimizer = isinstance(
+            self.optimizer, (torch.optim.Adam, torch.optim.AdamW)
+        )
+        if native_torch_optimizer or not HAVE_APEX_OR_TE:
             steps = list(set([g["step"] for g in state_dict["optimizer"]["param_groups"]]))
             assert len(steps) == 1
             step = torch.tensor(steps[0], dtype=torch.float)
 
             for s in state_dict_state.values():
                 # Native PyTorch state dict requires step (i.e., iteration).
-                s["step"] = step
+                s["step"] = step.detach().clone()
         elif isinstance(self.optimizer, HybridDeviceOptimizer):
             # Handle Torch AdamW special case, which, unlike FusedAdam, Torch AdamW
             # has an extra optimizer state "step".

--- a/megatron/plugin/Ascend/optimizer/__init__.py
+++ b/megatron/plugin/Ascend/optimizer/__init__.py
@@ -1,0 +1,1 @@
+"""Ascend optimizer implementations."""

--- a/megatron/plugin/Ascend/optimizer/adamw.py
+++ b/megatron/plugin/Ascend/optimizer/adamw.py
@@ -1,0 +1,30 @@
+"""Select TorchNPU fused AdamW through the Megatron override interface."""
+
+import torch
+
+from megatron.core.optimizer import _get_adam_class
+
+
+def get_adam_class(config, kwargs):
+    """Use native fused AdamW only for supported, device-resident NPU parameters.
+
+    Parameter groups, distributed optimizer wrapping, and checkpoint handling
+    remain owned by core. Unsupported configurations retain the original path.
+    """
+    npu = getattr(torch, "npu", None)
+    supported = (
+        npu is not None
+        and npu.is_available()
+        and config.decoupled_weight_decay
+        and not config.optimizer_cuda_graph
+        and not config.use_precision_aware_optimizer
+        and not config.optimizer_cpu_offload
+    )
+    if supported:
+        params = [param for group in kwargs["params"] for param in group["params"]]
+        supported = bool(params) and all(param.device.type == "npu" for param in params)
+    if not supported:
+        return _get_adam_class.__wrapped__(config, kwargs)
+
+    kwargs.update(fused=True, foreach=False, capturable=False)
+    return torch.optim.AdamW

--- a/megatron/plugin/override_registry.py
+++ b/megatron/plugin/override_registry.py
@@ -11,6 +11,16 @@ The ``@override`` decorator on the implementation function is no longer needed.
 
 from megatron.plugin.decorators import register
 
+# =============================================================================
+# Optimizer - NPU fused AdamW
+# =============================================================================
+register(
+    target="megatron.core.optimizer._get_adam_class",
+    impl="megatron.plugin.Ascend.optimizer.adamw.get_adam_class",
+    vendor="npu",
+)
+
+
 
 # =============================================================================
 # Optimizer - clip_grads

--- a/tests/unit_tests/optimizer/test_npu_adamw.py
+++ b/tests/unit_tests/optimizer/test_npu_adamw.py
@@ -1,0 +1,241 @@
+"""Dependency-free contract tests; these do not claim NPU numerical validation.
+
+Run directly with Python. The real override dispatcher and source functions are
+loaded in isolation, with hardware and tensor operations replaced by test doubles.
+"""
+
+import ast
+import copy
+import importlib.util
+import os
+from pathlib import Path
+import sys
+from types import ModuleType, SimpleNamespace
+import unittest
+from unittest.mock import patch
+
+
+ROOT = Path(__file__).resolve().parents[3]
+CORE = ROOT / "megatron/core/optimizer/__init__.py"
+DISTRIBUTED = ROOT / "megatron/core/optimizer/distrib_optimizer.py"
+PLUGIN = ROOT / "megatron/plugin/Ascend/optimizer/adamw.py"
+
+
+class Scalar:
+    def __init__(self, value, dtype="float32", device="cpu"):
+        self.value, self.dtype, self.device = value, dtype, device
+
+    def item(self):
+        return self.value
+
+    def detach(self):
+        return self
+
+    def clone(self):
+        return copy.copy(self)
+
+
+class Parameter:
+    def __init__(self, device="npu"):
+        self.device = SimpleNamespace(type=device)
+        self.data = self
+
+
+class Adam:
+    def __init__(self, values=(3, 3)):
+        self.state = {index: {"step": Scalar(value)} for index, value in enumerate(values)}
+        self.param_groups = [{"params": list(self.state)}]
+
+    def state_dict(self):
+        return copy.deepcopy({"state": self.state, "param_groups": self.param_groups})
+
+    def load_state_dict(self, state):
+        self.state = state["state"]
+        self.param_groups = state["param_groups"]
+
+
+class AdamW(Adam):
+    pass
+
+
+class FusedAdam:
+    def state_dict(self):
+        return {"state": {}, "param_groups": [{"params": [0], "step": 3}]}
+
+
+def source_function(path, name):
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    return next(node for node in ast.walk(tree) if isinstance(node, ast.FunctionDef) and node.name == name)
+
+
+def execute_function(node, namespace):
+    exec(compile(ast.Module(body=[copy.deepcopy(node)], type_ignores=[]), "<source>", "exec"), namespace)
+    return namespace[node.name]
+
+
+def load_module(name, path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+class NpuAdamWContractTest(unittest.TestCase):
+    def setUp(self):
+        self.env = patch.dict(os.environ, {"MG_FL_PREFER": "npu"})
+        self.env.start()
+        self.addCleanup(self.env.stop)
+        fake_torch = ModuleType("torch")
+        fake_torch.optim = SimpleNamespace(Adam=Adam, AdamW=AdamW)
+        fake_torch.npu = SimpleNamespace(is_available=lambda: True)
+        fake_torch.float32 = fake_torch.float = "float32"
+        fake_torch.tensor = lambda value, dtype: Scalar(value, dtype)
+        fake_torch.zeros = lambda shape, dtype, device: Scalar(0, dtype, device)
+        fake_torch.zeros_like = lambda value: Scalar(0)
+        self.torch = fake_torch
+        packages = {"torch": fake_torch}
+        for name in ("megatron", "megatron.plugin", "megatron.core", "megatron.plugin.Ascend",
+                     "megatron.plugin.Ascend.optimizer", "megatron.plugin.override_registry"):
+            packages[name] = ModuleType(name)
+            packages[name].__path__ = []
+        self.modules = patch.dict(sys.modules, packages)
+        self.modules.start()
+        self.addCleanup(self.modules.stop)
+        self.dispatcher = load_module("megatron.plugin.decorators", ROOT / "megatron/plugin/decorators.py")
+        self.core = ModuleType("megatron.core.optimizer")
+        self.core.__dict__.update(torch=fake_torch, overridable=self.dispatcher.overridable,
+                                  OptimizerConfig=object, Dict=dict, Any=object,
+                                  USING_PYTORCH_OPTIMIZER=False, Adam=FusedAdam)
+        sys.modules[self.core.__name__] = self.core
+        execute_function(source_function(CORE, "_get_adam_class"), self.core.__dict__)
+        self.plugin = load_module("megatron.plugin.Ascend.optimizer.adamw", PLUGIN)
+        registry = ast.parse((ROOT / "megatron/plugin/override_registry.py").read_text(encoding="utf-8"))
+        registration = next(
+            node for node in registry.body
+            if isinstance(node, ast.Expr) and isinstance(node.value, ast.Call)
+            and any(k.arg == "target" and isinstance(k.value, ast.Constant)
+                    and k.value.value == "megatron.core.optimizer._get_adam_class"
+                    for k in node.value.keywords)
+        )
+        exec(compile(ast.Module(body=[registration], type_ignores=[]), "<registry>", "exec"),
+             {"register": self.dispatcher.register})
+        self.config = SimpleNamespace(decoupled_weight_decay=True, optimizer_cuda_graph=False,
+                                      use_precision_aware_optimizer=False, optimizer_cpu_offload=False)
+        self.kwargs = {"params": [{"params": [Parameter()]}], "capturable": False}
+
+    def test_npu_dispatch_preserves_native_class_and_exact_options(self):
+        self.assertIs(self.core._get_adam_class(self.config, self.kwargs), AdamW)
+        self.assertEqual({k: self.kwargs[k] for k in ("fused", "foreach", "capturable")},
+                         {"fused": True, "foreach": False, "capturable": False})
+        self.assertNotIn("adam_w_mode", self.kwargs)
+
+    def test_explicit_default_uses_original_te_selection(self):
+        os.environ["MG_FL_PREFER"] = "default"
+        self.assertIs(self.core._get_adam_class(self.config, self.kwargs), FusedAdam)
+        self.assertTrue(self.kwargs["adam_w_mode"])
+        self.assertNotIn("fused", self.kwargs)
+
+    def test_native_default_selects_adam_or_adamw(self):
+        self.core.USING_PYTORCH_OPTIMIZER = True
+        original = self.core._get_adam_class.__wrapped__
+        self.assertIs(original(self.config, self.kwargs), AdamW)
+        self.config.decoupled_weight_decay = False
+        self.assertIs(original(self.config, self.kwargs), Adam)
+
+    def test_no_npu_falls_back_without_vendor_options(self):
+        del self.torch.npu
+        self.assertIs(self.plugin.get_adam_class(self.config, self.kwargs), FusedAdam)
+        self.assertNotIn("fused", self.kwargs)
+
+    def test_unavailable_npu_falls_back(self):
+        self.torch.npu.is_available = lambda: False
+        self.assertIs(self.plugin.get_adam_class(self.config, self.kwargs), FusedAdam)
+
+    def test_unsupported_modes_preserve_original_path(self):
+        for key, value in (("decoupled_weight_decay", False), ("optimizer_cuda_graph", True),
+                           ("use_precision_aware_optimizer", True), ("optimizer_cpu_offload", True)):
+            with self.subTest(key=key):
+                config = copy.copy(self.config)
+                setattr(config, key, value)
+                kwargs = copy.deepcopy(self.kwargs)
+                self.assertIs(self.plugin.get_adam_class(config, kwargs), FusedAdam)
+                self.assertNotIn("fused", kwargs)
+
+    def test_cpu_mixed_and_empty_params_do_not_select_npu(self):
+        for params in ([Parameter("cpu")], [Parameter(), Parameter("cpu")], []):
+            with self.subTest(params=params):
+                kwargs = {"params": [{"params": params}]}
+                self.assertIs(self.plugin.get_adam_class(self.config, kwargs), FusedAdam)
+
+    def distributed_function(self, name, have_te=True):
+        namespace = {"torch": self.torch, "HAVE_APEX_OR_TE": have_te,
+                     "HybridDeviceOptimizer": type("HybridDeviceOptimizer", (), {}),
+                     "USING_TE_OPTIMIZER": have_te, "USING_APEX_OPTIMIZER": False,
+                     "param_group_identifier_keys": []}
+        return execute_function(source_function(DISTRIBUTED, name), namespace)
+
+    def test_native_save_uses_instance_with_and_without_te(self):
+        for have_te in (True, False):
+            for cls in (Adam, AdamW):
+                with self.subTest(have_te=have_te, optimizer=cls):
+                    state = self.distributed_function("state_dict", have_te)(
+                        SimpleNamespace(optimizer=cls(), grad_scaler=None))
+                    self.assertEqual(state["optimizer"]["param_groups"][0]["step"], 3)
+
+    def test_empty_native_state_can_be_saved_at_step_zero(self):
+        state = self.distributed_function("state_dict")(
+            SimpleNamespace(optimizer=AdamW(values=()), grad_scaler=None))
+        self.assertEqual(state["optimizer"]["param_groups"][0]["step"], 0)
+
+    def test_inconsistent_parameter_steps_are_rejected(self):
+        with self.assertRaises(AssertionError):
+            self.distributed_function("state_dict")(
+                SimpleNamespace(optimizer=AdamW(values=(2, 3)), grad_scaler=None))
+
+    def test_te_save_still_reads_group_step(self):
+        state = self.distributed_function("state_dict")(
+            SimpleNamespace(optimizer=FusedAdam(), grad_scaler=None))
+        self.assertEqual(state["optimizer"]["param_groups"][0]["step"], 3)
+
+    def test_native_load_restores_distinct_step_scalars(self):
+        optimizer = AdamW(values=(0, 0))
+        receiver = SimpleNamespace(optimizer=optimizer, grad_scaler=None,
+                                   ddp_config=SimpleNamespace(use_megatron_fsdp=False),
+                                   config=SimpleNamespace(fp16=False))
+        self.distributed_function("load_state_dict")(
+            receiver, {"optimizer": {"param_groups": [{"step": 3}]}})
+        steps = [state["step"] for state in optimizer.state.values()]
+        self.assertEqual([step.item() for step in steps], [3, 3])
+        self.assertIsNot(steps[0], steps[1])
+        self.assertEqual(steps[0].dtype, "float32")
+
+    def test_native_init_creates_step_before_moments(self):
+        init = execute_function(source_function(CORE, "init_state_fn"), {"torch": self.torch})
+        for fused in (True, False):
+            optimizer, param = AdamW(values=()), Parameter()
+            optimizer.param_groups = [{"params": [param], "fused": fused}]
+            optimizer.state = {param: {}}
+            init(optimizer)
+            state = optimizer.state[param]
+            self.assertEqual(set(state), {"step", "exp_avg", "exp_avg_sq"})
+            self.assertEqual(state["step"].item(), 0)
+            self.assertEqual(state["step"].device, param.device if fused else "cpu")
+
+    def test_sharded_formats_already_handle_step_separately(self):
+        for name in ("sharded_param_state_fs_model_space",
+                     "load_parameter_state_from_fs_model_space",
+                     "load_parameter_state_from_fully_reshardable"):
+            with self.subTest(name=name):
+                node = source_function(DISTRIBUTED, name)
+                self.assertTrue(any(
+                    isinstance(branch, ast.If)
+                    and any(isinstance(value, ast.Constant) and value.value == "step"
+                            for value in ast.walk(branch.test))
+                    and any(isinstance(child, ast.Continue) for child in branch.body)
+                    for branch in ast.walk(node)
+                ))
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
# 描述

通过 Megatron-LM-FL 现有的优化器 Override 机制，在昇腾 NPU 上启用
TorchNPU fused AdamW。

原有的 TransformerEngine FusedAdam 路径会把一次 AdamW 更新拆分成多个
NPU 操作。对于受支持的 NPU 配置，本次改动将选择：

```python
torch.optim.AdamW(fused=True, foreach=False, capturable=False)
```

在经过验证的 TorchNPU 软件栈上，这条路径会将优化器更新下发到
`aclnnApplyAdamWV2`。硬件相关的选择逻辑仍然放在 Ascend 插件中。
Megatron Core 只暴露一个可被 Override 的优化器工厂，并根据实际使用的
优化器实例处理原生 PyTorch Adam 状态。不受支持的配置继续使用原来的
优化器路径。

## 改动类型

- [x] 新功能（增加功能且不产生破坏性变更）
- [ ] 基础设施/构建变更（修改 CI/CD 工作流或构建脚本）
- [x] 代码重构
- [ ] 文档变更
- [x] Bug 修复
- [ ] 破坏性变更

## 改动内容

- 将 Adam 实现的选择逻辑抽取为可被 Override 的 `_get_adam_class` 工厂，
  同时保留默认的 PyTorch 和 TE/Apex 行为。
- 为 NPU fused AdamW 注册 Ascend 优化器 Override。
- 只对受支持且参数位于 NPU 上的参数组选择
  `torch.optim.AdamW(fused=True, foreach=False, capturable=False)`。
- 对不受支持的配置回退到原来的优化器选择路径。
- 在初始化优化器动量的同时初始化原生 Adam 的 step Tensor。
- 根据实际优化器实例保存和恢复优化器 step 状态，而不是根据环境中是否
  安装可选的 TE/Apex 软件包进行判断。
- 为原生 Adam 的每个参数恢复一个彼此独立的 step Tensor。
- 增加 14 项契约测试，覆盖优化器分发、回退、初始化、保存和恢复行为。

## 调用路径

优化前：

```text
Megatron 优化器工厂
  -> TransformerEngine/Apex FusedAdam
  -> 多个 NPU 优化器操作
  -> CANN kernels
```

优化后，在满足支持条件时：

```text
Megatron 优化器工厂
  -> Megatron-LM-FL Override 分发器
  -> Ascend 优化器插件
  -> torch.optim.AdamW(fused=True)
  -> TorchNPU aclnnApplyAdamWV2
```

回退路径：

```text
Megatron 优化器工厂
  -> Ascend Override 条件检查不通过
  -> 原始 _get_adam_class 实现
  -> 原始 PyTorch 或 TE/Apex 优化器路径
```

## 启用与回退条件

只有在以下条件全部满足时，才会选择 fused NPU 路径：

- `torch.npu` 存在，并且报告有可用的 NPU；
- 已启用解耦权重衰减；
- 优化器参数非空，并且全部位于 NPU 上；
- 已关闭优化器 CUDA Graph；
- 已关闭 precision-aware optimizer；
- 已关闭优化器 CPU offload。

通过 FlagOS 现有的硬件厂商偏好配置选择该 Override：

```text
MG_FL_PREFER=npu
```

本次改动没有新增 Megatron 命令行参数。不存在 NPU、NPU 不可用、使用普通
Adam、参数位于 CPU 或 CPU/NPU 混合设备、参数组为空、使用优化器 CUDA
Graph、precision-aware optimizer、CPU offload，或者显式选择默认硬件厂商
实现时，都会继续使用原来的优化器路径。

## 优化器状态兼容性

TransformerEngine FusedAdam 将优化器 step 保存在参数组中，而原生 PyTorch
AdamW 会为每个参数保存一个标量 step Tensor。本次改动根据实际优化器实例
确定状态布局，而不是根据环境中是否安装 TE 或 Apex 进行判断。同时，它会
为原生 Adam 的每个参数恢复一个独立的 step Tensor。现有 TE/Apex FusedAdam
状态处理路径保持不变。

## 验证环境

本次候选提交信息如下：

```text
官方 PR 基线：942e8f56912de527fa4333425a0357784f6ca781
候选提交：1aa11e11ec661dabbd6b08a9a92b9f3782594029
候选分支：HDU-Tiankuan/Megatron-LM-FL:czx
```

下述数值一致性、优化器状态恢复、训练、HBM、算子 Profile 和 14 项契约测试
结果均在当前候选源码环境中采集。候选提交 `1aa11e11` 基于当前官方 PR
基线，以一个带 sign-off 的提交包含了完整的 6 文件 AdamW 源码和契约测试
改动。

## 契约测试

无外部依赖的契约测试覆盖以下内容：

- NPU fused AdamW 分发，以及准确的 `fused`/`foreach`/`capturable` 参数；
- 显式选择默认硬件厂商实现时的回退；
- 原生 Adam 与 AdamW 的选择；
- 缺少 NPU 和 NPU 不可用时的回退；
- CUDA Graph、precision-aware optimizer 和 CPU offload 回退；
- CPU 参数、混合设备参数和空参数回退；
- 安装和未安装 TE 时原生 Adam 状态的保存；
- step 为 0 时的空原生优化器状态；
- 不一致的逐参数 step 检测；
- 现有 TE FusedAdam 参数组 step 处理；
- 原生优化器独立 step 的恢复；
- 原生优化器状态初始化；
- 现有分片状态格式对 step 的处理。

已记录的结果：

```text
候选提交契约测试：14/14 通过
服务器契约测试：14/14 通过
```

契约测试使用测试替身验证分发和优化器状态行为，不把这些结果作为真实 NPU
数值验证。真实 NPU 数值一致性结果在下文单独给出。

## NPU 数值一致性

验证环境：

| 项目 | 值 |
|---|---|
| 设备 | 昇腾 910C，8 张 NPU |
| Python | 3.12.13 |
| PyTorch | 2.7.1+cpu |
| torch-npu | 2.7.1.post6 |
| FlagScale | 1.0.0 |
| TransformerEngine-FL | dea7cd6c826d619e0a22c1a7c0fc1904a21b62d2 |

两步 NPU 一致性测试为原有 TE FusedAdam 路径和 TorchNPU fused AdamW 路径
使用相同的初始值和梯度。

| 状态 | 最大绝对误差 |
|---|---:|
| 参数 | 0 |
| `exp_avg` | 7.450580596923828e-9 |
| `exp_avg_sq` | 2.584420144557953e-8 |

误差容限为 `rtol=1e-5`，参数和 `exp_avg` 使用 `atol=1e-6`，
`exp_avg_sq` 使用 `atol=1e-7`。最终 step 为 2，数据类型为
`torch.float32`，设备为 `npu:0`。

## 优化器状态恢复

在 step 3 保存优化器元数据，然后在新进程中恢复，并继续训练至 step 6。
与连续执行 6 步的结果相比，恢复运行的参数、`exp_avg` 和 `exp_avg_sq`
误差均为 0。

该验证通过一个轻量 receiver 调用了真实的
`DistributedOptimizer.state_dict/load_state_dict` 元数据逻辑，但它不是
完整的 8-rank 分布式 checkpoint 文件存储测试。

## 性能

性能测试使用 8-rank 昇腾 910C Qwen3.5 L4/V1 packed 训练验证配置。该模型
配置只是验证负载，优化器选择逻辑没有硬编码到该层数配置中。统计范围为
step 3-100，并排除前两个预热 step。

| 指标 | TE FusedAdam 基线 | NPU fused AdamW |
|---|---:|---:|
| 平均迭代时间 | 2203.693 ms | 1778.186 ms |
| 迭代时间中位数 | 2225.350 ms | 1715.800 ms |
| P90 迭代时间 | 2645.500 ms | 2003.400 ms |
| P95 迭代时间 | 3055.000 ms | 2058.100 ms |
| 名义 tokens/s | 3717.396 | 4606.943 |
| 实际非 padding tokens/s | 3453.915 | 4280.412 |
| 完成 step | 100/100 | 100/100 |
| 跳过的迭代 | 0 | 0 |
| NaN 迭代 | 0 | 0 |

在该硬件、软件栈和验证负载下，平均迭代时间下降 19.31%，名义吞吐提高
23.93%，测得加速比为 1.239 倍。这些数值不代表所有模型或配置都能获得
相同的通用加速效果。

## 算子 Profile

单个优化器 step 的 Profile 使用 32 个 FP32 参数 Tensor，每个 Tensor 包含
4096 个元素。

| Profile 事件 | TE FusedAdam | NPU fused AdamW |
|---|---:|---:|
| `aclnnApplyAdamWV2` | 0 | 32 |
| Host Enqueue | 384 | 65 |
| Complete events | 3330 | 489 |

Profile 结果确认，优化后的路径会下发到 TorchNPU fused AdamW 算子，而不是
把每次更新拆分成多个基础 NPU 操作。

## 范围

本 PR 不会：

- 修改 FlagScale 调度；
- 增加模型专属的层数判断逻辑；
- 依赖 Qwen3.5 L4/V1 验证配置；
- 修改 TransformerEngine-FL；
- 直接导入 TransformerEngineNPU；
- 启用尚未支持的优化器模式；
- 改变原有回退行为。

可选的 FlagScale 配置只使用现有的硬件厂商偏好：

```yaml
experiment:
  envs:
    MG_FL_PREFER: npu
```

FlagScale 配置不属于本次 Megatron-LM-FL PR 的提交内容。

## 检查清单

- [x] 我已阅读并遵循贡献指南
- [x] 功能已经完成
- [x] 我已经为代码添加注释
- [ ] 我已经同步修改相应文档
- [x] 本次修改在已记录的验证运行中没有产生新的 warning
- [x] 我已经添加/更新能够证明该功能正常工作的测试
- [ ] 新增和现有单元测试均已在本地通过

文档说明：本次改动没有新增 CLI 参数。启用条件、回退条件、验证信息和限制
均记录在本 PR 描述中。
