### PR TITLE
Add Ascend NPU support for GatedDeltaNet

### DIFF
--- a/megatron/core/ssm/gated_delta_net.py
+++ b/megatron/core/ssm/gated_delta_net.py
@@ -13,7 +13,6 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 from torch import Tensor
-from megatron.plugin.decorators import overridable
 
 from megatron.core.dist_checkpointing import ShardedTensor
 from megatron.core.dist_checkpointing.mapping import ReplicaId, ShardedTensorFactory
@@ -40,6 +39,7 @@ from megatron.core.transformer.utils import (
     sharded_state_dict_default,
 )
 from megatron.core.utils import deprecate_inference_params, nvtx_range_pop, nvtx_range_push
+from megatron.plugin.decorators import overridable
 
 try:
     from fla.modules.convolution import causal_conv1d

--- a/megatron/core/ssm/gated_delta_net.py
+++ b/megatron/core/ssm/gated_delta_net.py
@@ -13,6 +13,7 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 from torch import Tensor
+from megatron.plugin.decorators import overridable
 
 from megatron.core.dist_checkpointing import ShardedTensor
 from megatron.core.dist_checkpointing.mapping import ReplicaId, ShardedTensorFactory
@@ -436,7 +437,7 @@ class GatedDeltaNet(MegatronModule):
             qkv = qkv.transpose(1, 2)  # b, d, s -> b, s, d
         else:
             assert self.activation in ["silu", "swish"]
