### PR TITLE
fix(platform): platformize hardcoded CUDA references for v0.18.2 (MUSA)

### DIFF
--- a/megatron/core/jit.py
+++ b/megatron/core/jit.py
@@ -18,7 +18,17 @@ def enable_jit_fuser():
     global jit_fuser
     try:
         if is_torch_min_version("2.2.0a0"):
-            jit_fuser = torch.compile
+            from megatron.plugin.platform.platform_manager import get_platform
+
+            # JIT fusion (bias+gelu / bias+dropout+add / fused cross-entropy)
+            # is a CUDA-only optimization. On non-CUDA platforms torch.compile
+            # routes through the inductor, whose autotuner needs a platform
+            # triton backend (triton.backends.mtgpu for MUSA) that isn't
+            # guaranteed importable — keep the plain eager functions.
+            if get_platform().device_name() == "cuda":
+                jit_fuser = torch.compile
+            else:
+                jit_fuser = noop_decorator
     except ImportError:
 
         jit_fuser = noop_decorator

--- a/megatron/core/optimizer/clip_grads.py
+++ b/megatron/core/optimizer/clip_grads.py
@@ -112,7 +112,7 @@ def get_grad_norm_fp32(
     # Calculate norm.
     if norm_type == inf:
         total_norm = max(grad.abs().max() for grad in grads_for_norm)
-        total_norm_cuda = torch.tensor([float(total_norm)], dtype=torch.float, device='cuda')
+        total_norm_cuda = torch.tensor([float(total_norm)], dtype=torch.float, device=cur_platform.device(cur_platform.current_device()))
         # Take max across all data-parallel GPUs if using FSDP and then all model-parallel GPUs.
         if data_parallel_group:
             torch.distributed.all_reduce(
@@ -125,7 +125,7 @@ def get_grad_norm_fp32(
 
     else:
         if norm_type == 2.0:
-            dummy_overflow_buf = torch.zeros(1, dtype=torch.int, device='cuda')
+            dummy_overflow_buf = torch.zeros(1, dtype=torch.int, device=cur_platform.device(cur_platform.current_device()))
             # Use apex's multi-tensor applier for efficiency reasons.
             # Multi-tensor applier takes a function and a list of list
             # and performs the operation on that list all in one kernel.
@@ -137,7 +137,7 @@ def get_grad_norm_fp32(
                     False,  # no per-parameter norm
                 )
             else:
-                grad_norm = torch.zeros(1, dtype=torch.float, device='cuda')
+                grad_norm = torch.zeros(1, dtype=torch.float, device=cur_platform.device(cur_platform.current_device()))
             # Since we will be summing across data parallel groups,
             # we need the pow(norm-type).
             total_norm = grad_norm**norm_type
@@ -206,7 +206,7 @@ def clip_grad_by_total_norm_fp32(
 
     # Scale.
     clip_coeff = max_norm / (total_norm + 1.0e-6)
-    dummy_overflow_buf = torch.zeros(1, dtype=torch.int, device='cuda')
+    dummy_overflow_buf = torch.zeros(1, dtype=torch.int, device=cur_platform.device(cur_platform.current_device()))
     if isinstance(clip_coeff, torch.Tensor):
         clip_coeff.clamp_max_(1.0)
         assert (

--- a/megatron/core/rerun_state_machine.py
+++ b/megatron/core/rerun_state_machine.py
@@ -267,11 +267,11 @@ class RerunStateMachine:
         For multiple inputs, returns a tuple.
         """
         if isinstance(value, list):
-            val_tensor: torch.Tensor = torch.tensor(value, dtype=torch.int32, device='cuda')
+            val_tensor: torch.Tensor = torch.tensor(value, dtype=torch.int32, device=cur_platform.device(cur_platform.current_device()))  # FlagScale Modify
             torch.distributed.all_reduce(val_tensor)
             return tuple([x > 0 for x in val_tensor.tolist()])
         else:
-            val_tensor: torch.Tensor = torch.tensor([value], dtype=torch.int32, device='cuda')
+            val_tensor: torch.Tensor = torch.tensor([value], dtype=torch.int32, device=cur_platform.device(cur_platform.current_device()))  # FlagScale Modify
             torch.distributed.all_reduce(val_tensor)
             return val_tensor.item() > 0
 

--- a/megatron/core/utils.py
+++ b/megatron/core/utils.py
@@ -1215,7 +1215,9 @@ def local_multi_tensor_l2_norm(chunk_size, noop_flag, tensor_lists, per_tensor, 
     """
     l2 = [[(torch.norm(tensor)) for tensor in tensor_list] for tensor_list in tensor_lists]
     l2_reduced = torch.norm(torch.tensor(l2))
-    l2_cuda = torch.tensor([float(l2_reduced)], dtype=torch.float, device="cuda")
+    l2_cuda = torch.tensor(
+        [float(l2_reduced)], dtype=torch.float, device=cur_platform.device(cur_platform.current_device())
+    )
     return l2_cuda, None
 
 

--- a/megatron/training/config/common_config.py
+++ b/megatron/training/config/common_config.py
@@ -71,7 +71,7 @@ class ProfilingConfig:
 class DistributedInitConfig:
     """Configuration settings for distributed training initialization."""
 
-    distributed_backend: Literal["nccl", "gloo"] = "nccl"
+    distributed_backend: Literal["nccl", "gloo", "mccl"] = "nccl"
     """Which backend to use for distributed training."""
 
     distributed_timeout_minutes: int = 10

--- a/megatron/training/initialize.py
+++ b/megatron/training/initialize.py
@@ -54,8 +54,11 @@ def initialize_megatron(
     (optionally, only when args.lazy_mpu_init == True)
     """
     if not allow_no_cuda:
-        # Make sure cuda is available.
-        assert torch.cuda.is_available(), "Megatron requires CUDA."
+        # Make sure a supported accelerator platform is available.
+        # (fork: CUDA assert generalized to registered FlagOS platforms -- musa/npu/etc.)
+        from megatron.plugin.platform.platform_manager import is_current_platform_supported
+
+        assert is_current_platform_supported(), "Megatron requires CUDA or a supported FlagOS platform."
 
     args = get_args()
 
@@ -247,7 +250,10 @@ def _initialize_distributed(get_embedding_ranks, get_position_embedding_ranks, s
     """Initialize torch.distributed and core model parallel."""
     args = get_args()
 
-    device_count = torch.cuda.device_count()
+    from megatron.plugin.platform.platform_manager import get_platform
+
+    platform = get_platform()
+    device_count = platform.device_count()
     if torch.distributed.is_initialized():
 
         print_rank_0("torch distributed is already initialized, skipping initialization ...")
@@ -259,8 +265,8 @@ def _initialize_distributed(get_embedding_ranks, get_position_embedding_ranks, s
         print_rank_0("> initializing torch distributed ...")
         # Manually set the device ids.
         if device_count > 0:
-            torch.cuda.set_device(args.local_rank)
-            device_id = torch.device(f'cuda:{args.local_rank}')
+            platform.set_device(args.local_rank)
+            device_id = platform.device(args.local_rank)
         else:
             device_id = None
 
@@ -395,7 +401,9 @@ def _set_random_seed(
         random.seed(seed)
         np.random.seed(seed)
         torch.manual_seed(seed)
-        if torch.cuda.device_count() > 0:
+        from megatron.plugin.platform.platform_manager import get_platform
+
+        if get_platform().device_count() > 0:
             tensor_parallel.model_parallel_cuda_manual_seed(
                 seed, te_rng_tracker, inference_rng_tracker, use_cudagraphable_rng
             )
@@ -438,6 +446,14 @@ def set_jit_fusion_options():
 
 def _warmup_jit_function():
     """Compilie JIT functions before the main training steps"""
+    from megatron.plugin.platform.platform_manager import get_platform
+
+    # JIT fusion warmup is CUDA-only (nvfuser / legacy JIT fuser). On other
+    # platforms the fused ops don't exist and torch.rand(..., device="cuda")
+    # can't even allocate — --disable-jit-fuser doesn't help because
+    # set_jit_fusion_options() calls this unconditionally.
+    if get_platform().device_name() != "cuda":
+        return
     args = get_args()
     if args.bf16:
         dtype = torch.bfloat16

--- a/megatron/training/training.py
+++ b/megatron/training/training.py
@@ -146,6 +146,9 @@ from megatron.core.full_cuda_graph import FullCudaGraphWrapper
 from megatron.core.models.gpt.experimental_attention_variant_module_specs import (
     is_linear_attention_variant,
 )
+from megatron.plugin.platform.platform_manager import get_platform
+
+cur_platform = get_platform()
 from megatron.core.optimizer import get_mup_config_overrides, get_standard_config_overrides
 from megatron.core.optimizer.optimizer import param_group_identifier_keys
 from megatron.core.optimizer.optimizer_cuda_graph import OptimizerCudaGraphWrapper
@@ -1129,15 +1132,19 @@ def pretrain(
     pretrain_entry = _STARTUP_TIMESTAMPS.get('pretrain_entry')
 
     # Initialize program_start_global with a fallback value in case set_startup_timestamps() wasn't called
+    from megatron.plugin.platform.platform_manager import get_platform
+
+    platform = get_platform()
+    timestamp_device = platform.device(args.local_rank)
     program_start_global = _TRAIN_START_TIME
     if _STARTUP_TIMESTAMPS['program_start'] is not None:
-        program_start_global = torch.tensor([_STARTUP_TIMESTAMPS['program_start']], dtype=torch.double, device='cuda')
+        program_start_global = torch.tensor([_STARTUP_TIMESTAMPS['program_start']], dtype=torch.double, device=timestamp_device)
         torch.distributed.all_reduce(program_start_global, op=torch.distributed.ReduceOp.MIN)
         program_start_global = program_start_global.item()
     set_startup_timestamps(program_start=program_start_global)
 
     global _LEGACY_TRAIN_START_TIME
-    start_time_tensor = torch.tensor([_LEGACY_TRAIN_START_TIME], dtype=torch.double, device='cuda')
+    start_time_tensor = torch.tensor([_LEGACY_TRAIN_START_TIME], dtype=torch.double, device=timestamp_device)
     torch.distributed.all_reduce(start_time_tensor, op=torch.distributed.ReduceOp.MIN)
     _LEGACY_TRAIN_START_TIME = start_time_tensor.item()
 
@@ -1621,6 +1628,9 @@ def wrap_model_chunks_with_ddp(
 
 def get_model(model_provider_func, model_type=ModelType.encoder_or_decoder, wrap_with_ddp=True, config=None, pg_collection=None):
     """Build the model."""
+    from megatron.plugin.platform.platform_manager import get_platform
+
+    platform = get_platform()
     args = get_args()
     args.model_type = model_type
     if pg_collection is None:
@@ -1730,7 +1740,7 @@ def get_model(model_provider_func, model_type=ModelType.encoder_or_decoder, wrap
         and not args.init_model_with_meta_device
     ):
         for model_module in model:
-            model_module.cuda(torch.cuda.current_device())
+            model_module.to(platform.device(args.local_rank))
 
     # Fp16 conversion.
     if args.fp16 or args.bf16:
@@ -1739,7 +1749,7 @@ def get_model(model_provider_func, model_type=ModelType.encoder_or_decoder, wrap
 
     # Materialize tensors on meta device (GPU allocation) if not using FSDP2 and not using Megatron FSDP.
     if args.init_model_with_meta_device and not args.use_torch_fsdp2 and not args.use_megatron_fsdp:
-        model = [to_empty_if_meta_device(model_module, device=torch.device("cuda")) for model_module in model]
+        model = [to_empty_if_meta_device(model_module, device=platform.device(args.local_rank)) for model_module in model]
 
     # Before TE2.x: The model_module.bfloat16()/model_module.half() above will call the inplace
     #               copy of TE's Float8Tensor, which will write an unwanted value (amax calculated
@@ -1792,11 +1802,12 @@ def get_model(model_provider_func, model_type=ModelType.encoder_or_decoder, wrap
 
         # Setup stream for ddp initialization. The side-stream may be necessary for cuda graph
         #  capture support with DDP, but we sync it with the current stream to avoid races.
-        ddp_stream = torch.cuda.Stream()
+        stream_mod = torch.musa if platform.device_name() != "cuda" else torch.cuda
+        ddp_stream = stream_mod.Stream()
         # Wait for the default stream to complete before starting ddp_stream
-        ddp_stream.wait_stream(torch.cuda.current_stream())
+        ddp_stream.wait_stream(stream_mod.current_stream())
         # Make ddp_stream start after whatever the default stream already queued
-        with torch.cuda.stream(ddp_stream):
+        with stream_mod.stream(ddp_stream):
             model = wrap_model_chunks_with_ddp(
                 model,
                 config,
@@ -1814,7 +1825,7 @@ def get_model(model_provider_func, model_type=ModelType.encoder_or_decoder, wrap
             )
         # End of setup_stream
         # Critical: ensure side-stream work completes before touching params on default stream
-        torch.cuda.current_stream().wait_stream(ddp_stream)
+        stream_mod.current_stream().wait_stream(ddp_stream)
 
         # Broadcast params from data parallel src rank to other data parallel ranks.
         if args.data_parallel_random_init:
@@ -2134,7 +2145,7 @@ def dummy_train_step(data_iterator):
             if tp_rank == 0:
                 batch = next(data_iterator)
                 for key in BATCH_KEYS:
-                    batch[key] = batch[key].cuda(non_blocking=True) if key in batch and batch[key] is not None else None
+                    batch[key] = batch[key].to(cur_platform.current_device(), non_blocking=True) if key in batch and batch[key] is not None else None
             batch = get_batch_on_this_tp_rank(
                 batch,
                 broadcast_src_rank=mpu.get_tensor_model_parallel_src_rank(),
@@ -2403,7 +2414,7 @@ def training_log(
     for key in loss_dict:
         if not skipped_iter:
             total_loss_dict[key] = (
-                total_loss_dict.get(key, torch.tensor([0.0], dtype=torch.float, device='cuda'))
+                total_loss_dict.get(key, torch.tensor([0.0], dtype=torch.float, device=cur_platform.device(cur_platform.current_device())))
                 + loss_dict[key]
             )
         else:
@@ -2664,7 +2675,7 @@ def training_log(
                 if avg >= 0.0:
                     log_string += ' {}: {:.6E} |'.format(key, avg)
                 if should_reset:
-                    total_loss_dict[key] = torch.tensor([0.0], dtype=torch.float, device='cuda')
+                    total_loss_dict[key] = torch.tensor([0.0], dtype=torch.float, device=cur_platform.device(cur_platform.current_device()))
         if args.num_experts is not None and moe_log_string:
             log_string += moe_log_string
         log_string += f' loss scale: {loss_scale:.1f} |'
@@ -2889,7 +2900,7 @@ def post_training_step_callbacks(
 
     # Bring CPU and GPU back in sync if on right iteration.
     if args.train_sync_interval and iteration % args.train_sync_interval == 0:
-        torch.cuda.synchronize()
+        cur_platform.synchronize()
 
     # Straggler detector.
     if iteration % args.log_interval == 0 and args.log_straggler:
@@ -3020,7 +3031,7 @@ def checkpoint_and_decide_exit(
     if args.exit_duration_in_mins:
         train_time = (time.time() - _TRAIN_START_TIME) / 60.0
         done_cuda = torch.tensor(
-            [train_time > args.exit_duration_in_mins], dtype=torch.int, device='cuda'
+            [train_time > args.exit_duration_in_mins], dtype=torch.int, device=cur_platform.device(cur_platform.current_device())
         )
         torch.distributed.all_reduce(done_cuda, op=torch.distributed.ReduceOp.MAX)
         done = done_cuda.item()
@@ -3922,7 +3933,7 @@ def evaluate(
                 # Reduce across processes.
                 for key in loss_dicts[0].keys():
                     if key not in total_loss_dict:
-                        total_loss_dict[key] = torch.tensor([0.0, 0.0], dtype=torch.float, device='cuda')
+                        total_loss_dict[key] = torch.tensor([0.0, 0.0], dtype=torch.float, device=cur_platform.device(cur_platform.current_device()))
                     val = [x[key].view(-1) for x in loss_dicts]
 
                     if val[0].numel() == 2:
@@ -3959,7 +3970,7 @@ def evaluate(
             if args.exit_duration_in_mins:
                 train_time = (time.time() - _TRAIN_START_TIME) / 60.0
                 done_cuda = torch.tensor(
-                    [train_time > args.exit_duration_in_mins], dtype=torch.int, device='cuda'
+                    [train_time > args.exit_duration_in_mins], dtype=torch.int, device=cur_platform.device(cur_platform.current_device())
                 )
                 torch.distributed.all_reduce(done_cuda, op=torch.distributed.ReduceOp.MAX)
                 done = done_cuda.item()
@@ -4033,9 +4044,9 @@ def evaluate_and_print_results(
 
         # with full validation we need to distribute eval_iters to all ranks
         if mpu.get_tensor_model_parallel_rank() == 0:
-            eval_iters = torch.tensor(args.eval_iters, dtype=torch.long, device='cuda')
+            eval_iters = torch.tensor(args.eval_iters, dtype=torch.long, device=cur_platform.device(cur_platform.current_device()))
         else:
-            eval_iters = torch.tensor([0] * len(eval_iters), dtype=torch.long, device='cuda')
+            eval_iters = torch.tensor([0] * len(eval_iters), dtype=torch.long, device=cur_platform.device(cur_platform.current_device()))
         torch.distributed.broadcast(eval_iters, 0)
         eval_iters = eval_iters.tolist()
         args.eval_iters = eval_iters[0] if not args.multiple_validation_sets else eval_iters
@@ -4172,6 +4183,10 @@ def build_train_valid_test_data_loaders(build_train_valid_test_datasets_provider
 
     args = get_args()
 
+    from megatron.plugin.platform.platform_manager import get_platform
+
+    timestamp_device = get_platform().device(args.local_rank)
+
     (train_dataloader, valid_dataloaders, test_dataloader) = (None, None, None)
 
     print_rank_0('> building train, validation, and test datasets ...')
@@ -4242,10 +4257,10 @@ def build_train_valid_test_data_loaders(build_train_valid_test_datasets_provider
             do_test = test_dataloader is not None and (args.full_validation or args.eval_iters > 0)
 
         flags = torch.tensor(
-            [int(do_train), int(do_valid), int(do_test)], dtype=torch.long, device='cuda'
+            [int(do_train), int(do_valid), int(do_test)], dtype=torch.long, device=timestamp_device
         )
     else:
-        flags = torch.tensor([0, 0, 0], dtype=torch.long, device='cuda')
+        flags = torch.tensor([0, 0, 0], dtype=torch.long, device=timestamp_device)
 
     torch.distributed.broadcast(flags, 0)
 
@@ -4298,7 +4313,7 @@ def build_train_valid_test_data_iterators(build_train_valid_test_datasets_provid
                     args.eval_iters = [None] * len(valid_dataloaders)
                 else:
                     local_eval_iters = [len(dl) for dl in valid_dataloaders]
-                    eval_iters_tensor = torch.tensor(local_eval_iters, dtype=torch.long, device='cuda')
+                    eval_iters_tensor = torch.tensor(local_eval_iters, dtype=torch.long, device=cur_platform.device(cur_platform.current_device()))
                     torch.distributed.all_reduce(
                         eval_iters_tensor,
                         op=torch.distributed.ReduceOp.MAX,
@@ -4307,7 +4322,7 @@ def build_train_valid_test_data_iterators(build_train_valid_test_datasets_provid
                     args.eval_iters = eval_iters_tensor.tolist()
             else:
                 local_eval_iters = len(valid_dataloaders[0])
-                eval_iters_tensor = torch.tensor([local_eval_iters], dtype=torch.long, device='cuda')
+                eval_iters_tensor = torch.tensor([local_eval_iters], dtype=torch.long, device=cur_platform.device(cur_platform.current_device()))
                 torch.distributed.all_reduce(
                     eval_iters_tensor,
                     op=torch.distributed.ReduceOp.MAX,

--- a/megatron/training/utils/common_utils.py
+++ b/megatron/training/utils/common_utils.py
@@ -13,6 +13,9 @@ import torch
 
 from megatron.core.msc_utils import open_file
 from megatron.core._rank_utils import safe_get_rank as _safe_get_rank
+from megatron.plugin.platform.platform_manager import get_platform
+
+cur_platform = get_platform()
 from megatron.core.dist_checkpointing.strategies.nvrx import has_nvrx_async_support
 
 from megatron.core._slurm_utils import resolve_slurm_local_rank
@@ -117,14 +120,14 @@ def calc_params_l2_norm(model, force_create_fp32_copy=False):
                         params_data.append(param.data)
 
     # Calculate norm.
-    dummy_overflow_buf = torch.tensor([0], dtype=torch.int, device='cuda')
+    dummy_overflow_buf = torch.tensor([0], dtype=torch.int, device=cur_platform.device(cur_platform.current_device()))
     if len(params_data) > 0:
         norm, _ = multi_tensor_applier(
             multi_tensor_l2norm, dummy_overflow_buf, [params_data], False  # no per-parameter norm.
         )
         norm_2 = norm * norm
     else:
-        norm_2 = torch.zeros((1,), dtype=torch.float32, device='cuda')
+        norm_2 = torch.zeros((1,), dtype=torch.float32, device=cur_platform.device(cur_platform.current_device()))
 
     if data_parallel_group is not None:
         torch.distributed.all_reduce(
@@ -135,7 +138,7 @@ def calc_params_l2_norm(model, force_create_fp32_copy=False):
     # accumulated across the DP group since the main parameters are sharded because
     # of distributed optimizer.
     if len(sharded_params_data) > 0:
-        dummy_overflow_buf = torch.tensor([0], dtype=torch.int, device='cuda')
+        dummy_overflow_buf = torch.tensor([0], dtype=torch.int, device=cur_platform.device(cur_platform.current_device()))
         sharded_norm, _ = multi_tensor_applier(
             multi_tensor_l2norm,
             dummy_overflow_buf,
@@ -144,7 +147,7 @@ def calc_params_l2_norm(model, force_create_fp32_copy=False):
         )
         sharded_norm_2 = sharded_norm * sharded_norm
     else:
-        sharded_norm_2 = torch.zeros((1,), dtype=torch.float32, device='cuda')
+        sharded_norm_2 = torch.zeros((1,), dtype=torch.float32, device=cur_platform.device(cur_platform.current_device()))
     # Sum over all DP groups, including CP since distributed optimizer state is
     # sharded jointly over DP+CP.
     torch.distributed.all_reduce(
@@ -203,12 +206,12 @@ def calc_dtensor_params_l2_norm(params):
     for param in params:
         params_data[param._spec].append(param._local_tensor)
 
-    total_norm_2 = torch.zeros((1,), dtype=torch.float32, device='cuda')
-    dummy_overflow_buf = torch.zeros((1,), dtype=torch.int, device='cuda')
+    total_norm_2 = torch.zeros((1,), dtype=torch.float32, device=cur_platform.device(cur_platform.current_device()))
+    dummy_overflow_buf = torch.zeros((1,), dtype=torch.int, device=cur_platform.device(cur_platform.current_device()))
     for dtensor_spec, local_tensors in params_data.items():
         local_tensors = [t for t in local_tensors if t.numel() > 0]
         if len(local_tensors) == 0:
-            norm = torch.zeros((1,), dtype=torch.float32, device='cuda')
+            norm = torch.zeros((1,), dtype=torch.float32, device=cur_platform.device(cur_platform.current_device()))
         else:
             norm, _ = multi_tensor_applier(
                 multi_tensor_l2norm, dummy_overflow_buf, [local_tensors], False  # no per-parameter norm.
@@ -253,7 +256,7 @@ def reduce_max_stat_across_model_parallel_group(stat: float) -> float | None:
     """
     if stat is None:
         stat = -1.0
-    stat = torch.tensor([stat], dtype=torch.float32, device=torch.cuda.current_device())
+    stat = torch.tensor([stat], dtype=torch.float32, device=cur_platform.device(cur_platform.current_device()))
     torch.distributed.all_reduce(
         stat, op=torch.distributed.ReduceOp.MAX, group=mpu.get_model_parallel_group()
     )
@@ -272,7 +275,7 @@ def logical_and_across_model_parallel_group(input: bool) -> bool:
         input = 1
     else:
         input = 0
-    input = torch.tensor([input], dtype=torch.int, device=torch.cuda.current_device())
+    input = torch.tensor([input], dtype=torch.int, device=cur_platform.device(cur_platform.current_device()))
     torch.distributed.all_reduce(
         input, op=torch.distributed.ReduceOp.MIN, group=mpu.get_model_parallel_group()
     )

--- a/pretrain_gpt.py
+++ b/pretrain_gpt.py
@@ -79,6 +79,9 @@ def get_batch(data_iterator, vp_stage: Optional[int] = None):
     BATCH_KEYS = ["attention_mask", "cu_seqlens", "cu_seqlens_padded", "hybrid_cp_group", "labels", "local_cp_size", "loss_mask", "max_seqlen", "position_ids", "tokens"]
 
     args = get_args()
+    from megatron.plugin.platform.platform_manager import get_platform
+
+    device = get_platform().device(args.local_rank)
     config = core_transformer_config_from_args(args)
 
     cp_size = args.context_parallel_size
@@ -95,7 +98,7 @@ def get_batch(data_iterator, vp_stage: Optional[int] = None):
     if tp_rank == 0:
         batch = next(data_iterator)
         for key in BATCH_KEYS:
-            batch[key] = batch[key].cuda(non_blocking=True) if key in batch and batch[key] is not None else None
+            batch[key] = batch[key].to(device, non_blocking=True) if key in batch and batch[key] is not None else None
 
     batch = get_batch_on_this_tp_rank(batch, broadcast_src_rank=mpu.get_tensor_model_parallel_src_rank(), broadcast_group=mpu.get_tensor_model_parallel_group(), is_sft=is_sft, is_hybrid_cp=is_hybrid_cp, create_attention_mask_in_dataloader=create_attention_mask_in_dataloader, cp_size=cp_size, tp_rank=tp_rank, micro_batch_size=args.micro_batch_size, seq_length=args.seq_length, mtp_on_this_rank=mtp_on_this_rank, pipeline_model_parallel_size=args.pipeline_model_parallel_size, is_pipeline_first_stage=mpu.is_pipeline_first_stage(), is_pipeline_last_stage=mpu.is_pipeline_last_stage())
     


### PR DESCRIPTION
Fixes #171

## Summary

The v0.18.2 upgrade (PR #109) brought new upstream code paths that were never
CUDA-gated. On MUSA (cp310), the torch build is not linked with CUDA support, so
any unconditional `device='cuda'` tensor allocation raises
(`RuntimeError: PyTorch is not linked with support for cuda devices`) and
`torch.cuda.synchronize()` raises (`PyTorch was compiled without CUDA support`).
The tensors in question also feed torch.distributed, which on MUSA uses the MCCL
backend and requires MUSA tensors.

This PR platformizes the remaining hardcoded CUDA references across the
training and core paths using the fork's existing platform manager
(`megatron/plugin/platform/`). On CUDA every change is behavior-identical
(`device_name() == "cuda"`).

## Changes

- `megatron/training/config/common_config.py` — allow `mccl` as a distributed
  backend (`Literal["nccl", "gloo", "mccl"]`). MUSA uses MCCL.
- `megatron/training/initialize.py` — replace `assert torch.cuda.is_available()`
  with `is_current_platform_supported()`; platformize device selection in
  `_initialize_distributed`, the random-seed CUDA gate, and the CUDA-only early
  return in `_warmup_jit_function`.
- `megatron/training/training.py` — module-level `cur_platform = get_platform()`;
  platformize training-log loss accumulators, `post_training_step` synchronize,
  exit-duration tensors, eval-iter broadcasts, and `get_batch` device transfer.
- `megatron/training/utils/common_utils.py` — module-level `cur_platform`;
  platformize all `device='cuda'` / `cuda.current_device()` references.
- `megatron/core/jit.py` — enable the torch.compile fuser only when
  `device_name() == "cuda"`.
- `megatron/core/rerun_state_machine.py`, `megatron/core/utils.py`,
  `megatron/core/optimizer/clip_grads.py` — platformize all-reduce and L2-norm
  tensors via the module-level `cur_platform`.
- `pretrain_gpt.py` — platformize `get_batch` device transfer.

## Verification

- E2E GPT pretrain via `python3 -m pretrain_gpt`, 5 iterations + validation,
  on MUSA (MTT, cp310) with `--distributed-backend mccl` — all iterations and
  validation completed.
- FlagTree (F) path verified on the exact wheel. Triton (T) path pending
  re-verification on this wheel.
- 15 container patches derived from this work are indexed under
  `megatron/plugin/platform/` (see patch 15 note: `torch.musa.synchronize` is
  unavailable, hence `cur_platform.synchronize()`).

This PR was written in part with the assistance of generative AI.
