### PR TITLE
[NPU] Add Gated Delta Net plugin dispatch and fallback

### DIFF
--- a/megatron/core/ssm/gated_delta_net.py
+++ b/megatron/core/ssm/gated_delta_net.py
@@ -32,6 +32,7 @@ from megatron.core.transformer.utils import (
     sharded_state_dict_default,
 )
 from megatron.core.utils import deprecate_inference_params, nvtx_range_pop, nvtx_range_push
+from megatron.plugin.decorators import overridable
 
 # TODO: Implement GatedDeltaNetContextParallel
 # from .gated_delta_net_context_parallel import GatedDeltaNetContextParallel
@@ -350,8 +351,8 @@ class GatedDeltaNet(MegatronModule):
         value = value.reshape(batch, seq_len, -1, self.value_head_dim)
         # Apply L2 norm to query and key
         if self.use_qk_l2norm:
-            query = l2norm(query.contiguous())
-            key = l2norm(key.contiguous())
+            query = self._normalize_qk(query.contiguous())
+            key = self._normalize_qk(key.contiguous())
         if self.num_value_heads // self.num_key_heads > 1:
             query = query.repeat_interleave(self.num_value_heads // self.num_key_heads, dim=2)
             key = key.repeat_interleave(self.num_value_heads // self.num_key_heads, dim=2)
@@ -371,28 +372,9 @@ class GatedDeltaNet(MegatronModule):
         nvtx_range_pop(suffix="g_and_beta")
 
         nvtx_range_push(suffix="gated_delta_rule")
-        if self.config.deterministic_mode:
-            core_attn_out, last_recurrent_state = torch_chunk_gated_delta_rule(
-                query,
-                key,
-                value,
-                g=g,
-                beta=beta,
-                initial_state=None,
-                output_final_state=False,
-                use_qk_l2norm_in_kernel=False,
-            )
-        else:
-            core_attn_out, last_recurrent_state = chunk_gated_delta_rule(
-                query,
-                key,
-                value,
-                g=g,
-                beta=beta,
-                initial_state=None,
-                output_final_state=False,
-                use_qk_l2norm_in_kernel=False,
-            )
+        core_attn_out, last_recurrent_state = self._gated_delta_rule(
+            query, key, value, g, beta
+        )
         nvtx_range_pop(suffix="gated_delta_rule")
 
         # RMSNorm
@@ -411,6 +393,22 @@ class GatedDeltaNet(MegatronModule):
         nvtx_range_pop(suffix="out_proj")
 
         return out, out_bias
+
+    @overridable
+    def _normalize_qk(self, x):
+        """Normalize Q/K independently of the model's projection and head layout."""
+        return l2norm(x)
+
+    @overridable
+    def _gated_delta_rule(self, query, key, value, g, beta):
+        """Dispatch only the recurrent attention calculation."""
+        fn = torch_chunk_gated_delta_rule
+        if not self.config.deterministic_mode:
+            fn = chunk_gated_delta_rule
+        return fn(
+            query, key, value, g=g, beta=beta, initial_state=None,
+            output_final_state=False, use_qk_l2norm_in_kernel=False,
+        )
 
     @jit_fuser
     def _apply_gated_norm(self, x, gate):

--- a/megatron/plugin/Ascend/ssm/gated_delta_net.py
+++ b/megatron/plugin/Ascend/ssm/gated_delta_net.py
@@ -1,0 +1,52 @@
+# Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
+"""Ascend GDN dispatch; native MCore owns model and sequence handling."""
+
+import torch
+
+
+def normalize_qk(self, x):
+    return x / torch.norm(x, p=2, dim=-1, keepdim=True).clamp(min=1e-6)
+
+
+def gated_delta_rule(self, query, key, value, g, beta):
+    kwargs = {"g": g, "beta": beta}
+    if self.config.deterministic_mode:
+        return _torch_fallback(query, key, value, **kwargs)
+
+    try:
+        from transformer_engine.plugin.core.manager import get_default_manager
+    except ImportError:
+        return _torch_fallback(query, key, value, **kwargs)
+
+    manager = get_default_manager()
+    manager.ensure_initialized()
+    if not manager.registry.get_implementations("gated_delta_net_forward"):
+        return _torch_fallback(query, key, value, **kwargs)
+
+    result = manager.call(
+        "gated_delta_net_forward",
+        query=query,
+        key=key,
+        value=value,
+        g=kwargs["g"],
+        beta=kwargs["beta"],
+        initial_state=kwargs.get("initial_state"),
+        output_final_state=kwargs.get("output_final_state", False),
+        use_qk_l2norm=kwargs.get("use_qk_l2norm_in_kernel", False),
+        chunk_size=64,
+    )
+
+    if result is NotImplemented:
+        return _torch_fallback(query, key, value, **kwargs)
+    return result
+
+
+def _torch_fallback(query, key, value, **kwargs):
+    """Reuse MCore's native math with NPU-safe normalization for dense inputs."""
+    from megatron.core.ssm.gated_delta_net import torch_chunk_gated_delta_rule
+
+    if kwargs.get("use_qk_l2norm_in_kernel", False):
+        query = normalize_qk(None, query)
+        key = normalize_qk(None, key)
+        kwargs["use_qk_l2norm_in_kernel"] = False
+    return torch_chunk_gated_delta_rule(query, key, value, **kwargs)

--- a/megatron/plugin/override_registry.py
+++ b/megatron/plugin/override_registry.py
@@ -178,3 +178,16 @@ register(
     impl="megatron.plugin.Ascend.transformer.transformer_config.NPUTransformerConfig",
     vendor="npu",
 )
+
+
+register(
+    target="megatron.core.ssm.gated_delta_net.GatedDeltaNet._normalize_qk",
+    impl="megatron.plugin.Ascend.ssm.gated_delta_net.normalize_qk",
+    vendor="npu",
+)
+
+register(
+    target="megatron.core.ssm.gated_delta_net.GatedDeltaNet._gated_delta_rule",
+    impl="megatron.plugin.Ascend.ssm.gated_delta_net.gated_delta_rule",
+    vendor="npu",
+)

--- a/megatron/plugin/tests/test_gdn_dispatch.py
+++ b/megatron/plugin/tests/test_gdn_dispatch.py
@@ -1,0 +1,187 @@
+"""GDN hook registration, shared-manager use and deterministic fallback."""
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from megatron.core.ssm import gated_delta_net as core
+from megatron.plugin.Ascend.ssm import gated_delta_net as plugin
+
+
+@pytest.fixture(autouse=True)
+def select_npu_override(monkeypatch):
+    from megatron.plugin import decorators
+
+    monkeypatch.setenv("MG_FL_PREFER", "npu")
+    monkeypatch.setattr(decorators, "_plugin_impl_cache", {})
+    monkeypatch.setattr(decorators, "_original_impl_cache", set())
+
+
+def test_registered_hooks_reach_shared_manager(monkeypatch):
+    from transformer_engine.plugin.core import manager
+
+    calls = []
+
+    class Recorder:
+        registry = SimpleNamespace(get_implementations=lambda name: [object()])
+
+        def ensure_initialized(self):
+            pass
+
+        def call(self, name, **kwargs):
+            calls.append((name, kwargs))
+            return kwargs["value"], None
+
+    monkeypatch.setattr(manager, "get_default_manager", lambda: Recorder())
+    obj = SimpleNamespace(config=SimpleNamespace(deterministic_mode=False))
+    q = torch.randn(1, 3, 2, 4)
+    gate = torch.zeros(1, 3, 2)
+    out, state = core.GatedDeltaNet._gated_delta_rule(obj, q, q, q, g=gate, beta=gate)
+    assert out is q and state is None
+    assert calls[0][0] == "gated_delta_net_forward"
+    assert calls[0][1]["use_qk_l2norm"] is False
+    torch.testing.assert_close(
+        core.GatedDeltaNet._normalize_qk(obj, q), plugin.normalize_qk(obj, q)
+    )
+
+
+def test_deterministic_mode_uses_native_torch(monkeypatch):
+    from transformer_engine.plugin.core import manager
+
+    def forbidden():
+        raise AssertionError("Deterministic mode must not access the TE manager")
+
+    monkeypatch.setattr(manager, "get_default_manager", forbidden)
+    obj = SimpleNamespace(config=SimpleNamespace(deterministic_mode=True), gated_delta_rule=core.torch_chunk_gated_delta_rule)
+    q = torch.randn(1, 3, 2, 4) * 0.1
+    gate = torch.zeros(1, 3, 2)
+    actual = core.GatedDeltaNet._gated_delta_rule(obj, q, q, q, g=gate, beta=gate.sigmoid())[0]
+    expected = core.torch_chunk_gated_delta_rule(q, q, q, gate, gate.sigmoid())[0]
+    torch.testing.assert_close(actual, expected)
+
+
+def test_declined_call_matches_native_forward_backward(monkeypatch):
+    from transformer_engine.plugin.core import manager
+
+    class Decline:
+        registry = SimpleNamespace(get_implementations=lambda name: [object()])
+
+        def ensure_initialized(self):
+            pass
+
+        def call(self, *args, **kwargs):
+            return NotImplemented
+
+    monkeypatch.setattr(manager, "get_default_manager", Decline)
+    torch.manual_seed(42)
+    xs = [torch.randn(1, 65, 2, d) * 0.1 for d in (4, 4, 6)]
+    xs += [-torch.rand(1, 65, 2), torch.rand(1, 65, 2)]
+    a = [x.clone().requires_grad_() for x in xs]
+    b = [x.clone().requires_grad_() for x in xs]
+    obj = SimpleNamespace(config=SimpleNamespace(deterministic_mode=False))
+    actual = plugin.gated_delta_rule(obj, *a[:3], g=a[3], beta=a[4])[0]
+    expected = core.torch_chunk_gated_delta_rule(*b)[0]
+    torch.testing.assert_close(actual, expected)
+    actual.sum().backward()
+    expected.sum().backward()
+    for x, y in zip(a, b):
+        torch.testing.assert_close(x.grad, y.grad)
+
+
+@pytest.mark.parametrize("selector", ["cpu", "cuda", "npu"])
+@pytest.mark.parametrize("have_fla", [False, True])
+def test_constructor_preserves_fla_requirement(monkeypatch, selector, have_fla):
+    monkeypatch.setenv("MG_FL_PREFER", selector)
+    monkeypatch.setattr(core, "HAVE_FLA", have_fla)
+
+    class ConstructionReached(Exception):
+        pass
+
+    def reached(self, config):
+        raise ConstructionReached
+
+    monkeypatch.setattr(core.MegatronModule, "__init__", reached)
+    obj = object.__new__(core.GatedDeltaNet)
+    if have_fla:
+        with pytest.raises(ConstructionReached):
+            core.GatedDeltaNet.__init__(obj, config=None, submodules=None)
+    else:
+        with pytest.raises(ImportError, match="FLA is not installed"):
+            core.GatedDeltaNet.__init__(obj, config=None, submodules=None)
+
+
+
+
+
+
+def test_absent_te_operator_uses_native_torch(monkeypatch):
+    from transformer_engine.plugin.core import manager
+
+    fake = SimpleNamespace(
+        ensure_initialized=lambda: None,
+        registry=SimpleNamespace(get_implementations=lambda name: []),
+        call=lambda *a, **k: pytest.fail('Absent operator must not be called'),
+    )
+    monkeypatch.setattr(manager, 'get_default_manager', lambda: fake)
+    q = torch.randn(1, 3, 2, 4) * .1
+    g = -torch.rand(1, 3, 2)
+    obj = SimpleNamespace(config=SimpleNamespace(deterministic_mode=False))
+    actual = plugin.gated_delta_rule(obj, q, q, q, g=g, beta=g.sigmoid())
+    expected = core.torch_chunk_gated_delta_rule(q, q, q, g, g.sigmoid())
+    torch.testing.assert_close(actual, expected)
+
+
+def test_missing_te_import_uses_native_torch(monkeypatch):
+    import builtins
+    original = builtins.__import__
+
+    def without_te(name, *args, **kwargs):
+        if name == 'transformer_engine.plugin.core.manager':
+            raise ImportError('TE unavailable')
+        return original(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, '__import__', without_te)
+    q = torch.randn(1, 3, 2, 4) * .1
+    g = -torch.rand(1, 3, 2)
+    obj = SimpleNamespace(config=SimpleNamespace(deterministic_mode=False))
+    actual = plugin.gated_delta_rule(obj, q, q, q, g=g, beta=g.sigmoid())
+    expected = core.torch_chunk_gated_delta_rule(q, q, q, g, g.sigmoid())
+    torch.testing.assert_close(actual, expected)
+
+
+@pytest.mark.parametrize('error', [ValueError, RuntimeError, torch.OutOfMemoryError])
+def test_manager_execution_error_never_uses_native(monkeypatch, error):
+    from transformer_engine.plugin.core import manager
+
+    def fail(*a, **k):
+        raise error('kernel failure')
+
+    fake = SimpleNamespace(
+        ensure_initialized=lambda: None,
+        registry=SimpleNamespace(get_implementations=lambda name: [object()]),
+        call=fail,
+    )
+    monkeypatch.setattr(manager, 'get_default_manager', lambda: fake)
+    monkeypatch.setattr(plugin, '_torch_fallback', lambda *a, **k: pytest.fail('Do not hide execution errors'))
+    q = torch.randn(1, 3, 2, 4)
+    g = torch.zeros(1, 3, 2)
+    obj = SimpleNamespace(config=SimpleNamespace(deterministic_mode=False))
+    with pytest.raises(error, match='kernel failure'):
+        plugin.gated_delta_rule(obj, q, q, q, g=g, beta=g.sigmoid())
+
+
+def test_torch_fallback_normalization_and_state_gradients():
+    torch.manual_seed(42)
+    q, k, v = [torch.randn(1, 3, 2, 4, requires_grad=True) for _ in range(3)]
+    state = torch.zeros(1, 2, 4, 4, requires_grad=True)
+    g = -torch.rand(1, 3, 2)
+    out, final = plugin._torch_fallback(q, k, v, g=g, beta=g.sigmoid(),
+        initial_state=state, output_final_state=True, use_qk_l2norm_in_kernel=True)
+    expected = core.torch_chunk_gated_delta_rule(plugin.normalize_qk(None, q),
+        plugin.normalize_qk(None, k), v, g, g.sigmoid(), initial_state=state,
+        output_final_state=True)
+    torch.testing.assert_close((out, final), expected)
+    (out.sum() + final.sum()).backward()
+    for x in (q, k, v, state):
+        assert x.grad is not None and torch.isfinite(x.grad).all()


### PR DESCRIPTION
# Description

为 Gated Delta Net（GDN）的 Q/K 归一化和递推计算添加可覆盖接口，并通过 Ascend 插件对接 TE-FL 的 NPU GDN 实现。

Core 保留模型构建、投影、卷积和输出处理，默认接口沿用原生计算。Ascend 插件负责设备适配、调用共享 OpManager，以及在优化实现不可用时选择原生回退；具体优化内核由 TE-FL NPU backend 负责。

## Type of change

- [x] New feature（新增功能）
- [ ] Infra/Build change
- [ ] Code refactoring
- [ ] Documentation change
- [ ] Bug fix
- [ ] Breaking change

## Changes

- 在 GDN core 中添加 `_normalize_qk` 和 `_gated_delta_rule` 两个可覆盖接口，通过现有注册机制关联 Ascend 插件，避免复制整个模型 `forward`。
- Ascend 插件使用 PyTorch 运算实现可微 Q/K 归一化，通过共享 OpManager 调用 `gated_delta_net_forward`。
- 确定性模式、TE-FL 无法导入、算子未注册或 backend 返回 `NotImplemented` 时，回退到 MCore 的 `torch_chunk_gated_delta_rule` PyTorch 实现
- 保留构造函数中的 `HAVE_FLA` 检查、非 NPU 默认路径及当前基点的卷积逻辑，不修改模型参数或训练配置。
- 添加显式设置 `MG_FL_PREFER=npu` 的分发测试，以及构造约束、原生回退和错误传播测试。

## Validation

- Megatron 相关测试分别在外部未设置 `MG_FL_PREFER` 和设置为 `cpu` 的环境运行，两组各 15 项通过；需要验证 Ascend 分发的测试在 fixture 中显式选择 NPU。
- 真实 NPU 联合测试通过：验证缺失运行时后的原生回退、依赖恢复后的优化调用，以及反向梯度计算。
- 配套 TE-FL 的 33 项 CPU 合同测试和 8 项真实 NPU 精度测试通过。
- Ascend 910C 上完成 8 rank、100 步训练，退出码 0；全部 rank 均记录到 TE-FL 优化 GDN 前向和反向成功返回，跳步及 NaN 迭代数均为 0。
- 配置：Qwen3.5-35B-A3B 的 4 层语言／1 层视觉测试配置，BF16，TP2/PP1/EP4/DP4，MBS16/GBS256，关闭 MTP、重计算和数据 packing，冻结视觉模型及投影。使用共同自定义数据入口，包含兼容处理和 checkpoint 过滤。
- Step 3–100 平均耗时 **2259.62 ms/步**，吞吐 **113.29 samples/s**。这是配套双仓修改的联合运行结果，不是 Megatron 接口修改的独立收益；本轮没有新增基线对照、Profile 或长期收敛验证。

## Checklist

- [ ] 已阅读并遵守目标仓库的 contributing guidelines（提交前由作者确认）
- [x] 已实现上述声明范围内的功能
- [x] 已为接口职责和回退条件添加必要注释
- [ ] 已更新独立使用文档（本次未新增）
- [ ] 已确认没有新增 warnings（本轮未完成独立对照核查）
- [x] 已添加并运行与本功能相关的测试
- [ ] 全仓新增及既有测试均通过（本轮仅运行相关测试，未运行全仓测试）