-            qkv, _ = causal_conv1d(
+            qkv, _ = self._causal_conv1d(
                 x=qkv,  # FLA conv1d accepts [b, s, d] format input
                 weight=conv1d_weight.squeeze(1),  # d, 1, w -> d, w
                 bias=conv1d_bias,
@@ -464,7 +465,7 @@ class GatedDeltaNet(MegatronModule):
         nvtx_range_pop(suffix="g_and_beta")
 
         nvtx_range_push(suffix="gated_delta_rule")
-        core_attn_out, last_recurrent_state = self.gated_delta_rule(
+        core_attn_out, last_recurrent_state = self._gated_delta_rule(
             query,
             key,
             value,
@@ -521,6 +522,18 @@ class GatedDeltaNet(MegatronModule):
         y = y.to(x_dtype)
         return y
 
+    @overridable
+    def _normalize_qk(self, x):
+        return l2norm(x)
+
+    @overridable
+    def _gated_delta_rule(self, q, k, v, **kwargs):
+        return self.gated_delta_rule(q, k, v, **kwargs)
+
+    @overridable
+    def _causal_conv1d(self, **kwargs):
+        return causal_conv1d(**kwargs)
+
     @jit_fuser
     def _prepare_qkv_for_gated_delta_rule(self, qkv, gate, beta, alpha, batch, seq_len):
         """
@@ -540,7 +553,7 @@ class GatedDeltaNet(MegatronModule):
 
         # Apply L2 norm to query and key
         if self.use_qk_l2norm:
-            query_key = l2norm(query_key.contiguous())
+            query_key = self._normalize_qk(query_key.contiguous())
 
         # Split query and key
         split_size = self.qk_dim_local_tp // self.key_head_dim // self.cp_size

--- a/megatron/plugin/Ascend/ssm/__init__.py
+++ b/megatron/plugin/Ascend/ssm/__init__.py
@@ -1,0 +1,6 @@
+# Copyright (c) 2025, BAAI. All rights reserved.
+# Copyright (c) 2026, Huawei Technologies Co., Ltd. All rights reserved.
+#
+# See LICENSE for license information.
+
+"""Ascend NPU plugin implementations for megatron.core.ssm."""

--- a/megatron/plugin/Ascend/ssm/causal_conv1d.py
+++ b/megatron/plugin/Ascend/ssm/causal_conv1d.py
@@ -1,0 +1,65 @@
+# Copyright (c) 2026, BAAI. All rights reserved.
+# See LICENSE for license information.
+
+"""Dense NPU convolution compatibility path for Megatron GatedDeltaNet."""
+
+import torch.nn.functional as F
+
+
+def causal_conv1d(
+    x,
+    weight=None,
+    bias=None,
+    residual=None,
+    initial_state=None,
+    output_final_state=False,
+    activation=None,
+    backend="triton",
+    cu_seqlens=None,
+    **kwargs,
+):
+    # Stateful and variable-length inputs retain the upstream implementation.
+    if (
+        backend != "triton"
+        or kwargs
+        or x.device.type != "npu"
+        or x.ndim != 3
+        or weight is None
+        or initial_state is not None
+        or output_final_state
+        or cu_seqlens is not None
+        or activation not in (None, "silu", "swish")
+    ):
+        from fla.modules.convolution import causal_conv1d as original
+
+        return original(
+            x=x,
+            weight=weight,
+            bias=bias,
+            residual=residual,
+            initial_state=initial_state,
+            output_final_state=output_final_state,
+            activation=activation,
+            backend=backend,
+            cu_seqlens=cu_seqlens,
+            **kwargs,
+        )
+
+    output = F.conv1d(
+        x.transpose(1, 2).contiguous(),
+        weight.unsqueeze(1),
+        bias,
+        padding=weight.shape[-1] - 1,
+        groups=x.shape[-1],
+    )
+    output = output[..., :x.shape[1]]
+    if activation in ("silu", "swish"):
+        output = F.silu(output)
+    output = output.transpose(1, 2)
+    if residual is not None:
+        output = output + residual
+    return output, None
+
+
+def gated_delta_net_conv1d(self, **kwargs):
+    return causal_conv1d(**kwargs)

--- a/megatron/plugin/Ascend/ssm/chunk_gated_delta_rule.py
+++ b/megatron/plugin/Ascend/ssm/chunk_gated_delta_rule.py
@@ -1,0 +1,494 @@
+# Copyright (c) 2025, BAAI. All rights reserved.
+# Copyright (c) 2026, Huawei Technologies Co., Ltd. All rights reserved.
+#
+# See LICENSE for license information.
+
+"""Megatron GDN adaptation and Ascend forward/backward implementation.
+
+Optional FLA-NPU kernels are loaded only for supported NPU inputs.
+Unsupported inputs retain the original FLA path.
+"""
+
+from __future__ import annotations
+
+import importlib
+import logging
+import os
+from functools import lru_cache
+from types import SimpleNamespace
+from typing import Optional, Tuple
+
+import torch
+
+logger = logging.getLogger(__name__)
+
+# Head dim the AscendC GDN kernels are built for.
+_SUPPORTED_HEAD_DIM = 128
+# Chunk size the AscendC GDN kernels are built for.
+_SUPPORTED_CHUNK_SIZE = 64
+
+
+def _fla_original_chunk_gated_delta_rule():
+    """Return the original FLA implementation for unsupported inputs."""
+    try:
+        from fla.ops.gated_delta_rule import chunk_gated_delta_rule as original
+
+        return original
+    except ImportError as e:  # pragma: no cover - depends on site-packages
+        logger.warning(f"[GDN] FLA fallback unavailable: {e}")
+        return None
+
+
+def _fla_original_l2norm():
+    """Return FLA's own ``l2norm``, or None when unavailable."""
+    try:
+        from fla.modules.l2norm import l2norm as original
+
+        return original
+    except ImportError as e:  # pragma: no cover - depends on site-packages
+        logger.warning(f"[GDN] FLA l2norm fallback unavailable: {e}")
+        return None
+
+
+def l2norm(
+    x: torch.Tensor,
+    eps: float = 1e-6,
+    output_dtype: Optional[torch.dtype] = None,
+) -> torch.Tensor:
+    """L2 normalization over the last axis, matching FLA's signature exactly.
+
+    ``fla_npu.ops.triton.l2norm`` takes the same ``(x, eps, output_dtype)``
+    arguments as ``fla.modules.l2norm.l2norm``, so this is a straight swap on
+    NPU tensors and a delegation to FLA everywhere else.
+    """
+    if x.device.type == "npu":
+        try:
+            from fla_npu.ops.triton import l2norm as npu_l2norm
+
+        except ImportError as e:
+            logger.warning(f"[GDN] fla_npu l2norm unavailable, using FLA: {e}")
+        else:
+            return npu_l2norm(x, eps=eps, output_dtype=output_dtype)
+
+    original = _fla_original_l2norm()
+    if original is None:
+        raise RuntimeError(
+            "l2norm requires either fla_npu (on NPU) or FLA, but neither is importable."
+        )
+    return original(x, eps=eps, output_dtype=output_dtype)
+
+
+def _npu_kernels_support(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    g: torch.Tensor,
+    beta: torch.Tensor,
+    initial_state: Optional[torch.Tensor],
+    output_final_state: bool,
+    cu_seqlens: Optional[torch.Tensor],
+) -> bool:
+    """Report whether the AscendC kernels cover this input.
+
+    Checked before any kernel launches so an unsupported case costs nothing but
+    a fallback.  Variable-length (``cu_seqlens``) input is deliberately excluded
+    for now: the kernels accept it but that path is unverified on this stack.
+    """
+    if q.device.type != "npu":
+        return False
+    if any(t.device != q.device for t in (k, v, g, beta)):
+        return False
+    if q.dtype not in (torch.float16, torch.bfloat16):
+        return False
+    if k.dtype != q.dtype or v.dtype != q.dtype:
+        return False
+    if q.ndim != 4 or k.shape != q.shape or v.ndim != 4:
+        return False
+    if g.ndim != 3 or beta.ndim != 3:
+        return False
+    if v.shape[:3] != q.shape[:3] or g.shape != q.shape[:3] or beta.shape != g.shape:
+        return False
+    if any(size == 0 for size in q.shape[:3]):
+        return False
+    if q.shape[-1] != _SUPPORTED_HEAD_DIM or v.shape[-1] != _SUPPORTED_HEAD_DIM:
+        return False
+    if g.dtype != torch.float32 or beta.dtype != q.dtype:
+        return False
+    if initial_state is not None or output_final_state:
+        return False
+    if cu_seqlens is not None:
+        return False
+    return True
+
+
+def _runtime_available() -> bool:
+    """Check the fla_npu operator set is loaded, without launching kernels."""
+    try:
+        _load_kernels()
+        return hasattr(torch, "npu") and torch.npu.is_available()
+    except (ImportError, RuntimeError, OSError) as e:
+        logger.warning(f"[GDN] Runtime validation failed: {e}")
+        return False
+
+
+def chunk_gated_delta_rule(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    g: torch.Tensor,
+    beta: torch.Tensor,
+    scale: Optional[float] = None,
+    initial_state: Optional[torch.Tensor] = None,
+    output_final_state: bool = False,
+    use_qk_l2norm_in_kernel: bool = False,
+    cu_seqlens: Optional[torch.Tensor] = None,
+    head_first: bool = False,
+) -> Tuple[torch.Tensor, Optional[torch.Tensor]]:
+    """Chunked gated delta rule on Ascend NPU, matching FLA's signature.
+
+    Falls back to FLA for anything the AscendC kernels do not cover.  Kernel
+    execution errors propagate rather than silently becoming a fallback result,
+    so a broken kernel is visible instead of being masked by a slow path.
+
+    ``head_first=True`` is deprecated in FLA and means BHSD input; the AscendC
+    path assumes BSHD, so that case is handed back to FLA unchanged.
+    """
+    supported = not head_first and _npu_kernels_support(
+        q, k, v, g, beta, initial_state, output_final_state, cu_seqlens
+    )
+
+    if not supported or not _runtime_available():
+        original = _fla_original_chunk_gated_delta_rule()
+        if original is None:
+            raise RuntimeError(
+                "chunk_gated_delta_rule: input is unsupported by the Ascend kernels "
+                "and FLA is not importable for fallback."
+            )
+        return original(
+            q=q,
+            k=k,
+            v=v,
+            g=g,
+            beta=beta,
+            scale=scale,
+            initial_state=initial_state,
+            output_final_state=output_final_state,
+            use_qk_l2norm_in_kernel=use_qk_l2norm_in_kernel,
+            cu_seqlens=cu_seqlens,
+            head_first=head_first,
+        )
+
+    # BSHD -> BHSD for q/k/v; g and beta stay BSH.
+    output, final_state = flash_gated_delta_rule(
+        q=q.transpose(1, 2).contiguous(),
+        k=k.transpose(1, 2).contiguous(),
+        v=v.transpose(1, 2).contiguous(),
+        g=g.contiguous(),
+        beta=beta.contiguous(),
+        scale=scale,
+        use_qk_l2norm_in_kernel=use_qk_l2norm_in_kernel,
+    )
+
+    return output.contiguous(), final_state
+
+
+def normalize_qk(self, x):
+    return l2norm(x)
+
+
+def gated_delta_rule(self, q, k, v, **kwargs):
+    if self.config.deterministic_mode:
+        return self.gated_delta_rule(q, k, v, **kwargs)
+    return chunk_gated_delta_rule(q, k, v, **kwargs)
+
+
+@lru_cache(maxsize=1)
+def _load_kernels():
+    """Load optional kernels on first use; failed loads remain retryable."""
+    kernels = {}
+    module = importlib.import_module("fla_npu.ops.ascendc")
+    for alias, name in (
+        ("ascendc_chunk_bwd_dqkwg", "chunk_bwd_dqkwg"),
+        ("ascendc_chunk_bwd_dv_local", "chunk_bwd_dv_local"),
+        ("ascendc_chunk_fwd_o", "chunk_fwd_o"),
+        ("ascendc_chunk_gated_delta_rule_bwd_dhu", "chunk_gated_delta_rule_bwd_dhu"),
+        ("ascendc_chunk_gated_delta_rule_fwd_h", "chunk_gated_delta_rule_fwd_h"),
+        ("ascendc_prepare_wy_repr_bwd_da", "prepare_wy_repr_bwd_da"),
+        ("ascendc_prepare_wy_repr_bwd_full", "prepare_wy_repr_bwd_full"),
+        ("ascendc_recompute_w_u_fwd", "recompute_w_u_fwd"),
+        ("ascendc_solve_tri", "solve_tri"),
+    ):
+        kernel = getattr(module, name, None)
+        if not callable(kernel):
+            raise ImportError(f"Missing GDN kernel: {module.__name__}.{name}")
+        kernels[alias] = kernel
+    module = importlib.import_module("fla_npu.ops.triton")
+    for alias, name in (
+        ("autocast_custom_bwd", "autocast_custom_bwd"),
+        ("autocast_custom_fwd", "autocast_custom_fwd"),
+        ("chunk_local_cumsum", "chunk_local_cumsum"),
+        ("chunk_scaled_dot_kkt_fwd", "chunk_scaled_dot_kkt_fwd"),
+        ("input_guard", "input_guard"),
+        ("l2norm_bwd", "l2norm_bwd"),
+        ("l2norm_fwd", "l2norm_fwd"),
+        ("solve_tril_npu", "solve_tril_npu"),
+    ):
+        kernel = getattr(module, name, None)
+        if not callable(kernel):
+            raise ImportError(f"Missing GDN kernel: {module.__name__}.{name}")
+        kernels[alias] = kernel
+    return SimpleNamespace(**kernels)
+
+
+def solve_tri_ascendc(A: torch.Tensor, output_dtype: torch.dtype = torch.float) -> torch.Tensor:
+    """Solve triangular system using AscendC."""
+    ops = _load_kernels()
+    A_in = A.to(output_dtype).contiguous()
+    return ops.ascendc_solve_tri(A_in, layout="bsnd")
+
+
+def solve_tri(A: torch.Tensor, output_dtype: torch.dtype) -> torch.Tensor:
+    """Solve triangular system with backend selection."""
+    ops = _load_kernels()
+    backend = os.getenv("FLA_NPU_GDN_SOLVE_TRI_BACKEND", "ascendc").strip().lower()
+    if backend == "ascendc":
+        return solve_tri_ascendc(A, output_dtype=output_dtype)
+    elif backend == "triton":
+        return ops.solve_tril_npu(
+            A=A, cu_seqlens=None, chunk_indices_out=None, output_dtype=output_dtype
+        )
+    else:
+        raise ValueError(
+            f"FLA_NPU_GDN_SOLVE_TRI_BACKEND must be 'ascendc' or 'triton', got {backend!r}"
+        )
+
+
+def recompute_w_u(
+    k: torch.Tensor, v: torch.Tensor, beta: torch.Tensor, A: torch.Tensor, g: torch.Tensor
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    """Recompute W and U from K, V, beta, A."""
+    ops = _load_kernels()
+    w, u = ops.ascendc_recompute_w_u_fwd(
+        k, v, beta, A, _SUPPORTED_CHUNK_SIZE, g=g, gk=None, cu_seqlens=None, chunk_indices=None
+    )
+    return (w, u)
+
+
+def flash_chunk_gated_delta_rule_fwd(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    g: torch.Tensor,
+    beta: torch.Tensor,
+    scale: float,
+) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Dense recurrence: cumulative gates, WY representation, state, then output."""
+    ops = _load_kernels()
+    g = ops.chunk_local_cumsum(
+        g, chunk_size=_SUPPORTED_CHUNK_SIZE, cu_seqlens=None, chunk_indices_out=None, head_first=False
+    )
+    A = ops.chunk_scaled_dot_kkt_fwd(
+        k=k,
+        g=g,
+        beta=beta,
+        cu_seqlens=None,
+        chunk_indices=None,
+        chunk_size=_SUPPORTED_CHUNK_SIZE,
+        output_dtype=torch.float32,
+    )
+    A = solve_tri(A, output_dtype=k.dtype)
+    g = g.transpose(1, 2).contiguous()
+    beta = beta.transpose(1, 2).contiguous().float()
+    A = A.transpose(1, 2).contiguous()
+    w, u = recompute_w_u(k, v, beta, A, g)
+    h, v_new, _ = ops.ascendc_chunk_gated_delta_rule_fwd_h(
+        k,
+        w,
+        u,
+        g=g,
+        gk=None,
+        initial_state=None,
+        output_final_state=False,
+        chunk_size=_SUPPORTED_CHUNK_SIZE,
+        cu_seqlens=None,
+        chunk_indices=None,
+    )
+    o = ops.ascendc_chunk_fwd_o(
+        q,
+        k,
+        v_new,
+        h,
+        scale,
+        g=g,
+        g_gamma=None,
+        cu_seqlens=None,
+        chunk_indices=None,
+        chunk_size=_SUPPORTED_CHUNK_SIZE,
+        transpose_state_layout=False,
+    )
+    g = g.transpose(1, 2).contiguous()
+    o = o.transpose(1, 2).contiguous()
+    return (g, o, A)
+
+
+def flash_chunk_gated_delta_rule_bwd(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    g: torch.Tensor,
+    beta: torch.Tensor,
+    A: torch.Tensor,
+    scale: float,
+    do: torch.Tensor,
+) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Recompute intermediates and accumulate gradients through the WY factors."""
+    ops = _load_kernels()
+    g = g.transpose(1, 2).contiguous()
+    beta = beta.transpose(1, 2).contiguous().float()
+    w, u = recompute_w_u(k, v, beta, A, g)
+    do = do.transpose(1, 2).contiguous()
+    h, v_new, _ = ops.ascendc_chunk_gated_delta_rule_fwd_h(
+        k,
+        w,
+        u,
+        g=g,
+        gk=None,
+        initial_state=None,
+        output_final_state=False,
+        chunk_size=_SUPPORTED_CHUNK_SIZE,
+        cu_seqlens=None,
+        chunk_indices=None,
+    )
+    dv = ops.ascendc_chunk_bwd_dv_local(
+        q, k, do, g, scale, _SUPPORTED_CHUNK_SIZE, g_gamma=None, A=A, cu_seqlens=None, chunk_indices=None
+    )
+    dh, _, dv = ops.ascendc_chunk_gated_delta_rule_bwd_dhu(
+        q,
+        k,
+        w,
+        do,
+        dv,
+        scale,
+        _SUPPORTED_CHUNK_SIZE,
+        g=g,
+        gK=None,
+        h0=None,
+        dht=None,
+        cu_seqlens=None,
+        chunk_indices=None,
+        use_exp2=False,
+        transpose_state_layout=False,
+    )
+    dq, dk, dw, dg = ops.ascendc_chunk_bwd_dqkwg(
+        q,
+        k,
+        v_new,
+        g,
+        h,
+        do,
+        dh,
+        dv,
+        _SUPPORTED_CHUNK_SIZE,
+        cu_seqlens=None,
+        chunk_indices=None,
+        w=None,
+        g_gamma=None,
+        scale=scale,
+        use_exp2=False,
+        transpose_state_layout=False,
+    )
+    dA = ops.ascendc_prepare_wy_repr_bwd_da(
+        k, v, beta.float(), A, dw, dv, g.float(), chunk_size=_SUPPORTED_CHUNK_SIZE, cu_seqlens=None, chunk_indices=None
+    )
+    dk2, dv, db, dg2 = ops.ascendc_prepare_wy_repr_bwd_full(
+        k, v, beta, A, dA, dw, dv, g, _SUPPORTED_CHUNK_SIZE, cu_seqlens=None, chunk_indices=None
+    )
+    db = db.transpose(1, 2).contiguous()
+    dg2 = dg2.transpose(1, 2).contiguous()
+    dg = dg.transpose(1, 2).contiguous()
+    dk.add_(dk2)
+    dg.add_(dg2)
+    dg = ops.chunk_local_cumsum(
+        dg, chunk_size=_SUPPORTED_CHUNK_SIZE, reverse=True, cu_seqlens=None, chunk_indices_out=None, head_first=False
+    )
+    return (dq, dk, dv, db, dg)
+
+
+@lru_cache(maxsize=1)
+def _get_gdn_function():
+    ops = _load_kernels()
+
+    class ChunkGatedDeltaRuleFunction(torch.autograd.Function):
+        """Autograd function for GDN with complete forward/backward."""
+
+        @staticmethod
+        @ops.input_guard
+        @ops.autocast_custom_fwd
+        def forward(
+            ctx,
+            q: torch.Tensor,
+            k: torch.Tensor,
+            v: torch.Tensor,
+            g: torch.Tensor,
+            beta: torch.Tensor,
+            scale: float,
+            use_qk_l2norm_in_kernel: bool = False,
+        ):
+            if use_qk_l2norm_in_kernel:
+                q, q_rstd = ops.l2norm_fwd(q)
+                k, k_rstd = ops.l2norm_fwd(k)
+            else:
+                q_rstd, k_rstd = (None, None)
+            g, o, A = flash_chunk_gated_delta_rule_fwd(q=q, k=k, v=v, g=g, beta=beta, scale=scale)
+            ctx.save_for_backward(q, k, v, g, beta, A)
+            ctx.q_rstd = q_rstd
+            ctx.k_rstd = k_rstd
+            ctx.scale = scale
+            ctx.use_qk_l2norm_in_kernel = use_qk_l2norm_in_kernel
+            return (o.to(q.dtype), None)
+
+        @staticmethod
+        @ops.input_guard
+        @ops.autocast_custom_bwd
+        def backward(ctx, do: torch.Tensor, dht: Optional[torch.Tensor]):
+            q, k, v, g, beta, A = ctx.saved_tensors
+            dq, dk, dv, db, dg = flash_chunk_gated_delta_rule_bwd(
+                q=q, k=k, v=v, g=g, beta=beta, A=A, scale=ctx.scale, do=do
+            )
+            if ctx.use_qk_l2norm_in_kernel:
+                dq = ops.l2norm_bwd(q, ctx.q_rstd, dq)
+                dk = ops.l2norm_bwd(k, ctx.k_rstd, dk)
+            return (
+                dq.to(q.dtype),
+                dk.to(k.dtype),
+                dv.to(v.dtype),
+                dg.to(g.dtype),
+                db.to(beta.dtype),
+                None,
+                None,
+            )
+
+    return ChunkGatedDeltaRuleFunction
+
+
+def flash_gated_delta_rule(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    g: torch.Tensor,
+    beta: torch.Tensor,
+    scale: Optional[float] = None,
+    use_qk_l2norm_in_kernel: bool = False,
+) -> Tuple[torch.Tensor, Optional[torch.Tensor]]:
+    """Main entry point for GDN.
+
+    Internal dense-only entry; the adapter validates inputs before calling.
+    Expects BHSD layout for q, k, v and BSH for g, beta.
+    Returns output in BSHD layout.
+    """
+    if scale is None:
+        scale = k.shape[-1] ** (-0.5)
+    o, final_state = _get_gdn_function().apply(
+        q, k, v, g, beta, float(scale), use_qk_l2norm_in_kernel
+    )
+    return (o, final_state)

--- a/megatron/plugin/override_registry.py
+++ b/megatron/plugin/override_registry.py
@@ -178,3 +178,24 @@ register(
     impl="megatron.plugin.Ascend.transformer.transformer_config.NPUTransformerConfig",
     vendor="npu",
 )
+
+# =============================================================================
+# SSM - gated_delta_net (FLA kernels)
+# =============================================================================
+register(
+    target="megatron.core.ssm.gated_delta_net.GatedDeltaNet._normalize_qk",
+    impl="megatron.plugin.Ascend.ssm.chunk_gated_delta_rule.normalize_qk",
+    vendor="npu",
+)
+
+register(
+    target="megatron.core.ssm.gated_delta_net.GatedDeltaNet._gated_delta_rule",
+    impl="megatron.plugin.Ascend.ssm.chunk_gated_delta_rule.gated_delta_rule",
+    vendor="npu",
+)
+
+register(
+    target="megatron.core.ssm.gated_delta_net.GatedDeltaNet._causal_conv1d",
+    impl="megatron.plugin.Ascend.ssm.causal_conv1d.gated_delta_net_conv1d",
+    vendor="npu",
+)

--- a/tests/unit_tests/ssm/test_gdn_adapter_contract.py
+++ b/tests/unit_tests/ssm/test_gdn_adapter_contract.py
@@ -2,45 +2,70 @@ import importlib
 from types import SimpleNamespace
 from unittest.mock import patch
 import pytest
-P=importlib.import_module("megatron.plugin.Ascend.ssm.chunk_gated_delta_rule")
+
+P = importlib.import_module("megatron.plugin.Ascend.ssm.chunk_gated_delta_rule")
+
 
 def test_fallback_preserves_all_arguments():
-    values=[object() for _ in range(5)]
-    opts=dict(scale=0.2,initial_state=object(),output_final_state=True,use_qk_l2norm_in_kernel=True,cu_seqlens=object(),head_first=True)
-    sentinel=object()
-    with patch.object(P,"_fla_original_chunk_gated_delta_rule") as getter:
-        getter.return_value.return_value=(sentinel,None)
-        assert P.chunk_gated_delta_rule(*values,**opts)[0] is sentinel
-        getter.return_value.assert_called_once_with(**dict(zip(("q","k","v","g","beta"),values)),**opts)
+    values = [object() for _ in range(5)]
+    opts = dict(
+        scale=0.2,
+        initial_state=object(),
+        output_final_state=True,
+        use_qk_l2norm_in_kernel=True,
+        cu_seqlens=object(),
+        head_first=True,
+    )
+    sentinel = object()
+    with patch.object(P, "_fla_original_chunk_gated_delta_rule") as getter:
+        getter.return_value.return_value = (sentinel, None)
+        assert P.chunk_gated_delta_rule(*values, **opts)[0] is sentinel
+        getter.return_value.assert_called_once_with(
+            **dict(zip(("q", "k", "v", "g", "beta"), values)), **opts
+        )
+
 
 def test_missing_runtime_delegates_before_kernel_import():
-    values=[object() for _ in range(5)]
-    with patch.object(P,"_npu_kernels_support",return_value=True), patch.object(P,"_runtime_available",return_value=False), patch.object(P,"_fla_original_chunk_gated_delta_rule") as getter:
+    values = [object() for _ in range(5)]
+    with (
+        patch.object(P, "_npu_kernels_support", return_value=True),
+        patch.object(P, "_runtime_available", return_value=False),
+        patch.object(P, "_fla_original_chunk_gated_delta_rule") as getter,
+    ):
         P.chunk_gated_delta_rule(*values)
         getter.return_value.assert_called_once()
 
+
 def test_l2norm_execution_importerror_is_not_swallowed():
-    x=SimpleNamespace(device=SimpleNamespace(type="npu"))
+    x = SimpleNamespace(device=SimpleNamespace(type="npu"))
     import fla_npu.ops.triton as t
-    with patch.object(t,"l2norm",side_effect=ImportError("kernel execution failure")), patch.object(P,"_fla_original_l2norm") as fallback:
-        with pytest.raises(ImportError,match="kernel execution failure"):
+
+    with (
+        patch.object(t, "l2norm", side_effect=ImportError("kernel execution failure")),
+        patch.object(P, "_fla_original_l2norm") as fallback,
+    ):
+        with pytest.raises(ImportError, match="kernel execution failure"):
             P.l2norm(x)
         fallback.assert_not_called()
 
+
 def test_cross_device_is_unsupported():
-    q=SimpleNamespace(device=SimpleNamespace(type="npu"))
-    k=SimpleNamespace(device=object())
-    assert not P._npu_kernels_support(q,k,k,k,k,None,False,None)
+    q = SimpleNamespace(device=SimpleNamespace(type="npu"))
+    k = SimpleNamespace(device=object())
+    assert not P._npu_kernels_support(q, k, k, k, k, None, False, None)
 
 
 def test_module_import_does_not_require_fla_npu(monkeypatch):
     import builtins
     import importlib.util
+
     real_import = builtins.__import__
+
     def guarded_import(name, *args, **kwargs):
         if name.startswith("fla_npu"):
             raise ImportError("optional dependency unavailable")
         return real_import(name, *args, **kwargs)
+
     monkeypatch.setattr(builtins, "__import__", guarded_import)
     spec = importlib.util.spec_from_file_location("gdn_without_optional_kernels", P.__file__)
     module = importlib.util.module_from_spec(spec)

--- a/tests/unit_tests/ssm/test_gdn_adapter_contract.py
+++ b/tests/unit_tests/ssm/test_gdn_adapter_contract.py
@@ -1,0 +1,63 @@
+import importlib
+from types import SimpleNamespace
+from unittest.mock import patch
+import pytest
+P=importlib.import_module("megatron.plugin.Ascend.ssm.chunk_gated_delta_rule")
+
+def test_fallback_preserves_all_arguments():
+    values=[object() for _ in range(5)]
+    opts=dict(scale=0.2,initial_state=object(),output_final_state=True,use_qk_l2norm_in_kernel=True,cu_seqlens=object(),head_first=True)
+    sentinel=object()
+    with patch.object(P,"_fla_original_chunk_gated_delta_rule") as getter:
+        getter.return_value.return_value=(sentinel,None)
+        assert P.chunk_gated_delta_rule(*values,**opts)[0] is sentinel
+        getter.return_value.assert_called_once_with(**dict(zip(("q","k","v","g","beta"),values)),**opts)
+
+def test_missing_runtime_delegates_before_kernel_import():
+    values=[object() for _ in range(5)]
+    with patch.object(P,"_npu_kernels_support",return_value=True), patch.object(P,"_runtime_available",return_value=False), patch.object(P,"_fla_original_chunk_gated_delta_rule") as getter:
+        P.chunk_gated_delta_rule(*values)
+        getter.return_value.assert_called_once()
+
+def test_l2norm_execution_importerror_is_not_swallowed():
+    x=SimpleNamespace(device=SimpleNamespace(type="npu"))
+    import fla_npu.ops.triton as t
+    with patch.object(t,"l2norm",side_effect=ImportError("kernel execution failure")), patch.object(P,"_fla_original_l2norm") as fallback:
+        with pytest.raises(ImportError,match="kernel execution failure"):
+            P.l2norm(x)
+        fallback.assert_not_called()
+
+def test_cross_device_is_unsupported():
+    q=SimpleNamespace(device=SimpleNamespace(type="npu"))
+    k=SimpleNamespace(device=object())
+    assert not P._npu_kernels_support(q,k,k,k,k,None,False,None)
+
+
+def test_module_import_does_not_require_fla_npu(monkeypatch):
+    import builtins
+    import importlib.util
+    real_import = builtins.__import__
+    def guarded_import(name, *args, **kwargs):
+        if name.startswith("fla_npu"):
+            raise ImportError("optional dependency unavailable")
+        return real_import(name, *args, **kwargs)
+    monkeypatch.setattr(builtins, "__import__", guarded_import)
+    spec = importlib.util.spec_from_file_location("gdn_without_optional_kernels", P.__file__)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    assert module._load_kernels.cache_info().currsize == 0
+    assert module._get_gdn_function.cache_info().currsize == 0
+
+
+def test_failed_kernel_load_is_retryable_and_success_is_cached():
+    P._load_kernels.cache_clear()
+    try:
+        with patch.object(P.importlib, "import_module", side_effect=ImportError("missing kernels")):
+            with pytest.raises(ImportError, match="missing kernels"):
+                P._load_kernels()
+        assert P._load_kernels.cache_info().currsize == 0
+        kernels = P._load_kernels()
+        with patch.object(P.importlib, "import_module", side_effect=AssertionError("loaded twice")):
+            assert P._load_kernels() is kernels
+    finally:
+        P._load_kernels.cache_clear()

--- a/tests/unit_tests/ssm/test_gdn_conv_contract.py
+++ b/tests/unit_tests/ssm/test_gdn_conv_contract.py
@@ -1,0 +1,15 @@
+import importlib
+from types import SimpleNamespace
+from unittest.mock import patch
+import inspect
+import pytest
+P=importlib.import_module('megatron.plugin.Ascend.ssm.causal_conv1d')
+F=importlib.import_module('fla.modules.convolution')
+def test_signature():
+    assert list(inspect.signature(P.causal_conv1d).parameters)==list(inspect.signature(F.causal_conv1d).parameters)
+@pytest.mark.parametrize('options',[dict(backend='cuda'),dict(custom_option=3),dict(cu_seqlens=object()),dict(initial_state=object()),dict(output_final_state=True)])
+def test_unhandled_options_delegated(options):
+    x=SimpleNamespace(device=SimpleNamespace(type='npu'),ndim=3)
+    with patch.object(F,'causal_conv1d',return_value=('sentinel',None)) as fn:
+        assert P.causal_conv1d(x,weight=object(),**options)[0]=='sentinel'
+        for k,v in options.items(): assert fn.call_args.kwargs[k] is v

--- a/tests/unit_tests/ssm/test_gdn_conv_contract.py
+++ b/tests/unit_tests/ssm/test_gdn_conv_contract.py
@@ -3,13 +3,30 @@ from types import SimpleNamespace
 from unittest.mock import patch
 import inspect
 import pytest
-P=importlib.import_module('megatron.plugin.Ascend.ssm.causal_conv1d')
-F=importlib.import_module('fla.modules.convolution')
+
+P = importlib.import_module('megatron.plugin.Ascend.ssm.causal_conv1d')
+F = importlib.import_module('fla.modules.convolution')
+
+
 def test_signature():
-    assert list(inspect.signature(P.causal_conv1d).parameters)==list(inspect.signature(F.causal_conv1d).parameters)
-@pytest.mark.parametrize('options',[dict(backend='cuda'),dict(custom_option=3),dict(cu_seqlens=object()),dict(initial_state=object()),dict(output_final_state=True)])
+    assert list(inspect.signature(P.causal_conv1d).parameters) == list(
+        inspect.signature(F.causal_conv1d).parameters
+    )
+
+
+@pytest.mark.parametrize(
+    'options',
+    [
+        dict(backend='cuda'),
+        dict(custom_option=3),
+        dict(cu_seqlens=object()),
+        dict(initial_state=object()),
+        dict(output_final_state=True),
+    ],
+)
 def test_unhandled_options_delegated(options):
-    x=SimpleNamespace(device=SimpleNamespace(type='npu'),ndim=3)
-    with patch.object(F,'causal_conv1d',return_value=('sentinel',None)) as fn:
-        assert P.causal_conv1d(x,weight=object(),**options)[0]=='sentinel'
-        for k,v in options.items(): assert fn.call_args.kwargs[k] is v
+    x = SimpleNamespace(device=SimpleNamespace(type='npu'), ndim=3)
+    with patch.object(F, 'causal_conv1d', return_value=('sentinel', None)) as fn:
+        assert P.causal_conv1d(x, weight=object(), **options)[0] == 'sentinel'
+        for k, v in options.items():
+            assert fn.call_args.kwargs[k] is v

--- a/tests/unit_tests/ssm/test_gdn_override.py
+++ b/tests/unit_tests/ssm/test_gdn_override.py
@@ -1,0 +1,92 @@
+import importlib
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import pytest
+
+from megatron.core.ssm.gated_delta_net import GatedDeltaNet
+from megatron.plugin import decorators
+
+P = importlib.import_module('megatron.plugin.Ascend.ssm.chunk_gated_delta_rule')
+C = importlib.import_module('megatron.plugin.Ascend.ssm.causal_conv1d')
+CORE = importlib.import_module('megatron.core.ssm.gated_delta_net')
+
+
+@pytest.fixture(autouse=True)
+def clear_dispatch(monkeypatch):
+    monkeypatch.setenv('MG_FL_PREFER', 'npu')
+    decorators._plugin_impl_cache.clear()
+    decorators._original_impl_cache.clear()
+    yield
+    decorators._plugin_impl_cache.clear()
+    decorators._original_impl_cache.clear()
+
+
+def test_method_registration_and_dispatch(monkeypatch):
+    replacement = Mock(return_value=('optimized', None))
+    monkeypatch.setattr(P, 'chunk_gated_delta_rule', replacement)
+    layer = SimpleNamespace(config=SimpleNamespace(deterministic_mode=False))
+    q, k, v, cu = (object() for _ in range(4))
+    assert GatedDeltaNet._gated_delta_rule(layer, q, k, v, cu_seqlens=cu)[0] == 'optimized'
+    replacement.assert_called_once_with(q, k, v, cu_seqlens=cu)
+    assert 'GatedDeltaNet._gated_delta_rule' in decorators._lazy_registry
+    assert 'chunk.chunk_gated_delta_rule' not in decorators._lazy_registry
+
+
+def test_deterministic_keeps_native_selection(monkeypatch):
+    native = Mock(return_value=('reference', None))
+    optimized = Mock(side_effect=AssertionError('must not enter optimized GDN'))
+    monkeypatch.setattr(P, 'chunk_gated_delta_rule', optimized)
+    layer = SimpleNamespace(config=SimpleNamespace(deterministic_mode=True), gated_delta_rule=native)
+    q, k, v, cu = (object() for _ in range(4))
+    assert GatedDeltaNet._gated_delta_rule(layer, q, k, v, cu_seqlens=cu)[0] == 'reference'
+    native.assert_called_once_with(q, k, v, cu_seqlens=cu)
+
+
+def test_non_npu_keeps_native_selection(monkeypatch):
+    monkeypatch.setenv('MG_FL_PREFER', 'cpu')
+    native = Mock(return_value=('native', None))
+    layer = SimpleNamespace(gated_delta_rule=native)
+    args = (object(), object(), object())
+    opts = dict(cu_seqlens=object(), initial_state=object(), output_final_state=True)
+    assert GatedDeltaNet._gated_delta_rule(layer, *args, **opts)[0] == 'native'
+    native.assert_called_once_with(*args, **opts)
+
+
+@pytest.mark.parametrize('vendor,target,helper', [
+    ('npu', P, 'l2norm'), ('cpu', CORE, 'l2norm')])
+def test_normalization_dispatch(monkeypatch, vendor, target, helper):
+    monkeypatch.setenv('MG_FL_PREFER', vendor)
+    fn = Mock(return_value='normalized')
+    monkeypatch.setattr(target, helper, fn)
+    x = object()
+    assert GatedDeltaNet._normalize_qk(object(), x) == 'normalized'
+    fn.assert_called_once_with(x)
+
+
+@pytest.mark.parametrize('vendor,target', [('npu', C), ('cpu', CORE)])
+def test_convolution_dispatch_preserves_arguments(monkeypatch, vendor, target):
+    monkeypatch.setenv('MG_FL_PREFER', vendor)
+    fn = Mock(return_value=('conv', None))
+    monkeypatch.setattr(target, 'causal_conv1d', fn)
+    options = dict(x=object(), weight=object(), cu_seqlens=object(), activation='silu')
+    assert GatedDeltaNet._causal_conv1d(object(), **options)[0] == 'conv'
+    fn.assert_called_once_with(**options)
+
+
+def test_kernel_error_propagates(monkeypatch):
+    monkeypatch.setattr(P, 'chunk_gated_delta_rule', Mock(side_effect=RuntimeError('kernel failed')))
+    layer = SimpleNamespace(config=SimpleNamespace(deterministic_mode=False))
+    with pytest.raises(RuntimeError, match='kernel failed'):
+        GatedDeltaNet._gated_delta_rule(layer, None, None, None)
+
+
+def test_core_decorator_placement():
+    import ast
+    from pathlib import Path
+    module = ast.parse(Path(CORE.__file__).read_text())
+    cls = next(n for n in module.body if isinstance(n, ast.ClassDef) and n.name == "GatedDeltaNet")
+    methods = {n.name: n for n in cls.body if isinstance(n, ast.FunctionDef)}
+    for name in ("_normalize_qk", "_gated_delta_rule", "_causal_conv1d"):
+        assert [ast.unparse(d) for d in methods[name].decorator_list] == ["overridable"]
+    assert [ast.unparse(d) for d in methods["_prepare_qkv_for_gated_delta_rule"].decorator_list] == ["jit_fuser"]

--- a/tests/unit_tests/ssm/test_gdn_override.py
+++ b/tests/unit_tests/ssm/test_gdn_override.py
@@ -37,7 +37,9 @@ def test_deterministic_keeps_native_selection(monkeypatch):
     native = Mock(return_value=('reference', None))
     optimized = Mock(side_effect=AssertionError('must not enter optimized GDN'))
     monkeypatch.setattr(P, 'chunk_gated_delta_rule', optimized)
-    layer = SimpleNamespace(config=SimpleNamespace(deterministic_mode=True), gated_delta_rule=native)
+    layer = SimpleNamespace(
+        config=SimpleNamespace(deterministic_mode=True), gated_delta_rule=native
+    )
     q, k, v, cu = (object() for _ in range(4))
     assert GatedDeltaNet._gated_delta_rule(layer, q, k, v, cu_seqlens=cu)[0] == 'reference'
     native.assert_called_once_with(q, k, v, cu_seqlens=cu)
@@ -53,8 +55,7 @@ def test_non_npu_keeps_native_selection(monkeypatch):
     native.assert_called_once_with(*args, **opts)
 
 
-@pytest.mark.parametrize('vendor,target,helper', [
-    ('npu', P, 'l2norm'), ('cpu', CORE, 'l2norm')])
+@pytest.mark.parametrize('vendor,target,helper', [('npu', P, 'l2norm'), ('cpu', CORE, 'l2norm')])
 def test_normalization_dispatch(monkeypatch, vendor, target, helper):
     monkeypatch.setenv('MG_FL_PREFER', vendor)
     fn = Mock(return_value='normalized')
@@ -75,7 +76,9 @@ def test_convolution_dispatch_preserves_arguments(monkeypatch, vendor, target):
 
 
 def test_kernel_error_propagates(monkeypatch):
-    monkeypatch.setattr(P, 'chunk_gated_delta_rule', Mock(side_effect=RuntimeError('kernel failed')))
+    monkeypatch.setattr(
+        P, 'chunk_gated_delta_rule', Mock(side_effect=RuntimeError('kernel failed'))
+    )
     layer = SimpleNamespace(config=SimpleNamespace(deterministic_mode=False))
     with pytest.raises(RuntimeError, match='kernel failed'):
         GatedDeltaNet._gated_delta_rule(layer, None, None, None)
@@ -84,9 +87,12 @@ def test_kernel_error_propagates(monkeypatch):
 def test_core_decorator_placement():
     import ast
     from pathlib import Path
+
     module = ast.parse(Path(CORE.__file__).read_text())
     cls = next(n for n in module.body if isinstance(n, ast.ClassDef) and n.name == "GatedDeltaNet")
     methods = {n.name: n for n in cls.body if isinstance(n, ast.FunctionDef)}
     for name in ("_normalize_qk", "_gated_delta_rule", "_causal_conv1d"):
         assert [ast.unparse(d) for d in methods[name].decorator_list] == ["overridable"]
-    assert [ast.unparse(d) for d in methods["_prepare_qkv_for_gated_delta_rule"].decorator_list] == ["jit_fuser"]
+    assert [
+        ast.unparse(d) for d in methods["_prepare_qkv_for_gated_delta_rule"].decorator_list
+    ] == ["jit_fuser"]


### PR DESCRIPTION
# Description

为 GatedDeltaNet 增加 Ascend NPU 适配，使用 Megatron 现有的 `@overridable` 机制暴露 GDN 相关调用点，并由 Ascend plugin 接入 `fla_npu` 算子，支持稠密、无状态场景下的前向和反向计算

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [ ] Infra/Build change (changes to CI/CD workflows or build scripts)
- [ ] Code refactoring
- [ ] Documentation change
- [ ] Bug fix
- [ ] Breaking change

## Changes

- 在 `GatedDeltaNet` 中增加 Q/K 归一化、GDN 递推和因果卷积三个 `@overridable` 方法，通过 `override_registry.py` 注册 NPU 实现
- 插件负责输入检查、布局转换和可选依赖加载。当前 GDN 优化路径支持 FP16/BF16、head dimension 128 的稠密无状态输入；不支持的输入回到原始 FLA 路径，内核执行错误直接抛出
- **FLA Triton causal-conv 在当前 910C 环境的 backward 路径存在 UB 容量问题；减小 tile 后虽可运行，但性能较差，因此对当前稠密场景使用 PyTorch depthwise `conv1d` 兼容路径，GDN recurrence 前反向仍使用 `fla_npu` 高性能算子**

### 验证

- 21项相关测试通过，覆盖分派、装饰器位置、参数透传、fallback、异常传播和依赖加载
- FP16/BF16、序列长度65和128的 NPU 输出及五组输入梯度通过 FP32 reference 精度检查
- 两种 dtype、归一化开关共4组同输入对比中，精简前后的输出及五组梯度逐位一致
- 8 rank、100步训练完成，torchrun退出码0，skipped/NaN均为0，GDN和卷积前反向均在8个rank命中

配置：Qwen3.5-35B-A3B 的4层语言模型、1层视觉模型配置，BF16，TP2/PP1/EP4/DP4，MBS16/GBS256，序列上限1024；关闭MTP和重计算，冻结视觉与投影。使用相同的前1000条JSON样本，动态padding至8倍数

| 指标（Step3–100） | 结果 |
|---|---:|
| 平均每步耗时 | 2256.21 ms |
| 中位数 | 2172.35 ms |
| P95 | 2615.78 ms |
| 吞吐 | 113.46 samples/s |

在相同测试配置下，原生 PyTorch GDN 基线平均每步耗时为 2870.10 ms，当前实现为 2256.21 ms，平均 step time 降低 21.39%

## Checklist

- [x] I have read and followed the contributing guidelines
- [x] The functionality is complete
- [ ] I have commented my code, particularly in coverage report uploading steps
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] I have added/updated tests that prove my feature works
- [ ] New and existing unit tests pass locally
