### PR TITLE
[CICD] Add retry mechanism for TE-FL prepare checkout steps

### DIFF
--- a/.github/workflows/prepare_te_fl.yml
+++ b/.github/workflows/prepare_te_fl.yml
@@ -119,12 +119,54 @@ jobs:
     outputs:
       cache_key: ${{ steps.cache_key.outputs.key }}
     steps:
-      - name: Checkout Megatron source
+      - name: Checkout Megatron source (attempt 1)
+        id: checkout_megatron_1
+        continue-on-error: true
         uses: actions/checkout@v4
         with:
           fetch-depth: 1
 
-      - name: Checkout TransformerEngine-FL
+      - name: Checkout Megatron source (attempt 2)
+        id: checkout_megatron_2
+        if: steps.checkout_megatron_1.outcome == 'failure'
+        continue-on-error: true
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Checkout Megatron source (attempt 3)
+        id: checkout_megatron_3
+        if: steps.checkout_megatron_2.outcome == 'failure'
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Checkout TransformerEngine-FL (attempt 1)
+        id: checkout_te_fl_1
+        continue-on-error: true
+        uses: actions/checkout@v4
+        with:
+          repository: flagos-ai/TransformerEngine-FL
+          ref: main
+          path: te-fl
+          fetch-depth: 1
+          submodules: recursive
+
+      - name: Checkout TransformerEngine-FL (attempt 2)
+        id: checkout_te_fl_2
+        if: steps.checkout_te_fl_1.outcome == 'failure'
+        continue-on-error: true
+        uses: actions/checkout@v4
+        with:
+          repository: flagos-ai/TransformerEngine-FL
+          ref: main
+          path: te-fl
+          fetch-depth: 1
+          submodules: recursive
+
+      - name: Checkout TransformerEngine-FL (attempt 3)
+        id: checkout_te_fl_3
+        if: steps.checkout_te_fl_2.outcome == 'failure'
         uses: actions/checkout@v4
         with:
           repository: flagos-ai/TransformerEngine-FL


### PR DESCRIPTION
## Summary
  Add retry mechanism to the TE-FL prepare workflow checkout steps to improve CI stability.

  ## Changes

  ### Before
  - Megatron source checkout: 1 attempt
  - TransformerEngine-FL checkout: 1 attempt
  - Job fails immediately if either checkout fails

  ### After
  - **Megatron source checkout**: up to 3 attempts
    - attempt 1: initial try, continues on failure
    - attempt 2: runs only if attempt 1 fails
    - attempt 3: runs only if attempt 2 fails, job fails if this fails

  - **TransformerEngine-FL checkout**: up to 3 attempts
    - same three-attempt retry logic
    - includes recursive submodule checkout

  ## Technical Details
  - Uses `continue-on-error: true` to allow first two attempts to fail gracefully
  - Conditional retry triggered via `steps.<step_id>.outcome == 'failure'`
  - All original parameters preserved (fetch-depth, submodules, etc.)

  ## Impact
  - Only affects `.github/workflows/prepare_te_fl.yml`
  - No change to final workflow behavior, only adds fault tolerance
  - More resilient to network instability or temporary GitHub API rate limiting

  ## Testing Recommendations
  - Verify checkout succeeds on first attempt under normal conditions
  - Simulate network failures to verify retry mechanism activates correctly

