### PR TITLE
fix(device): use platform device in rerun state machine

### DIFF
--- a/megatron/core/rerun_state_machine.py
+++ b/megatron/core/rerun_state_machine.py
@@ -267,11 +267,15 @@ class RerunStateMachine:
         For multiple inputs, returns a tuple.
         """
         if isinstance(value, list):
-            val_tensor: torch.Tensor = torch.tensor(value, dtype=torch.int32, device=cur_platform.current_device_name())
+            val_tensor: torch.Tensor = torch.tensor(
+                value, dtype=torch.int32, device=cur_platform.current_device_name()
+            )
             torch.distributed.all_reduce(val_tensor)
             return tuple([x > 0 for x in val_tensor.tolist()])
         else:
-            val_tensor: torch.Tensor = torch.tensor([value], dtype=torch.int32, device=cur_platform.current_device_name())
+            val_tensor: torch.Tensor = torch.tensor(
+                [value], dtype=torch.int32, device=cur_platform.current_device_name()
+            )
             torch.distributed.all_reduce(val_tensor)
             return val_tensor.item() > 0
 

--- a/megatron/core/rerun_state_machine.py
+++ b/megatron/core/rerun_state_machine.py
@@ -267,11 +267,11 @@ class RerunStateMachine:
         For multiple inputs, returns a tuple.
         """
         if isinstance(value, list):
-            val_tensor: torch.Tensor = torch.tensor(value, dtype=torch.int32, device='cuda')
+            val_tensor: torch.Tensor = torch.tensor(value, dtype=torch.int32, device=cur_platform.current_device_name())
             torch.distributed.all_reduce(val_tensor)
             return tuple([x > 0 for x in val_tensor.tolist()])
         else:
-            val_tensor: torch.Tensor = torch.tensor([value], dtype=torch.int32, device='cuda')
+            val_tensor: torch.Tensor = torch.tensor([value], dtype=torch.int32, device=cur_platform.current_device_name())
             torch.distributed.all_reduce(val_tensor)
             return val_tensor.item() > 0
 


### PR DESCRIPTION
## Summary

Fix hardcoded CUDA device placement in the rerun state machine.

## Problem

`megatron/core/rerun_state_machine.py` creates temporary tensors in `_reduce_any()` with `device='cuda'`. This prevents the rerun state machine from working correctly on non-CUDA platforms such as MUSA.

## Changes

Replace both hardcoded CUDA device specifications with:

```python
cur_platform.current_device_name()